### PR TITLE
RUE-2079: a by-value parameter is not an inout root

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -6596,20 +6596,43 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &AnalysisContext,
     ) -> CompileResult<()> {
-        let Some(local) = ctx.locals.get(&root) else {
+        let name = self.body_interner().resolve(&root).to_string();
+        if let Some(local) = ctx.locals.get(&root) {
+            if local.is_mut {
+                return Ok(());
+            }
+            let help = format!(
+                "an `inout` argument writes to the caller's place; make the binding mutable: \
+                 `let mut {name} = ...`"
+            );
+            return Err(CompileError::new(ErrorKind::AssignToImmutable(name), span)
+                .with_label("variable declared as immutable here", local.span)
+                .with_help(help));
+        }
+        // A by-value parameter is an immutable binding (spec 6.1:32), so it is
+        // no more an `inout` root than a `let` binding is (RUE-2079). A `mut
+        // self` receiver is the one mutable by-value binding; `inout`
+        // parameters are mutable places, and `borrow` parameters were rejected
+        // before this check ran.
+        let Some(param) = ctx.param(root) else {
             return Ok(());
         };
-        if local.is_mut {
+        if param.mode != RirParamMode::Normal || param.is_mut {
             return Ok(());
         }
-        let name = self.body_interner().resolve(&root).to_string();
-        let help = format!(
-            "an `inout` argument writes to the caller's place; make the binding mutable: \
-             `let mut {name} = ...`"
-        );
-        Err(CompileError::new(ErrorKind::AssignToImmutable(name), span)
-            .with_label("variable declared as immutable here", local.span)
-            .with_help(help))
+        let help = if name == "self" {
+            "an `inout` argument writes to the caller's place; declare the receiver `mut self` \
+             to mutate the callee's copy, or `inout self` to write back to the caller"
+                .to_string()
+        } else {
+            format!(
+                "an `inout` argument writes to the caller's place; copy the parameter into a \
+                 mutable binding first: `let mut {name} = {name};`, or make the parameter \
+                 `inout {name}: {}` to write back to the caller",
+                self.format_type_name(param.ty)
+            )
+        };
+        Err(CompileError::new(ErrorKind::AssignToImmutable(name), span).with_help(help))
     }
 
     /// Reject a mutation of a collection that an enclosing `for` loop is
@@ -7604,7 +7627,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // An `inout` argument writes to the caller's place, so its
                 // root must be a mutable binding — the same requirement an
                 // assignment to that place and an `inout self` receiver carry
-                // (spec 6.1:43, RUE-2054).
+                // (spec 6.1:43, RUE-2054, RUE-2079).
                 if arg.is_inout() {
                     self.reject_immutable_inout_arg_root(
                         root,

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -649,12 +649,14 @@ fn main() -> i32 {
 exit_code = 42
 
 # ---------------------------------------------------------------------------
-# The CALLER's own parameter passed by reference (RUE-2042).
+# The CALLER's own parameter passed onward by reference (RUE-2042).
 #
 # Passing a place by reference hands the callee that place's ADDRESS, so every
 # read of the same root after the call must observe what the callee wrote.
-# That holds whatever the root is, and a caller's own by-value parameter is a
-# root like any other: `fn f(v: i64) { bump(inout v); v }` returns 6, not 5.
+# That holds whatever the root is. A by-value parameter is an immutable
+# binding and so cannot be that root (spec 6.1:43, RUE-2079); the parameter
+# roots that remain are an `inout` parameter passed onward and a `mut self`
+# receiver, and the RUE-2042 rule is their defence.
 #
 # A parameter read is materialized as a `Param { index }` instruction rather
 # than a `Load`, and the optimizer keys repeated reads of a never-written
@@ -668,11 +670,32 @@ exit_code = 42
 [[case]]
 name = "inout_param_arg_reread_after_call"
 differential_opt = true
-description = "RUE-2042 repro: a scalar by-value parameter passed `inout` reads the callee's write afterwards, not its entry value."
+description = "RUE-2042 repro on the surviving shape: a scalar `inout` parameter passed onward reads the callee's write afterwards, not its entry value."
 files = [{ path = "main.rue", source = """
 fn bump(inout x: i64) { x = x + 1; }
-fn f(v: i64) -> i64 { bump(inout v); v }
-fn main() -> i32 { @intCast(f(5)) }
+fn f(inout v: i64) -> i64 { bump(inout v); v }
+fn main() -> i32 {
+    let mut v: i64 = 5;
+    @intCast(f(inout v))
+}
+""" }]
+stdout = ""
+exit_code = 6
+
+[[case]]
+name = "inout_mut_self_field_arg_reread_after_call"
+differential_opt = true
+description = "A `mut self` receiver is the one mutable by-value parameter: its field passed `inout` reads the callee's write afterwards."
+files = [{ path = "main.rue", source = """
+struct C {
+    v: i64,
+    fn f(mut self) -> i64 { bump(inout self.v); self.v }
+}
+fn bump(inout x: i64) { x = x + 1; }
+fn main() -> i32 {
+    let c = C { v: 5 };
+    @intCast(c.f())
+}
 """ }]
 stdout = ""
 exit_code = 6
@@ -686,8 +709,11 @@ fn poke(inout x: i64) {
     let p: ptr mut i64 = checked { @raw_mut(x) };
     checked { @ptr_write(p, 42); };
 }
-fn f(v: i64) -> i64 { poke(inout v); v }
-fn main() -> i32 { @intCast(f(5)) }
+fn f(inout v: i64) -> i64 { poke(inout v); v }
+fn main() -> i32 {
+    let mut v: i64 = 5;
+    @intCast(f(inout v))
+}
 """ }]
 stdout = ""
 exit_code = 42
@@ -698,7 +724,7 @@ differential_opt = true
 description = "The call sits in a loop body: each iteration's read must observe the previous iteration's write, so three iterations add three."
 files = [{ path = "main.rue", source = """
 fn bump(inout x: i64) { x = x + 1; }
-fn f(v: i64) -> i64 {
+fn f(inout v: i64) -> i64 {
     let mut i: i64 = 0;
     while i < 3 {
         bump(inout v);
@@ -706,7 +732,10 @@ fn f(v: i64) -> i64 {
     }
     v
 }
-fn main() -> i32 { @intCast(f(5)) }
+fn main() -> i32 {
+    let mut v: i64 = 5;
+    @intCast(f(inout v))
+}
 """ }]
 stdout = ""
 exit_code = 8
@@ -717,13 +746,15 @@ differential_opt = true
 description = "The call sits in one arm of an `if` and the read is after the join, so the taken arm reports 6 and the untaken one reports 5."
 files = [{ path = "main.rue", source = """
 fn bump(inout x: i64) { x = x + 1; }
-fn f(v: i64, c: bool) -> i64 {
+fn f(inout v: i64, c: bool) -> i64 {
     if c { bump(inout v); }
     v
 }
 fn main() -> i32 {
-    @dbg(f(5, true));
-    @dbg(f(5, false));
+    let mut a: i64 = 5;
+    let mut b: i64 = 5;
+    @dbg(f(inout a, true));
+    @dbg(f(inout b, false));
     0
 }
 """ }]
@@ -739,8 +770,11 @@ differential_opt = true
 description = "Two by-ref passes of the same parameter: the second call's argument reads the first call's write, and so does the final read."
 files = [{ path = "main.rue", source = """
 fn bump(inout x: i64) { x = x + 1; }
-fn f(v: i64) -> i64 { bump(inout v); bump(inout v); v }
-fn main() -> i32 { @intCast(f(5)) }
+fn f(inout v: i64) -> i64 { bump(inout v); bump(inout v); v }
+fn main() -> i32 {
+    let mut v: i64 = 5;
+    @intCast(f(inout v))
+}
 """ }]
 stdout = ""
 exit_code = 7
@@ -748,18 +782,21 @@ exit_code = 7
 [[case]]
 name = "inout_param_arg_subword_and_float_scalars"
 differential_opt = true
-description = "The rule is per ABI slot, not per width: `u8`, `bool`, and `f64` parameters passed `inout` all re-read the callee's write."
+description = "The rule is per ABI slot, not per width: `u8`, `bool`, and `f64` parameters passed onward `inout` all re-read the callee's write."
 files = [{ path = "main.rue", source = """
 fn bump8(inout x: u8) { x = x + 1; }
 fn flip(inout b: bool) { b = !b; }
 fn bumpf(inout x: f64) { x = x + 1.0; }
-fn u8_case(v: u8) -> u8 { bump8(inout v); v }
-fn bool_case(v: bool) -> bool { flip(inout v); v }
-fn f64_case(v: f64) -> f64 { bumpf(inout v); v }
+fn u8_case(inout v: u8) -> u8 { bump8(inout v); v }
+fn bool_case(inout v: bool) -> bool { flip(inout v); v }
+fn f64_case(inout v: f64) -> f64 { bumpf(inout v); v }
 fn main() -> i32 {
-    @dbg(u8_case(5));
-    @dbg(bool_case(false));
-    @dbg(f64_case(5.0));
+    let mut a: u8 = 5;
+    let mut b: bool = false;
+    let mut c: f64 = 5.0;
+    @dbg(u8_case(inout a));
+    @dbg(bool_case(inout b));
+    @dbg(f64_case(inout c));
     0
 }
 """ }]
@@ -769,6 +806,17 @@ true
 6.0
 """
 exit_code = 0
+
+[[case]]
+name = "inout_by_value_param_arg_rejected"
+description = "A by-value parameter is an immutable binding, so passing it `inout` is E0203 (spec 6.1:43, RUE-2079); the local-copy control below is the legal spelling."
+files = [{ path = "main.rue", source = """
+fn bump(inout x: i64) { x = x + 1; }
+fn f(v: i64) -> i64 { bump(inout v); v }
+fn main() -> i32 { @intCast(f(5)) }
+""" }]
+compile_fail = true
+error_contains = ["[E0203]", "cannot assign to immutable variable 'v'"]
 
 [[case]]
 name = "inout_local_arg_reread_control"
@@ -789,12 +837,15 @@ exit_code = 6
 [[case]]
 name = "inout_aggregate_param_arg_reread_control"
 differential_opt = true
-description = "Control: a multi-slot aggregate parameter passed `inout` reads through a projection rather than a whole-slot parameter read, and was always correct."
+description = "Control: a multi-slot aggregate `inout` parameter passed onward reads through a projection rather than a whole-slot parameter read, and was always correct."
 files = [{ path = "main.rue", source = """
 struct P { a: i64, b: i64 }
 fn poke(inout p: P) { p.a = 9; }
-fn f(v: P) -> i64 { poke(inout v); v.a }
-fn main() -> i32 { @intCast(f(P { a: 1, b: 2 })) }
+fn f(inout v: P) -> i64 { poke(inout v); v.a }
+fn main() -> i32 {
+    let mut p = P { a: 1, b: 2 };
+    @intCast(f(inout p))
+}
 """ }]
 stdout = ""
 exit_code = 9

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -624,6 +624,59 @@ compile_fail = true
 error_contains = "E0203"
 
 [[case]]
+name = "inout_arg_by_value_parameter_rejected"
+spec = ["6.1:43", "6.1:32"]
+description = "A by-value parameter is an immutable binding, so passing it `inout` is rejected like a `let` binding"
+source = """
+fn bump(inout x: i32) {
+    x = x + 1;
+}
+fn f(v: i32) -> i32 {
+    bump(inout v);
+    v
+}
+fn main() -> i32 { f(41) }
+"""
+compile_fail = true
+error_contains = "E0203"
+
+[[case]]
+name = "inout_arg_mut_copy_of_parameter_accepted"
+spec = ["6.1:43", "6.1:32"]
+description = "Copying a by-value parameter into a `let mut` binding gives the callee a mutable place to pass `inout`"
+source = """
+fn bump(inout x: i32) {
+    x = x + 1;
+}
+fn f(v: i32) -> i32 {
+    let mut v = v;
+    bump(inout v);
+    v
+}
+fn main() -> i32 { f(41) }
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_arg_mut_self_receiver_accepted"
+spec = ["6.1:43", "6.4:24"]
+description = "A `mut self` receiver is a mutable by-value binding and so an `inout` root"
+source = """
+struct C {
+    v: i32,
+    fn bumped(mut self) -> i32 {
+        bump(inout self.v);
+        self.v
+    }
+}
+fn bump(inout x: i32) {
+    x = x + 1;
+}
+fn main() -> i32 { C { v: 41 }.bumped() }
+"""
+exit_code = 42
+
+[[case]]
 name = "inout_self_receiver_shares_mut_binding_rule"
 spec = ["6.1:43", "6.4:26"]
 description = "An `inout self` receiver carries the same requirement and reports the same diagnostic"

--- a/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
@@ -116,8 +116,8 @@ error_contains = [
 ]
 
 [[case]]
-name = "inout_argument_of_a_by_value_parameter_is_accepted"
-description = "A by-value parameter names the callee's own copy of the argument, which it may pass `inout`; the post-call read observes the write (spec 6.1:18, RUE-2042)."
+name = "inout_argument_of_a_by_value_parameter_is_rejected"
+description = "A by-value parameter is an immutable binding (spec 6.1:32), so passing it `inout` is the E0203 a `let` binding gets; the help names both repairs (spec 6.1:43, RUE-2079)."
 source = """
 fn bump(inout x: i32) { x = x + 1; }
 
@@ -128,4 +128,28 @@ fn takes(n: i32) -> i32 {
 
 fn main() -> i32 { takes(41) }
 """
-exit_code = 42
+compile_fail = true
+error_contains = [
+    "[E0203]",
+    "cannot assign to immutable variable 'n'",
+    "copy the parameter into a mutable binding first: `let mut n = n;`, or make the parameter `inout n: i32`",
+]
+
+[[case]]
+name = "inout_argument_of_a_by_value_receiver_is_rejected"
+description = "A plain `self` receiver is a by-value parameter too; the help names `mut self` and `inout self` (spec 6.1:43, RUE-2079)."
+source = """
+struct C {
+    v: i32,
+    fn bump_self(self) -> i32 { bump(inout self); self.v }
+}
+fn bump(inout c: C) { c.v = c.v + 1; }
+
+fn main() -> i32 { C { v: 41 }.bump_self() }
+"""
+compile_fail = true
+error_contains = [
+    "[E0203]",
+    "cannot assign to immutable variable 'self'",
+    "declare the receiver `mut self` to mutate the callee's copy, or `inout self` to write back to the caller",
+]

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -78,7 +78,12 @@ root binding is. An immutable local binding — a `let` binding, or a `for` or
 `match` pattern binding — is rejected with the diagnostic an assignment to that
 place would produce (E0203, 5.2:3). A place rooted at an `inout` parameter is
 mutable (6.1:14); one rooted at a `borrow` parameter is rejected under 6.1:24.
-The requirement is the same one an `inout self` receiver carries (6.4:26).
+A place rooted at a by-value parameter is rejected exactly as one rooted at a
+`let` binding is: the parameter is an immutable binding (6.1:32), and a callee
+that wants to pass its own copy `inout` first copies it into a `let mut`
+binding. The one mutable by-value binding is a `mut self` receiver (6.4:24),
+which is an `inout` root. The requirement is the same one an `inout self`
+receiver carries (6.4:26).
 
 {{ rule(id="6.1:18", cat="dynamic-semantics") }}
 


### PR DESCRIPTION
Spec 6.1:32 makes a by-value parameter an immutable binding, but the mutable-place check for `inout` arguments (6.1:43, RUE-2054) carved parameters out, so `fn f(v: i64) -> i64 { bump(inout v); v }` was accepted while the same shape on a `let` binding was E0203. The ruling on the issue was to do what Swift and Hylo do, and both reject passing an immutable parameter `inout`: Swift needs a `var` copy and Hylo a `var` binding or an `inout`/`set` parameter.

- `reject_immutable_inout_arg_root` now covers parameters: a by-value parameter passed `inout` is E0203 with a help naming both repairs, `let mut v = v;` or `inout v: T`. A `mut self` receiver stays a mutable by-value binding and so an `inout` root; `inout` parameters are unchanged and `borrow` parameters were already rejected.
- Spec 6.1:43 states the rule and cites 6.1:32 and the `mut self` receiver (6.4:24).
- The RUE-2042 CSE cases in `byref_params.toml` exercised the by-value shape. They now exercise the two parameter roots that remain legal, an `inout` parameter passed onward and a `mut self` receiver's field, so the CSE rule keeps its defence, and one case pins the rejection. The UI case that pinned acceptance pins the diagnostic for both a parameter and a plain `self` receiver instead. The spec gains rejection, `let mut` copy, and `mut self` cases under 6.1:43.

Verified locally: spec `items` and the full spec suite; the full UI suite; CLI `byref`, and the full CLI suite, where the only two failures (`fs_remove_dir_all::remove_dir_all_permission_denied_is_not_partial_success` and `std_net_tcp::tcp_ipv6_loopback_round_trip`) are environment-bound in the sandbox, which runs as root and has no IPv6 loopback, and touch nothing this change does; the tutorial-snippet gate.

Fixes RUE-2079