### PR TITLE
RUE-2177: add the compiler daemon's identity, endpoint and lifecycle controls

### DIFF
--- a/crates/rue-cli-tests/cases/daemon.toml
+++ b/crates/rue-cli-tests/cases/daemon.toml
@@ -1,0 +1,83 @@
+# The local compiler service's controls (ADR-0085 §2, RUE-2128): `rue daemon
+# start|status|stop`. Every case runs against a private endpoint root inside
+# its own directory, so no case shares a service with another or with the
+# developer's real runtime directory, and the harness stops what a case leaves
+# running. The service executes no compiler requests yet; these cases pin the
+# lifecycle contract the request path will rely on: `status` and `stop` never
+# start a service, `start` is idempotent and race-safe, and a scope selects
+# exactly one service.
+
+[section]
+id = "cli.daemon"
+name = "rue daemon lifecycle controls"
+description = "start/status/stop over a user-private endpoint scoped by directory, isolation, and compiler build."
+
+[[case]]
+name = "status_and_stop_without_a_service_start_nothing"
+description = "A query for a service that does not exist answers no, twice, and a stop is a no-op; neither launches anything."
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+daemon = { steps = [
+  { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+  { args = ["daemon", "status", "--json"], exit_code = 1, stderr_contains = ["no service is running for"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["no service was running for"] },
+  { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+] }
+
+[[case]]
+name = "start_status_and_stop_lifecycle"
+description = "start launches once and then finds the running service; status reports it in text and JSON; stop ends it and status answers no again."
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+daemon = { steps = [
+  { args = ["daemon", "start", "--idle-timeout-ms", "60000"], exit_code = 0, stdout_contains = ["rue daemon: started service pid"] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["rue daemon: running", "  protocol: 1", "  active request: none", "  retained hosts: 0", "  idle timeout: 60000 ms", "  isolation: none"] },
+  { args = ["daemon", "start", "--idle-timeout-ms", "60000"], exit_code = 0, stdout_contains = ["is already running for"], stdout_not_contains = ["started service"] },
+  { args = ["daemon", "status", "--json"], exit_code = 0, stdout_contains = ["\"protocol_version\":1", "\"retained_hosts\":0", "\"service_hex\":"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["rue daemon: stopped service pid"] },
+  { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["no service was running for"] },
+] }
+
+[[case]]
+name = "concurrent_starts_share_one_service"
+description = "Four simultaneous starts serialize on the startup lock: every one reports the same service and exactly one launches."
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+daemon = { steps = [
+  { args = ["daemon", "start", "--idle-timeout-ms", "60000"], exit_code = 0, concurrency = 4, stdout_contains = ["service pid"] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["rue daemon: running"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["rue daemon: stopped service pid"] },
+  { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+] }
+
+[[case]]
+name = "scope_and_isolation_select_distinct_services"
+description = "A service is owned by its scope directory and isolation name: the default scope, an isolated one, and a subdirectory scope are three services, each stopped on its own."
+files = [
+  { path = "main.rue", source = "fn main() -> i32 { 0 }\n" },
+  { path = "sub/main.rue", source = "fn main() -> i32 { 0 }\n" },
+]
+daemon = { steps = [
+  { args = ["daemon", "start", "--isolation", "ci", "--idle-timeout-ms", "60000"], exit_code = 0, stdout_contains = ["started service pid", "(isolation ci)"] },
+  { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+  { args = ["daemon", "status", "--isolation", "ci"], exit_code = 0, stdout_contains = ["  isolation: ci"] },
+  { args = ["daemon", "start", "--scope", "sub", "--idle-timeout-ms", "60000"], exit_code = 0, stdout_contains = ["started service pid"] },
+  { args = ["daemon", "status", "--scope", "sub"], exit_code = 0, stdout_contains = ["rue daemon: running"] },
+  { args = ["daemon", "status", "--scope", "."], exit_code = 1, stderr_contains = ["no service is running for"] },
+  { args = ["daemon", "stop", "--isolation", "ci"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+  { args = ["daemon", "status", "--scope", "sub"], exit_code = 0, stdout_contains = ["rue daemon: running"] },
+  { args = ["daemon", "stop", "--scope", "sub"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+  { args = ["daemon", "status", "--scope", "sub"], exit_code = 1, stderr_contains = ["no service is running for"] },
+] }
+
+[[case]]
+name = "malformed_controls_are_argument_errors"
+description = "A missing or unknown command, a flag without its value, and a scope that is not a directory are refused before anything is launched."
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+daemon = { steps = [
+  { args = ["daemon"], exit_code = 1, stderr_contains = ["`rue daemon` needs a command", "Usage: rue daemon"] },
+  { args = ["daemon", "restart"], exit_code = 1, stderr_contains = ["unknown daemon command `restart`"] },
+  { args = ["daemon", "status", "--scope"], exit_code = 1, stderr_contains = ["--scope requires a value"] },
+  { args = ["daemon", "stop", "--json"], exit_code = 1, stderr_contains = ["--json applies to `rue daemon status` only"] },
+  { args = ["daemon", "start", "--scope", "missing"], exit_code = 1, stderr_contains = ["daemon scope directory", "is not usable"] },
+  { args = ["daemon", "start", "--isolation", "no spaces"], exit_code = 1, stderr_contains = ["daemon isolation name"] },
+  { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+] }

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -3106,14 +3106,9 @@ fn run_daemon_case(
     if scenario.steps.is_empty() {
         return Err(TestFailure::assertion("daemon scenario has no steps"));
     }
-    // A short prefix keeps the socket path under the platform bound however
-    // long the system temporary directory is.
-    let temp_dir = tempfile::Builder::new()
-        .prefix("rd")
-        .tempdir()
-        .map_err(|error| {
-            TestFailure::fatal(format!("failed to create daemon temp dir: {error}"))
-        })?;
+    let temp_dir = short_private_temp_dir("rd").map_err(|error| {
+        TestFailure::fatal(format!("failed to create daemon temp dir: {error}"))
+    })?;
     let dir = temp_dir.path();
     for file in &case.files {
         let path = dir.join(&file.path);
@@ -3143,6 +3138,20 @@ fn run_daemon_case(
     );
     stop_leftover_daemon(case, rue_binary, real_std, dir, &endpoint_root);
     outcome
+}
+
+/// Creates a private temporary directory short enough to hold a daemon
+/// endpoint: Unix socket paths are bounded at about a hundred bytes, and the
+/// system temporary directory under Buck2 is a deep scratch path, so `/tmp`
+/// is tried first and the system directory is the fallback.
+fn short_private_temp_dir(prefix: &str) -> std::io::Result<tempfile::TempDir> {
+    let short = Path::new("/tmp");
+    if short.is_dir() {
+        if let Ok(dir) = tempfile::Builder::new().prefix(prefix).tempdir_in(short) {
+            return Ok(dir);
+        }
+    }
+    tempfile::Builder::new().prefix(prefix).tempdir()
 }
 
 fn run_daemon_steps(

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -60,6 +60,10 @@
 //!   says nothing about the compile, the case RUNS THAT EXECUTABLE instead of
 //!   compiling — see "Execution modes" below
 //! - `output`: name of produced executable (default `"prog"`)
+//! - `daemon`: ordered `rue daemon` controls run against a private endpoint
+//!   root inside the case directory (`RUE_DAEMON_ROOT`); each step pins an
+//!   exit status and output substrings, and `concurrency` runs a step several
+//!   times at once. The harness stops any service the steps leave behind.
 //! - `watch`: synchronized imperative scenario for real `--watch` orchestration;
 //!   it names a `kind` (`edit`, `cancel`, or `delete`), fixture edits, and the
 //!   expected executable exit codes after the initial and final publication
@@ -201,10 +205,10 @@ use std::time::{Duration, Instant, SystemTime};
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_target::{Arch, Target};
 use rue_test_runner::cli_corpus::{
-    AutomaticExampleContract, Case, CliCaseTier, ExecutionClass, ExecutionContractDeclaration,
-    HangTimeoutProfile, Section, StderrOccurrence, TestFile, TimeoutProfile, WatchEdit,
-    WatchScenario, WatchScenarioKind, WatchTestScenario, WatchTestScenarioKind,
-    unknown_known_bug_on_platforms, unknown_only_on_platforms,
+    AutomaticExampleContract, Case, CliCaseTier, DaemonScenario, DaemonStep, ExecutionClass,
+    ExecutionContractDeclaration, HangTimeoutProfile, Section, StderrOccurrence, TestFile,
+    TimeoutProfile, WatchEdit, WatchScenario, WatchScenarioKind, WatchTestScenario,
+    WatchTestScenarioKind, unknown_known_bug_on_platforms, unknown_only_on_platforms,
 };
 use rue_test_runner::{
     ExpectedFailureOutcome, KNOWN_TARGETS, PlatformCaseSelection, ShardSelector, TestFailure,
@@ -2126,6 +2130,7 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
         output: None,
         watch: None,
         watch_test: None,
+        daemon: None,
         env,
         executable_target: None,
         compile_fail: false,
@@ -3083,6 +3088,205 @@ fn assert_watch_program(
 /// Run a real driver `--watch` process while editing its source files through
 /// a file-backed protocol. The process is always placed in its own group and
 /// killed/reaped after the final publication, including assertion failures.
+/// Run a `rue daemon` lifecycle scenario (ADR-0085).
+///
+/// Every step runs the real driver in the case directory with the endpoint
+/// root pinned to a private directory inside it, so the user's runtime
+/// directory is never touched and cases never share a service. Whatever the
+/// steps leave running is stopped afterwards — on failure too — and a service
+/// that outlives its `stop` is killed, so a failing case cannot leak a
+/// detached process past the suite.
+fn run_daemon_case(
+    case: &Case,
+    scenario: &DaemonScenario,
+    contract: &ExecutionContract,
+    rue_binary: &Path,
+    real_std: &Path,
+) -> TestResult {
+    if scenario.steps.is_empty() {
+        return Err(TestFailure::assertion("daemon scenario has no steps"));
+    }
+    // A short prefix keeps the socket path under the platform bound however
+    // long the system temporary directory is.
+    let temp_dir = tempfile::Builder::new()
+        .prefix("rd")
+        .tempdir()
+        .map_err(|error| {
+            TestFailure::fatal(format!("failed to create daemon temp dir: {error}"))
+        })?;
+    let dir = temp_dir.path();
+    for file in &case.files {
+        let path = dir.join(&file.path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                TestFailure::fatal(format!(
+                    "failed to create daemon fixture directory: {error}"
+                ))
+            })?;
+        }
+        std::fs::write(&path, &file.source).map_err(|error| {
+            TestFailure::fatal(format!(
+                "failed to write daemon fixture {}: {error}",
+                file.path
+            ))
+        })?;
+    }
+    let endpoint_root = dir.join("r");
+    let outcome = run_daemon_steps(
+        case,
+        scenario,
+        contract,
+        rue_binary,
+        real_std,
+        dir,
+        &endpoint_root,
+    );
+    stop_leftover_daemon(case, rue_binary, real_std, dir, &endpoint_root);
+    outcome
+}
+
+fn run_daemon_steps(
+    case: &Case,
+    scenario: &DaemonScenario,
+    contract: &ExecutionContract,
+    rue_binary: &Path,
+    real_std: &Path,
+    dir: &Path,
+    endpoint_root: &Path,
+) -> TestResult {
+    for (index, step) in scenario.steps.iter().enumerate() {
+        if step.concurrency == 0 {
+            return Err(TestFailure::assertion(format!(
+                "daemon step {index} declares concurrency 0"
+            )));
+        }
+        let outputs: Vec<TestResult<Output>> = std::thread::scope(|scope| {
+            let workers: Vec<_> = (0..step.concurrency)
+                .map(|_| {
+                    scope.spawn(|| {
+                        let mut command =
+                            case_compiler_command(rue_binary, &step.args, dir, &case.env, real_std);
+                        command.env("RUE_DAEMON_ROOT", endpoint_root);
+                        run_phase_with_timeout(
+                            command,
+                            ProcessPhase::Compiler,
+                            contract.compile_timeout(),
+                            None,
+                        )
+                    })
+                })
+                .collect();
+            workers
+                .into_iter()
+                .map(|worker| {
+                    worker
+                        .join()
+                        .unwrap_or_else(|_| Err(TestFailure::fatal("daemon step thread panicked")))
+                })
+                .collect()
+        });
+        for (run, output) in outputs.into_iter().enumerate() {
+            let output = output?;
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            let label = format!("daemon step {index} (`{}`, run {run})", step.args.join(" "));
+            if let Some(ice) = ice_message(&output.status, &stderr) {
+                return Err(TestFailure::assertion(format!("{label}: {ice}")));
+            }
+            let code = output.status.code().unwrap_or(-1);
+            if code != step.exit_code {
+                return Err(TestFailure::assertion(format!(
+                    "{label}: expected exit {}, got {code}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+                    step.exit_code
+                )));
+            }
+            check_daemon_step_output(&label, step, &stdout, &stderr)?;
+        }
+    }
+    Ok(())
+}
+
+fn check_daemon_step_output(
+    label: &str,
+    step: &DaemonStep,
+    stdout: &str,
+    stderr: &str,
+) -> TestResult {
+    for expected in &step.stdout_contains {
+        if !stdout.contains(expected.as_str()) {
+            return Err(TestFailure::assertion(format!(
+                "{label}: stdout missing {expected:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )));
+        }
+    }
+    for forbidden in &step.stdout_not_contains {
+        if stdout.contains(forbidden.as_str()) {
+            return Err(TestFailure::assertion(format!(
+                "{label}: stdout must not contain {forbidden:?}\nstdout:\n{stdout}"
+            )));
+        }
+    }
+    for expected in &step.stderr_contains {
+        if !stderr.contains(expected.as_str()) {
+            return Err(TestFailure::assertion(format!(
+                "{label}: stderr missing {expected:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Stop every service a scenario's endpoint root still names. A service
+/// that ignores its stop is killed by the pid its record published; the
+/// record is only ever written by a service that held the endpoint, and the
+/// root is private to this case, so the pid cannot name anyone else's
+/// process while the suite runs.
+fn stop_leftover_daemon(case: &Case, rue_binary: &Path, real_std: &Path, dir: &Path, root: &Path) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let record = entry.path().join("service.json");
+        let Ok(bytes) = std::fs::read(&record) else {
+            continue;
+        };
+        let Ok(info) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+            continue;
+        };
+        let scope = info
+            .get("scope_directory")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned);
+        let isolation = info
+            .get("isolation")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned);
+        let mut args = vec!["daemon".to_owned(), "stop".to_owned()];
+        if let Some(scope) = scope {
+            args.push("--scope".to_owned());
+            args.push(scope);
+        }
+        if let Some(isolation) = isolation {
+            args.push("--isolation".to_owned());
+            args.push(isolation);
+        }
+        let mut command = case_compiler_command(rue_binary, &args, dir, &case.env, real_std);
+        command.env("RUE_DAEMON_ROOT", root);
+        let _ = run_with_timeout(command, Duration::from_secs(60), None);
+        if record.exists()
+            && let Some(pid) = info.get("pid").and_then(serde_json::Value::as_u64)
+            && let Ok(pid) = i32::try_from(pid)
+        {
+            // SAFETY: sending a signal to a pid we read from this case's own
+            // private endpoint record.
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+            let _ = std::fs::remove_file(&record);
+        }
+    }
+}
+
 fn run_watch_case(
     case: &Case,
     scenario: &WatchScenario,
@@ -4076,6 +4280,8 @@ fn run_case_wrapper(
         run_watch_case(case, scenario, contract, rue_binary, real_std)
     } else if let Some(scenario) = &case.watch_test {
         run_watch_test_case(case, scenario, contract, rue_binary, real_std)
+    } else if let Some(scenario) = &case.daemon {
+        run_daemon_case(case, scenario, contract, rue_binary, real_std)
     } else if case.differential_opt {
         run_case_differential(case, contract, rue_binary, real_std, repo_root)
     } else {
@@ -4431,7 +4637,12 @@ fn invalid_replay_repro(case: &Case) -> Option<&'static str> {
     if target.is_empty() {
         return Some("`replay_repro` must name a non-empty stable test ID");
     }
-    if case.compile_fail || case.compile_only || case.watch.is_some() || case.watch_test.is_some() {
+    if case.compile_fail
+        || case.compile_only
+        || case.watch.is_some()
+        || case.watch_test.is_some()
+        || case.daemon.is_some()
+    {
         return Some(
             "`replay_repro` requires an ordinary one-shot `rue test` case that publishes test events",
         );

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -126,6 +126,7 @@ enum IneligibleReason {
     CompileOnly,
     ApplicableKnownBug,
     WatchOrchestration,
+    DaemonOrchestration,
     DriverInvocation,
     StagedFixtures,
     HostCapability,
@@ -157,6 +158,7 @@ impl fmt::Display for IneligibleReason {
             Self::CompileOnly => f.write_str("compile-only case"),
             Self::ApplicableKnownBug => f.write_str("applicable known bug"),
             Self::WatchOrchestration => f.write_str("watch orchestration"),
+            Self::DaemonOrchestration => f.write_str("daemon orchestration"),
             Self::DriverInvocation => f.write_str("driver-only invocation"),
             Self::StagedFixtures => f.write_str("staged filesystem fixtures"),
             Self::HostCapability => f.write_str("required host capability"),
@@ -1402,6 +1404,7 @@ fn unsupported_corpus_field(case: &Case) -> Option<IneligibleReason> {
         args: _,
         watch: _,
         watch_test: _,
+        daemon: _,
         env: _,
         program_args: _,
         program_env: _,
@@ -1551,6 +1554,11 @@ fn check_case_with_native_with_configuration(
     // the sources it starts with are only the first of them (RUE-2023).
     if case.watch.is_some() || case.watch_test.is_some() {
         return CaseOutcome::Ineligible(IneligibleReason::WatchOrchestration);
+    }
+    // A daemon case is a sequence of service controls against a private
+    // endpoint; it compiles nothing, so there is no execution to compare.
+    if case.daemon.is_some() {
+        return CaseOutcome::Ineligible(IneligibleReason::DaemonOrchestration);
     }
     if let Some(reason) = unsupported_corpus_field(case) {
         return CaseOutcome::Ineligible(reason);
@@ -2557,6 +2565,9 @@ files = [{ path = "probe.rue", source = "not Rue" }]
         case.watch_test = Some(watch_test_scenario());
         assert_cli_ineligible(&case, IneligibleReason::WatchOrchestration);
         case.watch_test = None;
+        case.daemon = Some(rue_test_runner::cli_corpus::DaemonScenario { steps: Vec::new() });
+        assert_cli_ineligible(&case, IneligibleReason::DaemonOrchestration);
+        case.daemon = None;
         case.driver_exit_code = Some(3);
         assert_cli_ineligible(&case, IneligibleReason::DriverInvocation);
         case.driver_exit_code = None;

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -351,6 +351,38 @@ pub struct WatchEdit {
     pub symlink_target: Option<String>,
 }
 
+/// A `rue daemon` lifecycle scenario: driver invocations run in order, each
+/// with its own exit status and output expectations.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DaemonScenario {
+    pub steps: Vec<DaemonStep>,
+}
+
+/// One `rue daemon` invocation in a [`DaemonScenario`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DaemonStep {
+    /// The complete argument list, `daemon` token included.
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub exit_code: i32,
+    #[serde(default)]
+    pub stdout_contains: Vec<String>,
+    #[serde(default)]
+    pub stdout_not_contains: Vec<String>,
+    #[serde(default)]
+    pub stderr_contains: Vec<String>,
+    /// Run this many identical invocations at once. Every one must meet the
+    /// step's expectations; it is how a start race is staged.
+    #[serde(default = "one")]
+    pub concurrency: usize,
+}
+
+fn one() -> usize {
+    1
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Case {
@@ -407,6 +439,12 @@ pub struct Case {
     /// A synchronized, imperative `rue test --watch` integration scenario.
     #[serde(default)]
     pub watch_test: Option<WatchTestScenario>,
+    /// A sequence of `rue daemon` controls against one private endpoint root
+    /// (ADR-0085): the harness runs each step in the case directory, stops
+    /// whatever service the steps left behind, and never touches the user's
+    /// real runtime directory.
+    #[serde(default)]
+    pub daemon: Option<DaemonScenario>,
     /// Extra environment variables for the compiler invocation.
     #[serde(default)]
     pub env: HashMap<String, String>,

--- a/crates/rue/src/daemon/client.rs
+++ b/crates/rue/src/daemon/client.rs
@@ -1,0 +1,178 @@
+//! The client half of the service protocol: connect, prove identity, and issue
+//! control requests.
+
+use std::io;
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::Duration;
+
+use super::protocol::{
+    Hello, HelloReply, MAX_CONTROL_FRAME_BYTES, Request, RequestBody, Response, ResponseBody,
+    ServiceInfo, StatusReport, read_frame, write_frame,
+};
+
+/// Why a connection could not be established or used.
+#[derive(Debug)]
+pub enum ConnectError {
+    /// There is no socket at the endpoint.
+    NoSocket,
+    /// A socket exists but nothing accepts on it (a dead service left it).
+    Refused,
+    /// The socket is not owned by the current user.
+    Insecure(String),
+    /// The service answered the handshake by refusing this client.
+    Rejected(String),
+    /// The peer did not follow the protocol.
+    Protocol(String),
+    Io(io::Error),
+}
+
+impl std::fmt::Display for ConnectError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSocket => formatter.write_str("no service socket exists"),
+            Self::Refused => formatter.write_str("the service socket refused the connection"),
+            Self::Insecure(reason) => write!(formatter, "insecure service socket: {reason}"),
+            Self::Rejected(reason) => {
+                write!(formatter, "the service refused this client: {reason}")
+            }
+            Self::Protocol(reason) => write!(formatter, "protocol error: {reason}"),
+            Self::Io(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl From<io::Error> for ConnectError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<super::protocol::FrameError> for ConnectError {
+    fn from(error: super::protocol::FrameError) -> Self {
+        match error {
+            super::protocol::FrameError::Io(error) => Self::Io(error),
+            other => Self::Protocol(other.to_string()),
+        }
+    }
+}
+
+/// An established, identity-checked connection to a service.
+pub struct Connection {
+    stream: UnixStream,
+    service: ServiceInfo,
+    next_id: u64,
+}
+
+impl std::fmt::Debug for Connection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Connection")
+            .field("service", &self.service)
+            .field("next_id", &self.next_id)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Connect to `socket`, send `hello`, and require a welcome. The socket must
+/// be owned by the current user before anything is written to it; `timeout`
+/// bounds every read during the handshake.
+pub fn connect(
+    socket: &Path,
+    hello: &Hello,
+    timeout: Duration,
+) -> Result<Connection, ConnectError> {
+    let metadata = match std::fs::symlink_metadata(socket) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(ConnectError::NoSocket);
+        }
+        Err(error) => return Err(ConnectError::Io(error)),
+    };
+    // SAFETY: geteuid has no preconditions and cannot fail.
+    let uid = unsafe { libc::geteuid() };
+    if metadata.uid() != uid {
+        return Err(ConnectError::Insecure(format!(
+            "{} is owned by uid {}, not the current user {uid}",
+            socket.display(),
+            metadata.uid()
+        )));
+    }
+    let stream = match UnixStream::connect(socket) {
+        Ok(stream) => stream,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(ConnectError::NoSocket);
+        }
+        Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => {
+            return Err(ConnectError::Refused);
+        }
+        Err(error) => return Err(ConnectError::Io(error)),
+    };
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
+    let mut stream = stream;
+    write_frame(&mut stream, hello)?;
+    let reply: HelloReply = read_frame(&mut stream, MAX_CONTROL_FRAME_BYTES)?
+        .ok_or_else(|| ConnectError::Protocol("the service closed without answering".into()))?;
+    match reply {
+        HelloReply::Welcome { service } => Ok(Connection {
+            stream,
+            service,
+            next_id: 1,
+        }),
+        HelloReply::Rejected { reason } => Err(ConnectError::Rejected(reason)),
+    }
+}
+
+impl Connection {
+    pub fn service(&self) -> &ServiceInfo {
+        &self.service
+    }
+
+    /// Issue one request and wait for its response.
+    pub fn request(&mut self, body: RequestBody) -> Result<ResponseBody, ConnectError> {
+        let id = self.next_id;
+        self.next_id += 1;
+        write_frame(&mut self.stream, &Request { id, body })?;
+        let response: Response = read_frame(&mut self.stream, MAX_CONTROL_FRAME_BYTES)?
+            .ok_or_else(|| ConnectError::Protocol("the service closed mid-request".into()))?;
+        if response.id != id {
+            return Err(ConnectError::Protocol(format!(
+                "the service answered request {} while {id} was pending",
+                response.id
+            )));
+        }
+        Ok(response.body)
+    }
+
+    pub fn ping(&mut self) -> Result<(), ConnectError> {
+        match self.request(RequestBody::Ping)? {
+            ResponseBody::Pong => Ok(()),
+            other => Err(unexpected("pong", &other)),
+        }
+    }
+
+    pub fn status(&mut self) -> Result<StatusReport, ConnectError> {
+        match self.request(RequestBody::Status)? {
+            ResponseBody::Status { report } => Ok(*report),
+            other => Err(unexpected("a status report", &other)),
+        }
+    }
+
+    /// Ask the service to stop. It acknowledges before exiting; completion
+    /// is observed by its endpoint lock coming free.
+    pub fn stop(&mut self) -> Result<(), ConnectError> {
+        match self.request(RequestBody::Stop)? {
+            ResponseBody::Stopping => Ok(()),
+            other => Err(unexpected("a stop acknowledgement", &other)),
+        }
+    }
+}
+
+fn unexpected(expected: &str, actual: &ResponseBody) -> ConnectError {
+    match actual {
+        ResponseBody::Error { message } => ConnectError::Protocol(message.clone()),
+        other => ConnectError::Protocol(format!("expected {expected}, got {other:?}")),
+    }
+}

--- a/crates/rue/src/daemon/mod.rs
+++ b/crates/rue/src/daemon/mod.rs
@@ -1,0 +1,849 @@
+//! The local compiler service's identity, endpoint, and lifecycle
+//! (ADR-0085 §2, §5).
+//!
+//! A service is owned by one OS user, one scope directory, an optional
+//! isolation name, one exact compiler build, and one protocol version. Those
+//! five inputs digest into the service identity; the endpoint directory is
+//! named by it, so two compiler builds or two worktrees can never meet on one
+//! socket, and the handshake compares the same identity again so a stale or
+//! foreign endpoint is refused rather than trusted by its pathname.
+//!
+//! Liveness is a held file lock, never a recorded PID: a live service holds
+//! `service.lock` for its whole life, so "can the lock be taken" is the one
+//! question every control path asks before it believes a socket or record.
+//! Startup is serialized by `startup.lock`, and readiness is published only
+//! when the socket answers the handshake.
+
+pub mod client;
+pub mod protocol;
+mod service;
+
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use sha2::{Digest, Sha256};
+
+use crate::running_image::{RunningImageIdentity, running_image_identity};
+pub use protocol::{DAEMON_PROTOCOL_VERSION, IdentityRecord, ServiceInfo, StatusReport};
+pub use service::ServeExit;
+
+/// How long an idle service lives by default before retiring itself. A
+/// calibrated policy belongs to the qualification phase (ADR-0085 §7); this is
+/// the conservative bound an opt-in service uses until then.
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// How long `start` waits for a launched service to answer its handshake.
+pub const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Environment variable naming the endpoint root. It exists so a test harness
+/// or an operator can keep a set of services apart from the user's ordinary
+/// runtime directory; the directory must still be private to the user.
+pub const ENDPOINT_ROOT_ENV: &str = "RUE_DAEMON_ROOT";
+
+/// The longest socket path both maintained platforms accept (`sun_path` is
+/// 104 bytes on macOS and 108 on Linux, including the terminator).
+const MAX_SOCKET_PATH_BYTES: usize = 103;
+
+/// Why a service operation could not proceed. Every variant names what the
+/// caller can change; none is a program diagnostic.
+#[derive(Debug)]
+pub enum DaemonError {
+    /// The running compiler image has no verifiable identity, so no service
+    /// can be scoped to it.
+    IdentityUnavailable(String),
+    /// A scope, isolation name, or endpoint root the caller supplied is not
+    /// usable.
+    InvalidConfiguration(String),
+    /// The endpoint root or directory is not private to the current user.
+    InsecureEndpoint(PathBuf, String),
+    /// A filesystem or socket operation failed.
+    Io { context: String, error: io::Error },
+    /// A service answered on this endpoint but is not the one this identity
+    /// names, or spoke the protocol incorrectly.
+    Protocol(String),
+    /// A launched service did not become ready within the startup budget.
+    StartupTimeout { waited: Duration, detail: String },
+}
+
+impl DaemonError {
+    fn io(context: impl Into<String>, error: io::Error) -> Self {
+        Self::Io {
+            context: context.into(),
+            error,
+        }
+    }
+}
+
+impl std::fmt::Display for DaemonError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IdentityUnavailable(reason) => {
+                write!(formatter, "the compiler daemon is unavailable: {reason}")
+            }
+            Self::InvalidConfiguration(reason) => formatter.write_str(reason),
+            Self::InsecureEndpoint(path, reason) => write!(
+                formatter,
+                "refusing daemon endpoint {}: {reason}",
+                path.display()
+            ),
+            Self::Io { context, error } => write!(formatter, "{context}: {error}"),
+            Self::Protocol(reason) => write!(formatter, "daemon protocol error: {reason}"),
+            Self::StartupTimeout { waited, detail } => write!(
+                formatter,
+                "the compiler daemon did not become ready within {} ms{detail}",
+                waited.as_millis()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DaemonError {}
+
+/// The process/resource grouping a service belongs to (ADR-0085 §2). It is
+/// only that: it never changes the compiler's project root, import
+/// containment, manifest, or source identities.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DaemonScope {
+    directory: PathBuf,
+    isolation: Option<String>,
+}
+
+impl DaemonScope {
+    /// Scope a service to `directory`, which must exist; it is canonicalized
+    /// so every spelling of one directory selects one service. `isolation`
+    /// separates otherwise identical services and is limited to a short
+    /// portable name.
+    pub fn new(directory: &Path, isolation: Option<&str>) -> Result<Self, DaemonError> {
+        let directory = fs::canonicalize(directory).map_err(|error| {
+            DaemonError::InvalidConfiguration(format!(
+                "daemon scope directory {} is not usable: {error}",
+                directory.display()
+            ))
+        })?;
+        if !directory.is_dir() {
+            return Err(DaemonError::InvalidConfiguration(format!(
+                "daemon scope {} is not a directory",
+                directory.display()
+            )));
+        }
+        let isolation = match isolation {
+            None => None,
+            Some(name) => {
+                let valid = !name.is_empty()
+                    && name.len() <= 64
+                    && name
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || b"._-".contains(&byte));
+                if !valid {
+                    return Err(DaemonError::InvalidConfiguration(format!(
+                        "daemon isolation name {name:?} must be 1-64 characters of \
+                         letters, digits, `.`, `_`, or `-`"
+                    )));
+                }
+                Some(name.to_owned())
+            }
+        };
+        Ok(Self {
+            directory,
+            isolation,
+        })
+    }
+
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    pub fn isolation(&self) -> Option<&str> {
+        self.isolation.as_deref()
+    }
+}
+
+impl std::fmt::Display for DaemonScope {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.directory.display())?;
+        if let Some(isolation) = &self.isolation {
+            write!(formatter, " (isolation {isolation})")?;
+        }
+        Ok(())
+    }
+}
+
+/// The identity a client and a service must share: the current user, the
+/// scope, the protocol version, and the verified running compiler image.
+#[derive(Clone, Debug)]
+pub struct ServiceIdentity {
+    scope: DaemonScope,
+    image: RunningImageIdentity,
+    digest: [u8; 32],
+}
+
+impl ServiceIdentity {
+    /// The identity of a service for `scope` run by this process's image and
+    /// user. Fails when the running image cannot be identified; there is no
+    /// pathname or version fallback (RUE-2153).
+    pub fn current(scope: DaemonScope) -> Result<Self, DaemonError> {
+        // A process's image cannot change underneath it, and identifying it
+        // hashes the whole executable, so it is captured once per process.
+        static IMAGE: std::sync::OnceLock<Result<RunningImageIdentity, String>> =
+            std::sync::OnceLock::new();
+        let image = IMAGE
+            .get_or_init(|| running_image_identity().map_err(|error| error.reason().to_owned()))
+            .clone()
+            .map_err(DaemonError::IdentityUnavailable)?;
+        Ok(Self::with_image(scope, image))
+    }
+
+    fn with_image(scope: DaemonScope, image: RunningImageIdentity) -> Self {
+        let digest = service_digest(current_uid(), &scope, &image);
+        Self {
+            scope,
+            image,
+            digest,
+        }
+    }
+
+    pub fn scope(&self) -> &DaemonScope {
+        &self.scope
+    }
+
+    /// The endpoint directory name: enough of the digest to be unique across
+    /// a user's services while keeping socket paths short.
+    pub fn endpoint_name(&self) -> String {
+        hex(&self.digest[..8])
+    }
+
+    /// The comparable record both ends exchange in the handshake.
+    pub fn record(&self) -> IdentityRecord {
+        IdentityRecord {
+            scheme_version: self.image.scheme_version(),
+            architecture: format!("{:?}", self.image.architecture()),
+            scheme: format!("{:?}", self.image.scheme()),
+            image_hex: hex(self.image.as_bytes()),
+            service_hex: hex(&self.digest),
+        }
+    }
+
+    fn hello(&self) -> protocol::Hello {
+        protocol::Hello {
+            protocol_version: DAEMON_PROTOCOL_VERSION,
+            identity: self.record(),
+        }
+    }
+}
+
+/// Digest the service identity inputs. Each field is length-prefixed so no
+/// two input tuples share bytes, and the domain tag pins the layout.
+fn service_digest(uid: u32, scope: &DaemonScope, image: &RunningImageIdentity) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    let mut field = |bytes: &[u8]| {
+        hasher.update((bytes.len() as u64).to_be_bytes());
+        hasher.update(bytes);
+    };
+    field(b"rue-daemon-service-identity");
+    field(&DAEMON_PROTOCOL_VERSION.to_be_bytes());
+    field(&uid.to_be_bytes());
+    field(scope.directory.as_os_str().as_encoded_bytes());
+    field(scope.isolation.as_deref().unwrap_or("").as_bytes());
+    field(&image.scheme_version().to_be_bytes());
+    field(format!("{:?}", image.architecture()).as_bytes());
+    field(format!("{:?}", image.scheme()).as_bytes());
+    field(image.as_bytes());
+    hasher.finalize().into()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn current_uid() -> u32 {
+    // SAFETY: geteuid has no preconditions and cannot fail.
+    unsafe { libc::geteuid() }
+}
+
+/// The user-private directory every service endpoint lives under.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EndpointRoot(PathBuf);
+
+impl EndpointRoot {
+    /// Resolve the root: [`ENDPOINT_ROOT_ENV`] when set, otherwise `rue/`
+    /// under `XDG_RUNTIME_DIR`, otherwise `rue-daemon-<uid>` under the system
+    /// temporary directory. Nothing is created here; see [`Self::ensure`].
+    pub fn resolve() -> Result<Self, DaemonError> {
+        if let Some(explicit) = std::env::var_os(ENDPOINT_ROOT_ENV) {
+            if explicit.is_empty() {
+                return Err(DaemonError::InvalidConfiguration(format!(
+                    "{ENDPOINT_ROOT_ENV} is set but empty"
+                )));
+            }
+            return Ok(Self(PathBuf::from(explicit)));
+        }
+        if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR").filter(|value| !value.is_empty())
+        {
+            return Ok(Self(PathBuf::from(runtime).join("rue")));
+        }
+        Ok(Self(
+            std::env::temp_dir().join(format!("rue-daemon-{}", current_uid())),
+        ))
+    }
+
+    /// Use an explicit root, for callers that carry one rather than reading
+    /// the environment (a launched service, a test).
+    pub fn explicit(path: PathBuf) -> Self {
+        Self(path)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Create the root if needed and verify it is private to this user.
+    fn ensure(&self) -> Result<(), DaemonError> {
+        ensure_private_dir(&self.0)
+    }
+}
+
+/// Create `path` as a 0700 directory owned by this user, or verify an
+/// existing one is. A directory another user owns or can traverse is refused:
+/// the socket inside it would be reachable by them.
+fn ensure_private_dir(path: &Path) -> Result<(), DaemonError> {
+    match fs::metadata(path) {
+        Ok(metadata) => verify_private_dir(path, &metadata),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                fs::create_dir_all(parent).map_err(|error| {
+                    DaemonError::io(format!("creating {}", parent.display()), error)
+                })?;
+            }
+            match fs::DirBuilder::new().mode(0o700).create(path) {
+                Ok(()) => {}
+                // Lost a race with another client creating it: fine, verify it.
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(DaemonError::io(
+                        format!("creating {}", path.display()),
+                        error,
+                    ));
+                }
+            }
+            let metadata = fs::metadata(path).map_err(|error| {
+                DaemonError::io(format!("inspecting {}", path.display()), error)
+            })?;
+            verify_private_dir(path, &metadata)
+        }
+        Err(error) => Err(DaemonError::io(
+            format!("inspecting {}", path.display()),
+            error,
+        )),
+    }
+}
+
+fn verify_private_dir(path: &Path, metadata: &fs::Metadata) -> Result<(), DaemonError> {
+    if !metadata.is_dir() {
+        return Err(DaemonError::InsecureEndpoint(
+            path.to_path_buf(),
+            "it is not a directory".into(),
+        ));
+    }
+    if metadata.uid() != current_uid() {
+        return Err(DaemonError::InsecureEndpoint(
+            path.to_path_buf(),
+            format!(
+                "it is owned by uid {}, not the current user {}",
+                metadata.uid(),
+                current_uid()
+            ),
+        ));
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        return Err(DaemonError::InsecureEndpoint(
+            path.to_path_buf(),
+            format!(
+                "its mode {:o} lets other users reach it; it must be 0700",
+                metadata.permissions().mode() & 0o777
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// The files of one service endpoint.
+#[derive(Clone, Debug)]
+pub struct Endpoint {
+    directory: PathBuf,
+    socket: PathBuf,
+    service_lock: PathBuf,
+    startup_lock: PathBuf,
+    record: PathBuf,
+}
+
+impl Endpoint {
+    fn locate(root: &EndpointRoot, identity: &ServiceIdentity) -> Result<Self, DaemonError> {
+        let directory = root.path().join(identity.endpoint_name());
+        let socket = directory.join("socket");
+        if socket.as_os_str().len() > MAX_SOCKET_PATH_BYTES {
+            return Err(DaemonError::InvalidConfiguration(format!(
+                "daemon socket path {} is {} bytes; Unix sockets allow {MAX_SOCKET_PATH_BYTES}. \
+                 Set {ENDPOINT_ROOT_ENV} to a shorter private directory",
+                socket.display(),
+                socket.as_os_str().len()
+            )));
+        }
+        Ok(Self {
+            service_lock: directory.join("service.lock"),
+            startup_lock: directory.join("startup.lock"),
+            record: directory.join("service.json"),
+            socket,
+            directory,
+        })
+    }
+
+    /// Locate and create the endpoint, verifying the root and the directory
+    /// are private to this user.
+    fn prepare(root: &EndpointRoot, identity: &ServiceIdentity) -> Result<Self, DaemonError> {
+        root.ensure()?;
+        let endpoint = Self::locate(root, identity)?;
+        ensure_private_dir(&endpoint.directory)?;
+        Ok(endpoint)
+    }
+
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    pub fn socket(&self) -> &Path {
+        &self.socket
+    }
+
+    /// Remove the socket and record a dead service left behind. Only valid
+    /// while the caller holds proof nobody is alive (the service lock, or the
+    /// startup lock plus a free service lock).
+    fn clear_stale(&self) -> Result<(), DaemonError> {
+        for path in [&self.socket, &self.record] {
+            match fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(DaemonError::io(
+                        format!("removing {}", path.display()),
+                        error,
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// An advisory exclusive lock on a file, released when dropped.
+struct FileLock {
+    _file: File,
+}
+
+impl FileLock {
+    fn open(path: &Path) -> Result<File, DaemonError> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC)
+            .open(path)
+            .map_err(|error| DaemonError::io(format!("opening {}", path.display()), error))
+    }
+
+    /// Take the lock now, or report `None` when someone else holds it.
+    fn try_exclusive(path: &Path) -> Result<Option<Self>, DaemonError> {
+        let file = Self::open(path)?;
+        // SAFETY: flock on an owned, open descriptor.
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if rc == 0 {
+            return Ok(Some(Self { _file: file }));
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() == io::ErrorKind::WouldBlock {
+            return Ok(None);
+        }
+        Err(DaemonError::io(
+            format!("locking {}", path.display()),
+            error,
+        ))
+    }
+
+    /// Take the lock, polling until `deadline`.
+    fn exclusive_by(path: &Path, deadline: Instant) -> Result<Option<Self>, DaemonError> {
+        loop {
+            if let Some(lock) = Self::try_exclusive(path)? {
+                return Ok(Some(lock));
+            }
+            if Instant::now() >= deadline {
+                return Ok(None);
+            }
+            sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What probing an endpoint found.
+enum Probe {
+    /// A compatible service answered the handshake.
+    Live(Box<client::Connection>),
+    /// No service holds the endpoint. Any socket or record there is stale.
+    Absent,
+    /// A service holds the endpoint's lock but does not answer yet.
+    Starting,
+}
+
+fn probe(endpoint: &Endpoint, identity: &ServiceIdentity) -> Result<Probe, DaemonError> {
+    match client::connect(&endpoint.socket, &identity.hello(), HANDSHAKE_TIMEOUT) {
+        Ok(connection) => Ok(Probe::Live(Box::new(connection))),
+        Err(client::ConnectError::NoSocket | client::ConnectError::Refused) => {
+            match FileLock::try_exclusive(&endpoint.service_lock)? {
+                // Holding the lock ourselves proves nobody is alive; drop it
+                // right away so a starting service can take it.
+                Some(_free) => Ok(Probe::Absent),
+                None => Ok(Probe::Starting),
+            }
+        }
+        Err(client::ConnectError::Rejected(reason)) => Err(DaemonError::Protocol(format!(
+            "the service at {} refused this compiler: {reason}",
+            endpoint.socket.display()
+        ))),
+        Err(client::ConnectError::Insecure(reason)) => Err(DaemonError::InsecureEndpoint(
+            endpoint.socket.clone(),
+            reason,
+        )),
+        Err(client::ConnectError::Protocol(reason)) => Err(DaemonError::Protocol(reason)),
+        Err(client::ConnectError::Io(error)) => Err(DaemonError::io(
+            format!("connecting to {}", endpoint.socket.display()),
+            error,
+        )),
+    }
+}
+
+/// Options for [`start`].
+#[derive(Clone, Debug)]
+pub struct StartOptions {
+    pub idle_timeout: Duration,
+    pub startup_timeout: Duration,
+}
+
+impl Default for StartOptions {
+    fn default() -> Self {
+        Self {
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+            startup_timeout: DEFAULT_STARTUP_TIMEOUT,
+        }
+    }
+}
+
+/// What a launcher needs to bring a service up for an endpoint.
+#[derive(Clone, Debug)]
+pub struct LaunchPlan {
+    pub scope: DaemonScope,
+    pub root: EndpointRoot,
+    pub idle_timeout: Duration,
+}
+
+/// A service being brought up, so `start` can tell an early death from a slow
+/// start.
+pub trait LaunchedService {
+    /// `Some(reason)` once the service has ended without becoming ready.
+    fn ended(&mut self) -> Option<String>;
+}
+
+/// How `start` brings a service up. The command-line driver launches a
+/// detached process running `rue daemon serve`; tests may run the service on
+/// a thread of their own process.
+pub trait ServiceLauncher {
+    fn launch(&self, plan: &LaunchPlan) -> Result<Box<dyn LaunchedService>, DaemonError>;
+}
+
+/// The result of [`start`].
+#[derive(Debug)]
+pub struct StartOutcome {
+    pub service: ServiceInfo,
+    /// Whether this call launched the service, as opposed to finding one.
+    pub launched: bool,
+}
+
+/// Use or start the service for `scope` (ADR-0085 §5): serialize with the
+/// startup lock, believe only a service that answers the handshake, recover a
+/// stale endpoint whose lock nobody holds, launch, and wait a bounded time for
+/// readiness.
+pub fn start(
+    scope: DaemonScope,
+    root: &EndpointRoot,
+    options: &StartOptions,
+    launcher: &dyn ServiceLauncher,
+) -> Result<StartOutcome, DaemonError> {
+    let identity = ServiceIdentity::current(scope)?;
+    let endpoint = Endpoint::prepare(root, &identity)?;
+    let began = Instant::now();
+    let deadline = began + options.startup_timeout;
+    let Some(_startup) = FileLock::exclusive_by(&endpoint.startup_lock, deadline)? else {
+        return Err(DaemonError::StartupTimeout {
+            waited: began.elapsed(),
+            detail: ": another start is still holding the startup lock".into(),
+        });
+    };
+    let mut launched: Option<Box<dyn LaunchedService>> = None;
+    loop {
+        match probe(&endpoint, &identity)? {
+            Probe::Live(connection) => {
+                return Ok(StartOutcome {
+                    service: connection.service().clone(),
+                    launched: launched.is_some(),
+                });
+            }
+            Probe::Absent => match launched.as_mut() {
+                Some(service) => {
+                    if let Some(reason) = service.ended() {
+                        return Err(DaemonError::StartupTimeout {
+                            waited: began.elapsed(),
+                            detail: format!(": the launched service ended first ({reason})"),
+                        });
+                    }
+                }
+                None => {
+                    endpoint.clear_stale()?;
+                    launched = Some(launcher.launch(&LaunchPlan {
+                        scope: identity.scope().clone(),
+                        root: root.clone(),
+                        idle_timeout: options.idle_timeout,
+                    })?);
+                }
+            },
+            Probe::Starting => {}
+        }
+        if Instant::now() >= deadline {
+            let detail = match launched.as_mut().and_then(|service| service.ended()) {
+                Some(reason) => format!(": the launched service ended ({reason})"),
+                None if launched.is_some() => ": it holds the endpoint but never answered".into(),
+                None => ": another service holds the endpoint but never answered".into(),
+            };
+            return Err(DaemonError::StartupTimeout {
+                waited: began.elapsed(),
+                detail,
+            });
+        }
+        sleep(POLL_INTERVAL);
+    }
+}
+
+/// Report the service for `scope`, or `None` when none answers. Never
+/// starts one and creates nothing (ADR-0085 §2).
+pub fn status(
+    scope: DaemonScope,
+    root: &EndpointRoot,
+) -> Result<Option<StatusReport>, DaemonError> {
+    let identity = ServiceIdentity::current(scope)?;
+    let endpoint = Endpoint::locate(root, &identity)?;
+    if !endpoint.directory.exists() {
+        return Ok(None);
+    }
+    match probe(&endpoint, &identity)? {
+        Probe::Live(mut connection) => connection
+            .status()
+            .map(Some)
+            .map_err(|error| DaemonError::Protocol(error.to_string())),
+        Probe::Absent | Probe::Starting => Ok(None),
+    }
+}
+
+/// The result of [`stop`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum StopOutcome {
+    NotRunning,
+    Stopped { pid: u32 },
+}
+
+/// Stop the service for `scope` and wait for it to release its endpoint.
+/// Never starts one; a service that is still starting is waited for and then
+/// stopped, so `stop` after a racing `start` leaves nothing behind.
+pub fn stop(
+    scope: DaemonScope,
+    root: &EndpointRoot,
+    timeout: Duration,
+) -> Result<StopOutcome, DaemonError> {
+    let identity = ServiceIdentity::current(scope)?;
+    let endpoint = Endpoint::locate(root, &identity)?;
+    if !endpoint.directory.exists() {
+        return Ok(StopOutcome::NotRunning);
+    }
+    let deadline = Instant::now() + timeout;
+    let mut connection = loop {
+        match probe(&endpoint, &identity)? {
+            Probe::Live(connection) => break connection,
+            Probe::Absent => return Ok(StopOutcome::NotRunning),
+            Probe::Starting => {
+                if Instant::now() >= deadline {
+                    return Err(DaemonError::StartupTimeout {
+                        waited: timeout,
+                        detail: ": a starting service never answered, so it could not be stopped"
+                            .into(),
+                    });
+                }
+                sleep(POLL_INTERVAL);
+            }
+        }
+    };
+    let pid = connection.service().pid;
+    connection
+        .stop()
+        .map_err(|error| DaemonError::Protocol(error.to_string()))?;
+    drop(connection);
+    // The service releases its lock as it exits; that is the completion
+    // signal, not the acknowledgement above.
+    match FileLock::exclusive_by(&endpoint.service_lock, deadline)? {
+        Some(_free) => Ok(StopOutcome::Stopped { pid }),
+        None => Err(DaemonError::StartupTimeout {
+            waited: timeout,
+            detail: format!(
+                ": service pid {pid} acknowledged the stop but still holds its endpoint"
+            ),
+        }),
+    }
+}
+
+/// Run the service for `scope` in this process until it is stopped or idles
+/// out. This is the body of `rue daemon serve`; a client never calls it.
+pub fn serve(
+    scope: DaemonScope,
+    root: &EndpointRoot,
+    idle_timeout: Duration,
+) -> Result<ServeExit, DaemonError> {
+    let identity = ServiceIdentity::current(scope)?;
+    let endpoint = Endpoint::prepare(root, &identity)?;
+    let Some(_service_lock) = FileLock::try_exclusive(&endpoint.service_lock)? else {
+        return Ok(ServeExit::AlreadyRunning);
+    };
+    // Holding the service lock proves whatever socket is there is dead.
+    endpoint.clear_stale()?;
+    let listener = std::os::unix::net::UnixListener::bind(&endpoint.socket).map_err(|error| {
+        DaemonError::io(format!("binding {}", endpoint.socket.display()), error)
+    })?;
+    fs::set_permissions(&endpoint.socket, fs::Permissions::from_mode(0o600)).map_err(|error| {
+        DaemonError::io(format!("securing {}", endpoint.socket.display()), error)
+    })?;
+    let info = ServiceInfo {
+        pid: std::process::id(),
+        protocol_version: DAEMON_PROTOCOL_VERSION,
+        identity: identity.record(),
+        scope_directory: identity.scope().directory().display().to_string(),
+        isolation: identity.scope().isolation().map(str::to_owned),
+        endpoint_directory: endpoint.directory.display().to_string(),
+        started_at_unix_ms: unix_millis(),
+    };
+    write_record(&endpoint, &info)?;
+    let exit = service::run(listener, info, idle_timeout);
+    endpoint.clear_stale()?;
+    Ok(exit)
+}
+
+fn write_record(endpoint: &Endpoint, info: &ServiceInfo) -> Result<(), DaemonError> {
+    let pending = endpoint.directory.join("service.json.pending");
+    let body = serde_json::to_vec_pretty(info).map_err(io::Error::other);
+    let body = body.map_err(|error| DaemonError::io("encoding the service record", error))?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&pending)
+        .map_err(|error| DaemonError::io(format!("writing {}", pending.display()), error))?;
+    io::Write::write_all(&mut file, &body)
+        .map_err(|error| DaemonError::io(format!("writing {}", pending.display()), error))?;
+    fs::rename(&pending, &endpoint.record).map_err(|error| {
+        DaemonError::io(format!("publishing {}", endpoint.record.display()), error)
+    })
+}
+
+fn unix_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Launches `rue daemon serve` as a detached process: its own session, null
+/// standard streams, cwd at the endpoint directory rather than in any
+/// worktree, and the endpoint root passed explicitly so it never depends on
+/// the launching client's environment beyond the executable itself.
+pub struct ProcessLauncher {
+    executable: PathBuf,
+}
+
+impl ProcessLauncher {
+    /// Launch the image this process is running. The launched service proves
+    /// its own identity in the handshake, so a replacement installed between
+    /// this call and its exec is refused rather than trusted by path.
+    pub fn current_executable() -> Result<Self, DaemonError> {
+        let executable = std::env::current_exe()
+            .map_err(|error| DaemonError::io("locating the compiler executable", error))?;
+        Ok(Self { executable })
+    }
+}
+
+struct LaunchedProcess(Child);
+
+impl LaunchedService for LaunchedProcess {
+    fn ended(&mut self) -> Option<String> {
+        match self.0.try_wait() {
+            Ok(Some(status)) => Some(format!("exit status {status}")),
+            Ok(None) => None,
+            Err(error) => Some(format!("cannot observe the service process: {error}")),
+        }
+    }
+}
+
+impl ServiceLauncher for ProcessLauncher {
+    fn launch(&self, plan: &LaunchPlan) -> Result<Box<dyn LaunchedService>, DaemonError> {
+        use std::os::unix::process::CommandExt;
+        let mut command = Command::new(&self.executable);
+        command
+            .arg("daemon")
+            .arg("serve")
+            .arg("--scope")
+            .arg(plan.scope.directory())
+            .arg("--endpoint-root")
+            .arg(plan.root.path())
+            .arg("--idle-timeout-ms")
+            .arg(plan.idle_timeout.as_millis().to_string());
+        if let Some(isolation) = plan.scope.isolation() {
+            command.arg("--isolation").arg(isolation);
+        }
+        command
+            .current_dir(plan.root.path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        // SAFETY: setsid is async-signal-safe and touches no parent state.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let child = command
+            .spawn()
+            .map_err(|error| DaemonError::io("launching the compiler daemon", error))?;
+        Ok(Box::new(LaunchedProcess(child)))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rue/src/daemon/protocol.rs
+++ b/crates/rue/src/daemon/protocol.rs
@@ -1,0 +1,302 @@
+//! The wire protocol between a Rue compiler client and its local service.
+//!
+//! Messages are length-prefixed JSON frames on a Unix-domain socket: a 4-byte
+//! big-endian length followed by that many bytes of one JSON object. The
+//! protocol is deliberately narrow (ADR-0085 §5): every message is an explicit
+//! data-transfer object, never a serialized compiler struct, query key, or
+//! arena index. Both ends run the same compiler build — the handshake proves
+//! it — so the protocol version below changes only when the message shapes do.
+
+use std::io::{self, Read, Write};
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+/// The version of the message shapes in this module. It participates in the
+/// service identity, so a client and a service that disagree on it can never
+/// meet on one socket, and the handshake checks it again anyway.
+pub const DAEMON_PROTOCOL_VERSION: u32 = 1;
+
+/// The largest control frame either side accepts. Control messages are a few
+/// hundred bytes; a frame claiming more than this is a malformed or hostile
+/// peer, and the connection is dropped instead of allocating for it.
+pub const MAX_CONTROL_FRAME_BYTES: usize = 1 << 20;
+
+/// Why a frame could not be read.
+#[derive(Debug)]
+pub enum FrameError {
+    /// The peer closed the connection in the middle of a frame.
+    Truncated,
+    /// The peer announced a frame larger than the bound the reader allows.
+    Oversized { announced: usize, limit: usize },
+    /// The frame's bytes were not the expected JSON object.
+    Malformed(String),
+    /// The socket itself failed.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for FrameError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Truncated => formatter.write_str("the connection closed inside a frame"),
+            Self::Oversized { announced, limit } => write!(
+                formatter,
+                "the peer announced a {announced}-byte frame; the limit is {limit} bytes"
+            ),
+            Self::Malformed(message) => write!(formatter, "malformed frame: {message}"),
+            Self::Io(error) => write!(formatter, "socket error: {error}"),
+        }
+    }
+}
+
+impl From<io::Error> for FrameError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// Write one message as a frame.
+pub fn write_frame(stream: &mut impl Write, message: &impl Serialize) -> io::Result<()> {
+    let body = serde_json::to_vec(message).map_err(io::Error::other)?;
+    let length = u32::try_from(body.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "a frame cannot exceed 4 GiB"))?;
+    stream.write_all(&length.to_be_bytes())?;
+    stream.write_all(&body)?;
+    stream.flush()
+}
+
+/// Read one frame, or `None` when the peer closed the connection cleanly
+/// between frames. A frame longer than `limit` is refused before any of its
+/// body is read.
+pub fn read_frame<T: DeserializeOwned>(
+    stream: &mut impl Read,
+    limit: usize,
+) -> Result<Option<T>, FrameError> {
+    let mut header = [0u8; 4];
+    match stream.read_exact(&mut header) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(FrameError::Io(error)),
+    }
+    let announced = u32::from_be_bytes(header) as usize;
+    if announced > limit {
+        return Err(FrameError::Oversized { announced, limit });
+    }
+    let mut body = vec![0u8; announced];
+    stream.read_exact(&mut body).map_err(|error| {
+        if error.kind() == io::ErrorKind::UnexpectedEof {
+            FrameError::Truncated
+        } else {
+            FrameError::Io(error)
+        }
+    })?;
+    serde_json::from_slice(&body)
+        .map(Some)
+        .map_err(|error| FrameError::Malformed(error.to_string()))
+}
+
+/// The running compiler image and service scope a peer claims, in a form
+/// both ends can compare byte for byte.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityRecord {
+    pub scheme_version: u16,
+    pub architecture: String,
+    pub scheme: String,
+    /// The image identity bytes, lowercase hex.
+    pub image_hex: String,
+    /// The service digest over user, scope, isolation, protocol, and image,
+    /// lowercase hex. The endpoint directory is named by its prefix.
+    pub service_hex: String,
+}
+
+/// The first message a client sends.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Hello {
+    pub protocol_version: u32,
+    pub identity: IdentityRecord,
+}
+
+/// What a service knows about itself, reported in the handshake and in
+/// status.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServiceInfo {
+    pub pid: u32,
+    pub protocol_version: u32,
+    pub identity: IdentityRecord,
+    pub scope_directory: String,
+    pub isolation: Option<String>,
+    pub endpoint_directory: String,
+    pub started_at_unix_ms: u64,
+}
+
+/// The service's answer to [`Hello`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HelloReply {
+    Welcome { service: ServiceInfo },
+    Rejected { reason: String },
+}
+
+/// One request on an established connection.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Request {
+    pub id: u64,
+    pub body: RequestBody,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RequestBody {
+    Ping,
+    Status,
+    /// End the service. It answers [`ResponseBody::Stopping`] and then exits;
+    /// the caller observes completion by the socket disappearing.
+    Stop,
+}
+
+/// One response, carrying the id of the request it answers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Response {
+    pub id: u64,
+    pub body: ResponseBody,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResponseBody {
+    Pong,
+    Status { report: Box<StatusReport> },
+    Stopping,
+    Error { message: String },
+}
+
+/// What `rue daemon status` reports (ADR-0085 §2): identity, PID, scope,
+/// active request, queue, retained hosts, and the resource policy in force.
+/// The request and host fields are structural placeholders until the service
+/// executes compiler requests; a status consumer sees the same shape then.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StatusReport {
+    pub service: ServiceInfo,
+    pub uptime_ms: u64,
+    pub idle_timeout_ms: u64,
+    /// Connections open right now, this one included.
+    pub connections: u32,
+    pub active_request: Option<String>,
+    pub queued_requests: u32,
+    pub retained_hosts: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> IdentityRecord {
+        IdentityRecord {
+            scheme_version: 1,
+            architecture: "x86_64".into(),
+            scheme: "test".into(),
+            image_hex: "ab".into(),
+            service_hex: "cd".into(),
+        }
+    }
+
+    #[test]
+    fn frames_round_trip_and_stop_cleanly_at_eof() {
+        let mut wire = Vec::new();
+        write_frame(
+            &mut wire,
+            &Request {
+                id: 7,
+                body: RequestBody::Status,
+            },
+        )
+        .unwrap();
+        write_frame(
+            &mut wire,
+            &Response {
+                id: 7,
+                body: ResponseBody::Pong,
+            },
+        )
+        .unwrap();
+        let mut reader = wire.as_slice();
+        let request: Request = read_frame(&mut reader, MAX_CONTROL_FRAME_BYTES)
+            .unwrap()
+            .unwrap();
+        assert_eq!(request.id, 7);
+        assert!(matches!(request.body, RequestBody::Status));
+        let response: Response = read_frame(&mut reader, MAX_CONTROL_FRAME_BYTES)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(response.body, ResponseBody::Pong));
+        let end: Option<Request> = read_frame(&mut reader, MAX_CONTROL_FRAME_BYTES).unwrap();
+        assert!(end.is_none(), "a clean EOF between frames is not an error");
+    }
+
+    #[test]
+    fn oversized_and_truncated_frames_are_refused_before_allocation() {
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&(u32::MAX).to_be_bytes());
+        let mut reader = wire.as_slice();
+        let error = read_frame::<Request>(&mut reader, 16).unwrap_err();
+        assert!(
+            matches!(error, FrameError::Oversized { limit: 16, .. }),
+            "{error}"
+        );
+
+        let mut wire = Vec::new();
+        write_frame(
+            &mut wire,
+            &Hello {
+                protocol_version: 1,
+                identity: identity(),
+            },
+        )
+        .unwrap();
+        wire.truncate(wire.len() - 3);
+        let mut reader = wire.as_slice();
+        let error = read_frame::<Hello>(&mut reader, MAX_CONTROL_FRAME_BYTES).unwrap_err();
+        assert!(matches!(error, FrameError::Truncated), "{error}");
+    }
+
+    #[test]
+    fn malformed_frames_name_the_problem() {
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&3_u32.to_be_bytes());
+        wire.extend_from_slice(b"nop");
+        let mut reader = wire.as_slice();
+        let error = read_frame::<Hello>(&mut reader, MAX_CONTROL_FRAME_BYTES).unwrap_err();
+        assert!(matches!(error, FrameError::Malformed(_)), "{error}");
+    }
+
+    #[test]
+    fn hello_reply_and_status_serialize_with_tagged_kinds() {
+        let reply = HelloReply::Rejected {
+            reason: "identity mismatch".into(),
+        };
+        let json = serde_json::to_string(&reply).unwrap();
+        assert!(json.contains("\"kind\":\"rejected\""), "{json}");
+        let body = ResponseBody::Status {
+            report: Box::new(StatusReport {
+                service: ServiceInfo {
+                    pid: 1,
+                    protocol_version: DAEMON_PROTOCOL_VERSION,
+                    identity: identity(),
+                    scope_directory: "/p".into(),
+                    isolation: None,
+                    endpoint_directory: "/e".into(),
+                    started_at_unix_ms: 0,
+                },
+                uptime_ms: 5,
+                idle_timeout_ms: 10,
+                connections: 1,
+                active_request: None,
+                queued_requests: 0,
+                retained_hosts: 0,
+            }),
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"kind\":\"status\""), "{json}");
+        let back: ResponseBody = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, ResponseBody::Status { .. }));
+    }
+}

--- a/crates/rue/src/daemon/service.rs
+++ b/crates/rue/src/daemon/service.rs
@@ -1,0 +1,288 @@
+//! The service loop: accept connections, verify the peer, answer control
+//! requests, and retire on stop or idleness.
+//!
+//! Control messages must stay serviceable while compiler work runs
+//! (ADR-0085 §6), so every connection is handled on its own thread and the
+//! accept loop never blocks on one. The compiler owner and its admission queue
+//! arrive with request execution; the loop here is shaped for them: one shared
+//! state, connection threads that only submit and wait, and a stop flag every
+//! thread observes.
+
+use std::io;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::protocol::{
+    DAEMON_PROTOCOL_VERSION, Hello, HelloReply, MAX_CONTROL_FRAME_BYTES, Request, RequestBody,
+    Response, ResponseBody, ServiceInfo, StatusReport, read_frame, write_frame,
+};
+
+/// Why the service loop returned.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ServeExit {
+    /// A client asked it to stop.
+    Stopped,
+    /// No connection arrived within the idle timeout.
+    Idle,
+    /// Another service already held the endpoint; nothing was served.
+    AlreadyRunning,
+}
+
+/// How long a connection has to complete its handshake.
+const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(5);
+/// How often the accept loop wakes to check for stop and idleness.
+const ACCEPT_POLL: Duration = Duration::from_millis(25);
+
+struct Shared {
+    info: ServiceInfo,
+    started: Instant,
+    idle_timeout: Duration,
+    stop: AtomicBool,
+    connections: AtomicU32,
+    last_activity: Mutex<Instant>,
+}
+
+impl Shared {
+    fn touch(&self) {
+        *self
+            .last_activity
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = Instant::now();
+    }
+
+    fn idle_for(&self) -> Duration {
+        self.last_activity
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .elapsed()
+    }
+
+    fn report(&self) -> StatusReport {
+        StatusReport {
+            service: self.info.clone(),
+            uptime_ms: self.started.elapsed().as_millis() as u64,
+            idle_timeout_ms: self.idle_timeout.as_millis() as u64,
+            connections: self.connections.load(Ordering::Acquire),
+            active_request: None,
+            queued_requests: 0,
+            retained_hosts: 0,
+        }
+    }
+}
+
+/// Serve `listener` until stopped or idle. The listener is already bound and
+/// secured; the caller owns the endpoint lock for the whole call.
+pub(super) fn run(listener: UnixListener, info: ServiceInfo, idle_timeout: Duration) -> ServeExit {
+    // A client that vanishes mid-write must be a failed connection, never a
+    // dead service.
+    // SAFETY: changing this process's SIGPIPE disposition has no preconditions.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+    }
+    if listener.set_nonblocking(true).is_err() {
+        return ServeExit::Idle;
+    }
+    let shared = Arc::new(Shared {
+        info,
+        started: Instant::now(),
+        idle_timeout,
+        stop: AtomicBool::new(false),
+        connections: AtomicU32::new(0),
+        last_activity: Mutex::new(Instant::now()),
+    });
+    let mut handlers: Vec<thread::JoinHandle<()>> = Vec::new();
+    loop {
+        if shared.stop.load(Ordering::Acquire) {
+            break;
+        }
+        match listener.accept() {
+            Ok((stream, _)) => {
+                shared.touch();
+                let shared = Arc::clone(&shared);
+                handlers.push(thread::spawn(move || handle_connection(stream, &shared)));
+                handlers.retain(|handle| !handle.is_finished());
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                if shared.connections.load(Ordering::Acquire) == 0
+                    && shared.idle_for() >= shared.idle_timeout
+                {
+                    return ServeExit::Idle;
+                }
+                thread::sleep(ACCEPT_POLL);
+            }
+            Err(_) => thread::sleep(ACCEPT_POLL),
+        }
+    }
+    // Let the stopping client's acknowledgement and any other in-flight
+    // control reply finish before the endpoint is torn down.
+    for handle in handlers {
+        let _ = handle.join();
+    }
+    ServeExit::Stopped
+}
+
+/// A connection counted for the whole time its thread runs.
+struct ConnectionGuard<'a>(&'a Shared);
+
+impl<'a> ConnectionGuard<'a> {
+    fn new(shared: &'a Shared) -> Self {
+        shared.connections.fetch_add(1, Ordering::AcqRel);
+        Self(shared)
+    }
+}
+
+impl Drop for ConnectionGuard<'_> {
+    fn drop(&mut self) {
+        self.0.connections.fetch_sub(1, Ordering::AcqRel);
+        self.0.touch();
+    }
+}
+
+fn handle_connection(stream: UnixStream, shared: &Shared) {
+    let _guard = ConnectionGuard::new(shared);
+    let mut stream = stream;
+    if stream.set_nonblocking(false).is_err() {
+        return;
+    }
+    // The socket file is 0600 in a 0700 directory, so only this user can
+    // reach it; the kernel's peer identity is checked anyway so a
+    // misconfigured directory can never widen who the service talks to.
+    match peer_uid(&stream) {
+        // SAFETY: geteuid has no preconditions and cannot fail.
+        Ok(uid) if uid == unsafe { libc::geteuid() } => {}
+        _ => return,
+    }
+    if stream
+        .set_read_timeout(Some(HANDSHAKE_READ_TIMEOUT))
+        .is_err()
+    {
+        return;
+    }
+    let hello: Hello = match read_frame(&mut stream, MAX_CONTROL_FRAME_BYTES) {
+        Ok(Some(hello)) => hello,
+        Ok(None) | Err(_) => return,
+    };
+    if let Some(reason) = rejection(&hello, &shared.info) {
+        let _ = write_frame(&mut stream, &HelloReply::Rejected { reason });
+        return;
+    }
+    if write_frame(
+        &mut stream,
+        &HelloReply::Welcome {
+            service: shared.info.clone(),
+        },
+    )
+    .is_err()
+    {
+        return;
+    }
+    // Requests may legitimately wait: a later compile request holds the
+    // connection for its whole run.
+    if stream.set_read_timeout(None).is_err() {
+        return;
+    }
+    loop {
+        let request: Request = match read_frame(&mut stream, MAX_CONTROL_FRAME_BYTES) {
+            Ok(Some(request)) => request,
+            Ok(None) | Err(_) => return,
+        };
+        shared.touch();
+        let (body, stop_after) = match request.body {
+            RequestBody::Ping => (ResponseBody::Pong, false),
+            RequestBody::Status => (
+                ResponseBody::Status {
+                    report: Box::new(shared.report()),
+                },
+                false,
+            ),
+            RequestBody::Stop => (ResponseBody::Stopping, true),
+        };
+        let written = write_frame(
+            &mut stream,
+            &Response {
+                id: request.id,
+                body,
+            },
+        );
+        if stop_after {
+            shared.stop.store(true, Ordering::Release);
+            return;
+        }
+        if written.is_err() {
+            return;
+        }
+    }
+}
+
+/// Why a hello is refused, if it is: the protocol version and the full
+/// identity record must both match this service's own.
+fn rejection(hello: &Hello, info: &ServiceInfo) -> Option<String> {
+    if hello.protocol_version != DAEMON_PROTOCOL_VERSION {
+        return Some(format!(
+            "protocol version {} differs from the service's {}",
+            hello.protocol_version, DAEMON_PROTOCOL_VERSION
+        ));
+    }
+    if hello.identity != info.identity {
+        return Some(format!(
+            "compiler identity {} differs from the service's {}",
+            short(&hello.identity.service_hex),
+            short(&info.identity.service_hex)
+        ));
+    }
+    None
+}
+
+fn short(hex: &str) -> &str {
+    hex.get(..16).unwrap_or(hex)
+}
+
+/// The effective uid of the process on the other end of `stream`.
+#[cfg(target_os = "linux")]
+fn peer_uid(stream: &UnixStream) -> io::Result<u32> {
+    let mut credentials = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: getsockopt writes at most `length` bytes into `credentials`,
+    // which is exactly the struct SO_PEERCRED fills.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&raw mut credentials).cast::<libc::c_void>(),
+            &raw mut length,
+        )
+    };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(credentials.uid)
+}
+
+#[cfg(target_os = "macos")]
+fn peer_uid(stream: &UnixStream) -> io::Result<u32> {
+    let mut uid: libc::uid_t = 0;
+    let mut gid: libc::gid_t = 0;
+    // SAFETY: getpeereid writes one uid and one gid into the provided slots.
+    let rc = unsafe { libc::getpeereid(stream.as_raw_fd(), &raw mut uid, &raw mut gid) };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(uid)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn peer_uid(_stream: &UnixStream) -> io::Result<u32> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "peer credentials are not available on this platform",
+    ))
+}

--- a/crates/rue/src/daemon/tests.rs
+++ b/crates/rue/src/daemon/tests.rs
@@ -61,9 +61,7 @@ struct Fixture {
 
 impl Fixture {
     fn new() -> Self {
-        // A short root: the socket path must stay under the platform bound
-        // even when the system temporary directory is long.
-        let dir = tempfile::Builder::new().prefix("rd").tempdir().unwrap();
+        let dir = short_private_temp_dir();
         let scope_dir = dir.path().join("scope");
         fs::create_dir(&scope_dir).unwrap();
         let root = EndpointRoot::explicit(dir.path().join("r"));
@@ -84,6 +82,20 @@ impl Fixture {
             startup_timeout: Duration::from_secs(20),
         }
     }
+}
+
+/// A private temporary directory short enough to hold an endpoint: Unix
+/// socket paths are bounded at about a hundred bytes, and the system
+/// temporary directory under Buck2 is a deep scratch path, so `/tmp` is tried
+/// first and the system directory is the fallback.
+fn short_private_temp_dir() -> tempfile::TempDir {
+    let short = Path::new("/tmp");
+    if short.is_dir() {
+        if let Ok(dir) = tempfile::Builder::new().prefix("rd").tempdir_in(short) {
+            return dir;
+        }
+    }
+    tempfile::Builder::new().prefix("rd").tempdir().unwrap()
 }
 
 fn wait_until(deadline: Duration, mut condition: impl FnMut() -> bool) -> bool {

--- a/crates/rue/src/daemon/tests.rs
+++ b/crates/rue/src/daemon/tests.rs
@@ -1,0 +1,427 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::*;
+
+/// Runs the service on a thread of this process, so lifecycle logic is tested
+/// without spawning the compiler executable; `launches` counts how many
+/// services were brought up.
+struct ThreadLauncher {
+    launches: Arc<AtomicUsize>,
+}
+
+impl ThreadLauncher {
+    fn new() -> Self {
+        Self {
+            launches: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+struct LaunchedThread(Option<thread::JoinHandle<Result<ServeExit, DaemonError>>>);
+
+impl LaunchedService for LaunchedThread {
+    fn ended(&mut self) -> Option<String> {
+        let finished = self.0.as_ref().is_some_and(thread::JoinHandle::is_finished);
+        if !finished {
+            return None;
+        }
+        let handle = self.0.take()?;
+        Some(match handle.join() {
+            Ok(Ok(exit)) => format!("{exit:?}"),
+            Ok(Err(error)) => error.to_string(),
+            Err(_) => "the service thread panicked".into(),
+        })
+    }
+}
+
+impl ServiceLauncher for ThreadLauncher {
+    fn launch(&self, plan: &LaunchPlan) -> Result<Box<dyn LaunchedService>, DaemonError> {
+        self.launches.fetch_add(1, Ordering::AcqRel);
+        let scope = plan.scope.clone();
+        let root = plan.root.clone();
+        let idle_timeout = plan.idle_timeout;
+        Ok(Box::new(LaunchedThread(Some(thread::spawn(move || {
+            serve(scope, &root, idle_timeout)
+        })))))
+    }
+}
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    scope_dir: PathBuf,
+    root: EndpointRoot,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        // A short root: the socket path must stay under the platform bound
+        // even when the system temporary directory is long.
+        let dir = tempfile::Builder::new().prefix("rd").tempdir().unwrap();
+        let scope_dir = dir.path().join("scope");
+        fs::create_dir(&scope_dir).unwrap();
+        let root = EndpointRoot::explicit(dir.path().join("r"));
+        Self {
+            _dir: dir,
+            scope_dir,
+            root,
+        }
+    }
+
+    fn scope(&self) -> DaemonScope {
+        DaemonScope::new(&self.scope_dir, None).unwrap()
+    }
+
+    fn options(&self) -> StartOptions {
+        StartOptions {
+            idle_timeout: Duration::from_secs(60),
+            startup_timeout: Duration::from_secs(20),
+        }
+    }
+}
+
+fn wait_until(deadline: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let started = Instant::now();
+    while started.elapsed() < deadline {
+        if condition() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    condition()
+}
+
+#[test]
+fn service_identity_depends_on_scope_isolation_and_image() {
+    let fixture = Fixture::new();
+    let other_dir = fixture._dir.path().join("other");
+    fs::create_dir(&other_dir).unwrap();
+    let base = ServiceIdentity::current(fixture.scope()).unwrap();
+    let again = ServiceIdentity::current(fixture.scope()).unwrap();
+    assert_eq!(
+        base.record(),
+        again.record(),
+        "one scope and image: one identity"
+    );
+    assert_eq!(base.endpoint_name().len(), 16);
+    assert!(
+        base.endpoint_name()
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    );
+
+    let isolated =
+        ServiceIdentity::current(DaemonScope::new(&fixture.scope_dir, Some("a")).unwrap()).unwrap();
+    assert_ne!(base.endpoint_name(), isolated.endpoint_name());
+    let elsewhere = ServiceIdentity::current(DaemonScope::new(&other_dir, None).unwrap()).unwrap();
+    assert_ne!(base.endpoint_name(), elsewhere.endpoint_name());
+    // The image participates: the same user and scope under another image
+    // names another endpoint.
+    let other_image = ServiceIdentity::with_image(
+        fixture.scope(),
+        crate::running_image::RunningImageIdentity::for_test(vec![1, 2, 3]),
+    );
+    assert_ne!(base.endpoint_name(), other_image.endpoint_name());
+    assert_ne!(base.record().image_hex, other_image.record().image_hex);
+
+    // A scope is canonical: another spelling of the directory is the same one.
+    let dotted = fixture.scope_dir.join(".");
+    let via_dot = ServiceIdentity::current(DaemonScope::new(&dotted, None).unwrap()).unwrap();
+    assert_eq!(base.endpoint_name(), via_dot.endpoint_name());
+}
+
+#[test]
+fn scope_and_isolation_are_validated() {
+    let fixture = Fixture::new();
+    assert!(DaemonScope::new(&fixture._dir.path().join("missing"), None).is_err());
+    for bad in ["", "has space", "a/b", &"x".repeat(65)] {
+        assert!(
+            DaemonScope::new(&fixture.scope_dir, Some(bad)).is_err(),
+            "{bad:?} must be refused"
+        );
+    }
+    assert!(DaemonScope::new(&fixture.scope_dir, Some("build-1.x_y")).is_ok());
+}
+
+#[test]
+fn endpoint_root_must_be_private_to_the_user() {
+    let fixture = Fixture::new();
+    let shared = fixture._dir.path().join("shared");
+    fs::create_dir(&shared).unwrap();
+    fs::set_permissions(&shared, fs::Permissions::from_mode(0o755)).unwrap();
+    let error = EndpointRoot::explicit(shared).ensure().unwrap_err();
+    assert!(
+        matches!(error, DaemonError::InsecureEndpoint(..)),
+        "{error}"
+    );
+
+    fixture.root.ensure().unwrap();
+    let mode = fs::metadata(fixture.root.path())
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o700, "a created root is private");
+    fixture.root.ensure().unwrap();
+}
+
+#[test]
+fn status_never_creates_an_endpoint() {
+    let fixture = Fixture::new();
+    assert!(status(fixture.scope(), &fixture.root).unwrap().is_none());
+    assert!(
+        !fixture.root.path().exists(),
+        "status must not create the root"
+    );
+    assert_eq!(
+        stop(fixture.scope(), &fixture.root, Duration::from_secs(1)).unwrap(),
+        StopOutcome::NotRunning
+    );
+    assert!(
+        !fixture.root.path().exists(),
+        "stop must not create the root"
+    );
+}
+
+#[test]
+fn start_status_and_stop_round_trip() {
+    let fixture = Fixture::new();
+    let launcher = ThreadLauncher::new();
+    let started = start(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    assert!(started.launched);
+    assert_eq!(started.service.pid, std::process::id());
+    assert_eq!(started.service.protocol_version, DAEMON_PROTOCOL_VERSION);
+    assert_eq!(
+        started.service.scope_directory,
+        fixture.scope().directory().display().to_string()
+    );
+
+    let report = status(fixture.scope(), &fixture.root)
+        .unwrap()
+        .expect("a started service reports");
+    assert_eq!(report.service, started.service);
+    assert!(report.connections >= 1, "the status connection counts");
+    assert_eq!(report.active_request, None);
+    assert_eq!(report.retained_hosts, 0);
+    assert_eq!(report.idle_timeout_ms, 60_000);
+
+    let again = start(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    assert!(!again.launched, "a running service is used, not relaunched");
+    assert_eq!(again.service, started.service);
+    assert_eq!(launcher.launches.load(Ordering::Acquire), 1);
+
+    let endpoint = Endpoint::locate(
+        &fixture.root,
+        &ServiceIdentity::current(fixture.scope()).unwrap(),
+    )
+    .unwrap();
+    assert!(endpoint.socket().exists());
+    let record: ServiceInfo =
+        serde_json::from_slice(&fs::read(endpoint.directory().join("service.json")).unwrap())
+            .unwrap();
+    assert_eq!(record, started.service);
+
+    assert_eq!(
+        stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap(),
+        StopOutcome::Stopped {
+            pid: std::process::id()
+        }
+    );
+    assert!(status(fixture.scope(), &fixture.root).unwrap().is_none());
+    assert!(
+        !endpoint.socket().exists(),
+        "a stopped service removes its socket"
+    );
+    assert!(!endpoint.directory().join("service.json").exists());
+    assert_eq!(
+        stop(fixture.scope(), &fixture.root, Duration::from_secs(1)).unwrap(),
+        StopOutcome::NotRunning
+    );
+}
+
+#[test]
+fn a_stale_endpoint_is_recovered_before_launching() {
+    let fixture = Fixture::new();
+    let identity = ServiceIdentity::current(fixture.scope()).unwrap();
+    let endpoint = Endpoint::prepare(&fixture.root, &identity).unwrap();
+    // A dead service's leavings: a socket nothing listens on and a record.
+    let _stale = std::os::unix::net::UnixListener::bind(endpoint.socket()).unwrap();
+    drop(_stale);
+    fs::write(endpoint.directory().join("service.json"), b"{}").unwrap();
+    assert!(status(fixture.scope(), &fixture.root).unwrap().is_none());
+
+    let launcher = ThreadLauncher::new();
+    let started = start(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    assert!(started.launched);
+    let report = status(fixture.scope(), &fixture.root).unwrap().unwrap();
+    assert_eq!(report.service.pid, std::process::id());
+    stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap();
+}
+
+#[test]
+fn concurrent_starts_share_one_service() {
+    let fixture = Fixture::new();
+    let launcher = Arc::new(ThreadLauncher::new());
+    let barrier = Arc::new(Barrier::new(4));
+    let mut starters = Vec::new();
+    for _ in 0..4 {
+        let scope = fixture.scope();
+        let root = fixture.root.clone();
+        let options = fixture.options();
+        let launcher = Arc::clone(&launcher);
+        let barrier = Arc::clone(&barrier);
+        starters.push(thread::spawn(move || {
+            barrier.wait();
+            start(scope, &root, &options, &*launcher).unwrap()
+        }));
+    }
+    let outcomes: Vec<StartOutcome> = starters
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect();
+    assert_eq!(launcher.launches.load(Ordering::Acquire), 1);
+    assert_eq!(
+        outcomes.iter().filter(|outcome| outcome.launched).count(),
+        1,
+        "exactly one start launches; the rest find the service"
+    );
+    for outcome in &outcomes {
+        assert_eq!(outcome.service, outcomes[0].service);
+    }
+    stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap();
+}
+
+#[test]
+fn a_client_with_another_identity_or_protocol_is_refused() {
+    let fixture = Fixture::new();
+    let launcher = ThreadLauncher::new();
+    start(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    let identity = ServiceIdentity::current(fixture.scope()).unwrap();
+    let endpoint = Endpoint::locate(&fixture.root, &identity).unwrap();
+
+    let mut other_image = identity.hello();
+    other_image.identity.image_hex.push_str("00");
+    let refused = client::connect(endpoint.socket(), &other_image, Duration::from_secs(5));
+    assert!(
+        matches!(refused, Err(client::ConnectError::Rejected(ref reason)) if reason.contains("identity")),
+        "{refused:?}"
+    );
+
+    let mut other_protocol = identity.hello();
+    other_protocol.protocol_version += 1;
+    let refused = client::connect(endpoint.socket(), &other_protocol, Duration::from_secs(5));
+    assert!(
+        matches!(refused, Err(client::ConnectError::Rejected(ref reason)) if reason.contains("protocol")),
+        "{refused:?}"
+    );
+
+    // The service is unharmed by refused peers.
+    let mut accepted =
+        client::connect(endpoint.socket(), &identity.hello(), Duration::from_secs(5)).unwrap();
+    accepted.ping().unwrap();
+    drop(accepted);
+    stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap();
+}
+
+#[test]
+fn malformed_peers_are_dropped_without_disturbing_the_service() {
+    let fixture = Fixture::new();
+    let launcher = ThreadLauncher::new();
+    start(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    let identity = ServiceIdentity::current(fixture.scope()).unwrap();
+    let endpoint = Endpoint::locate(&fixture.root, &identity).unwrap();
+
+    // An oversized frame announcement.
+    let mut raw = UnixStream::connect(endpoint.socket()).unwrap();
+    raw.write_all(&u32::MAX.to_be_bytes()).unwrap();
+    raw.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let mut sink = Vec::new();
+    let _ = raw.read_to_end(&mut sink);
+    assert!(sink.is_empty(), "nothing is answered to an oversized frame");
+    drop(raw);
+
+    // A truncated hello.
+    let mut raw = UnixStream::connect(endpoint.socket()).unwrap();
+    raw.write_all(&40_u32.to_be_bytes()).unwrap();
+    raw.write_all(b"{\"protocol_version\":1").unwrap();
+    drop(raw);
+
+    let report = status(fixture.scope(), &fixture.root).unwrap().unwrap();
+    assert_eq!(report.service.pid, std::process::id());
+    stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap();
+}
+
+#[test]
+fn an_idle_service_retires_itself_and_clears_its_endpoint() {
+    let fixture = Fixture::new();
+    let scope = fixture.scope();
+    let root = fixture.root.clone();
+    let server = thread::spawn(move || serve(scope, &root, Duration::from_millis(1500)));
+    let identity = ServiceIdentity::current(fixture.scope()).unwrap();
+    let endpoint = Endpoint::locate(&fixture.root, &identity).unwrap();
+    assert!(wait_until(Duration::from_secs(10), || status(
+        fixture.scope(),
+        &fixture.root
+    )
+    .unwrap()
+    .is_some()));
+    assert_eq!(server.join().unwrap().unwrap(), ServeExit::Idle);
+    assert!(!endpoint.socket().exists());
+    assert!(status(fixture.scope(), &fixture.root).unwrap().is_none());
+}
+
+#[test]
+fn a_second_server_on_a_held_endpoint_yields() {
+    let fixture = Fixture::new();
+    let launcher = ThreadLauncher::new();
+    start(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    assert_eq!(
+        serve(fixture.scope(), &fixture.root, Duration::from_secs(60)).unwrap(),
+        ServeExit::AlreadyRunning
+    );
+    let report = status(fixture.scope(), &fixture.root).unwrap().unwrap();
+    assert_eq!(report.service.pid, std::process::id());
+    stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap();
+}

--- a/crates/rue/src/daemon_cli.rs
+++ b/crates/rue/src/daemon_cli.rs
@@ -1,0 +1,319 @@
+//! `rue daemon <start|status|stop|serve>`: the command-line controls of the
+//! local compiler service (ADR-0085 §2).
+//!
+//! Every control resolves the same service ordinary compilation will: the
+//! scope directory (`--scope`, default the invocation directory) and an
+//! optional isolation name. `status` and `stop` never start a service. `serve`
+//! is the service itself and is launched detached by `start`; it is not meant
+//! to be run by hand, but doing so runs the service in the foreground.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rue_driver::daemon::{
+    self, DaemonError, DaemonScope, EndpointRoot, ProcessLauncher, ServeExit, StartOptions,
+    StatusReport, StopOutcome,
+};
+
+use crate::HostPathContext;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DaemonCommand {
+    Start,
+    Status,
+    Stop,
+    Serve,
+}
+
+/// One parsed `rue daemon` command line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DaemonInvocation {
+    pub(crate) command: DaemonCommand,
+    /// The scope directory as written; resolved against the invocation
+    /// directory when the command runs.
+    pub(crate) scope: Option<String>,
+    pub(crate) isolation: Option<String>,
+    /// An explicit endpoint root. `start` passes the root it resolved to the
+    /// service it launches, so the two can never disagree about it.
+    pub(crate) endpoint_root: Option<String>,
+    pub(crate) idle_timeout: Option<Duration>,
+    /// Report status as one JSON object instead of text.
+    pub(crate) json: bool,
+}
+
+const USAGE: &str = "Usage: rue daemon <start|status|stop> [--scope <dir>] [--isolation <name>] \
+                     [--idle-timeout-ms <N>] [--json]";
+
+/// Parse the arguments after the `daemon` token.
+pub(crate) fn parse_daemon_args(args: &[&str]) -> Result<DaemonInvocation, String> {
+    let Some((command, rest)) = args.split_first() else {
+        return Err(format!("`rue daemon` needs a command\n{USAGE}"));
+    };
+    let command = match *command {
+        "start" => DaemonCommand::Start,
+        "status" => DaemonCommand::Status,
+        "stop" => DaemonCommand::Stop,
+        "serve" => DaemonCommand::Serve,
+        other => return Err(format!("unknown daemon command `{other}`\n{USAGE}")),
+    };
+    let mut invocation = DaemonInvocation {
+        command,
+        scope: None,
+        isolation: None,
+        endpoint_root: None,
+        idle_timeout: None,
+        json: false,
+    };
+    let mut iter = rest.iter();
+    while let Some(arg) = iter.next() {
+        let mut value = |flag: &str| -> Result<String, String> {
+            iter.next()
+                .map(|value| (*value).to_owned())
+                .ok_or_else(|| format!("{flag} requires a value\n{USAGE}"))
+        };
+        match *arg {
+            "--scope" => invocation.scope = Some(value("--scope")?),
+            "--isolation" => invocation.isolation = Some(value("--isolation")?),
+            "--endpoint-root" => invocation.endpoint_root = Some(value("--endpoint-root")?),
+            "--idle-timeout-ms" => {
+                let text = value("--idle-timeout-ms")?;
+                let millis: u64 = text.parse().map_err(|_| {
+                    format!(
+                        "--idle-timeout-ms requires a whole number of milliseconds, got `{text}`"
+                    )
+                })?;
+                if millis == 0 {
+                    return Err("--idle-timeout-ms must be at least 1".into());
+                }
+                invocation.idle_timeout = Some(Duration::from_millis(millis));
+            }
+            "--json" => invocation.json = true,
+            other => return Err(format!("unknown daemon option `{other}`\n{USAGE}")),
+        }
+    }
+    if invocation.json && command != DaemonCommand::Status {
+        return Err(format!(
+            "--json applies to `rue daemon status` only\n{USAGE}"
+        ));
+    }
+    if invocation.idle_timeout.is_some()
+        && !matches!(command, DaemonCommand::Start | DaemonCommand::Serve)
+    {
+        return Err(format!(
+            "--idle-timeout-ms applies to `rue daemon start` only\n{USAGE}"
+        ));
+    }
+    Ok(invocation)
+}
+
+/// Run one daemon control and return the process exit status. Status reports
+/// go to stdout; every failure and every "no service" answer is a stderr line.
+pub(crate) fn run(invocation: &DaemonInvocation) -> i32 {
+    match execute(invocation) {
+        Ok(status) => status,
+        Err(error) => {
+            eprintln!("Error: {error}");
+            1
+        }
+    }
+}
+
+fn execute(invocation: &DaemonInvocation) -> Result<i32, DaemonError> {
+    let path_context = HostPathContext::capture().map_err(DaemonError::InvalidConfiguration)?;
+    let scope_dir: PathBuf = match &invocation.scope {
+        Some(scope) => path_context.anchor(Path::new(scope)),
+        None => path_context.working_directory().to_path_buf(),
+    };
+    let scope = DaemonScope::new(&scope_dir, invocation.isolation.as_deref())?;
+    let root = match &invocation.endpoint_root {
+        Some(root) => EndpointRoot::explicit(path_context.anchor(Path::new(root))),
+        None => EndpointRoot::resolve()?,
+    };
+    let idle_timeout = invocation
+        .idle_timeout
+        .unwrap_or(daemon::DEFAULT_IDLE_TIMEOUT);
+    match invocation.command {
+        DaemonCommand::Start => {
+            let launcher = ProcessLauncher::current_executable()?;
+            let options = StartOptions {
+                idle_timeout,
+                ..StartOptions::default()
+            };
+            let outcome = daemon::start(scope.clone(), &root, &options, &launcher)?;
+            if outcome.launched {
+                println!(
+                    "rue daemon: started service pid {} for {scope}",
+                    outcome.service.pid
+                );
+            } else {
+                println!(
+                    "rue daemon: service pid {} is already running for {scope}",
+                    outcome.service.pid
+                );
+            }
+            Ok(0)
+        }
+        DaemonCommand::Status => match daemon::status(scope.clone(), &root)? {
+            Some(report) => {
+                if invocation.json {
+                    println!(
+                        "{}",
+                        serde_json::to_string(&report).expect("a status report serializes")
+                    );
+                } else {
+                    print!("{}", render_status(&report));
+                }
+                Ok(0)
+            }
+            None => {
+                eprintln!("rue daemon: no service is running for {scope}");
+                Ok(1)
+            }
+        },
+        DaemonCommand::Stop => match daemon::stop(scope.clone(), &root, STOP_TIMEOUT)? {
+            StopOutcome::Stopped { pid } => {
+                println!("rue daemon: stopped service pid {pid} for {scope}");
+                Ok(0)
+            }
+            StopOutcome::NotRunning => {
+                println!("rue daemon: no service was running for {scope}");
+                Ok(0)
+            }
+        },
+        DaemonCommand::Serve => match daemon::serve(scope, &root, idle_timeout)? {
+            ServeExit::Stopped | ServeExit::Idle | ServeExit::AlreadyRunning => Ok(0),
+        },
+    }
+}
+
+/// How long `stop` waits for the service to release its endpoint.
+const STOP_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn render_status(report: &StatusReport) -> String {
+    let service = &report.service;
+    let mut text = String::new();
+    text.push_str("rue daemon: running\n");
+    text.push_str(&format!("  pid: {}\n", service.pid));
+    text.push_str(&format!("  scope: {}\n", service.scope_directory));
+    text.push_str(&format!(
+        "  isolation: {}\n",
+        service.isolation.as_deref().unwrap_or("none")
+    ));
+    text.push_str(&format!("  endpoint: {}\n", service.endpoint_directory));
+    text.push_str(&format!("  protocol: {}\n", service.protocol_version));
+    text.push_str(&format!(
+        "  image: {} {} {}\n",
+        service.identity.architecture, service.identity.scheme, service.identity.image_hex
+    ));
+    text.push_str(&format!(
+        "  service identity: {}\n",
+        service.identity.service_hex
+    ));
+    text.push_str(&format!("  uptime: {} ms\n", report.uptime_ms));
+    text.push_str(&format!("  idle timeout: {} ms\n", report.idle_timeout_ms));
+    text.push_str(&format!("  connections: {}\n", report.connections));
+    text.push_str(&format!(
+        "  active request: {}\n",
+        report.active_request.as_deref().unwrap_or("none")
+    ));
+    text.push_str(&format!("  queued requests: {}\n", report.queued_requests));
+    text.push_str(&format!("  retained hosts: {}\n", report.retained_hosts));
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commands_and_options_parse() {
+        let parsed = parse_daemon_args(&[
+            "start",
+            "--scope",
+            "proj",
+            "--isolation",
+            "ci",
+            "--idle-timeout-ms",
+            "1500",
+        ])
+        .unwrap();
+        assert_eq!(parsed.command, DaemonCommand::Start);
+        assert_eq!(parsed.scope.as_deref(), Some("proj"));
+        assert_eq!(parsed.isolation.as_deref(), Some("ci"));
+        assert_eq!(parsed.idle_timeout, Some(Duration::from_millis(1500)));
+        assert!(!parsed.json);
+
+        let parsed = parse_daemon_args(&["status", "--json"]).unwrap();
+        assert_eq!(parsed.command, DaemonCommand::Status);
+        assert!(parsed.json);
+        assert!(parsed.scope.is_none());
+
+        let parsed =
+            parse_daemon_args(&["serve", "--endpoint-root", "/tmp/r", "--scope", "/p"]).unwrap();
+        assert_eq!(parsed.command, DaemonCommand::Serve);
+        assert_eq!(parsed.endpoint_root.as_deref(), Some("/tmp/r"));
+        assert_eq!(
+            parse_daemon_args(&["stop"]).unwrap().command,
+            DaemonCommand::Stop
+        );
+    }
+
+    #[test]
+    fn malformed_command_lines_are_refused_with_usage() {
+        for args in [
+            &[][..],
+            &["restart"],
+            &["start", "--scope"],
+            &["start", "--bogus"],
+            &["start", "--idle-timeout-ms", "soon"],
+            &["start", "--idle-timeout-ms", "0"],
+            &["stop", "--json"],
+            &["status", "--idle-timeout-ms", "5"],
+        ] {
+            let error = parse_daemon_args(args).unwrap_err();
+            assert!(!error.is_empty(), "{args:?}");
+        }
+        assert!(parse_daemon_args(&["restart"]).unwrap_err().contains(USAGE));
+    }
+
+    #[test]
+    fn status_renders_every_field_a_reader_needs() {
+        let report = StatusReport {
+            service: daemon::ServiceInfo {
+                pid: 4242,
+                protocol_version: daemon::DAEMON_PROTOCOL_VERSION,
+                identity: daemon::IdentityRecord {
+                    scheme_version: 1,
+                    architecture: "X86_64".into(),
+                    scheme: "LinuxProcSelfExeSha256".into(),
+                    image_hex: "abcd".into(),
+                    service_hex: "0123".into(),
+                },
+                scope_directory: "/work/project".into(),
+                isolation: Some("ci".into()),
+                endpoint_directory: "/run/rue/0123".into(),
+                started_at_unix_ms: 0,
+            },
+            uptime_ms: 12,
+            idle_timeout_ms: 1_800_000,
+            connections: 1,
+            active_request: None,
+            queued_requests: 0,
+            retained_hosts: 0,
+        };
+        let text = render_status(&report);
+        for needle in [
+            "pid: 4242",
+            "scope: /work/project",
+            "isolation: ci",
+            "endpoint: /run/rue/0123",
+            "protocol: 1",
+            "image: X86_64 LinuxProcSelfExeSha256 abcd",
+            "idle timeout: 1800000 ms",
+            "active request: none",
+            "retained hosts: 0",
+        ] {
+            assert!(text.contains(needle), "missing {needle:?} in:\n{text}");
+        }
+    }
+}

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -5,6 +5,7 @@
 //! compiler query graph while one retained `CompilerSession` owns every
 //! compiler artifact across revisions.
 
+pub mod daemon;
 mod host;
 #[cfg(test)]
 mod host_workflow_tests;

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -16,6 +16,7 @@ mod allocation;
 mod compile;
 #[cfg(not(rue_benchmark_allocations))]
 mod compiler_allocator;
+mod daemon_cli;
 mod emit;
 mod output;
 mod platform_signing;
@@ -273,6 +274,7 @@ Usage: rue [options] <root.rue> [output]
        rue [options] <root.rue> -o <output>
        rue test [options] <root.rue>
        rue explain <E####>
+       rue daemon <start|status|stop> [--scope <dir>] [--isolation <name>]
 
 The compiler takes exactly one root source file and discovers every other
 file through its @import graph; pass build-system inputs with --source-manifest.
@@ -280,6 +282,14 @@ file through its @import graph; pass build-system inputs with --source-manifest.
 Commands:
   explain <E####>      Show the compiler-owned explanation for an error code
   test <root.rue>      Build the root's test image and run its tests
+  daemon <command>     Control the local compiler service (ADR-0085): `start`
+                       uses or launches the service for a scope, `status`
+                       reports it, `stop` ends it; neither `status` nor `stop`
+                       starts one. The scope is a directory (--scope, default
+                       the current directory) plus an optional --isolation name;
+                       it groups processes and never changes what a program
+                       imports. --idle-timeout-ms bounds a started service's
+                       idle life; `status --json` reports one JSON object.
 
 `rue test` options (see docs/process/test-events.md for the event schema):
   --list               List the inventory; no codegen, no linking, no execution
@@ -384,6 +394,8 @@ enum ParseResult {
     Options(Box<Options>),
     /// Show compiler-owned information without entering the compile path.
     Explain(ErrorCode),
+    /// Control the local compiler service (ADR-0085); never compiles.
+    Daemon(daemon_cli::DaemonInvocation),
     /// Parsing failed with an error.
     Error,
     /// User requested help or version (already printed, should exit 0).
@@ -556,6 +568,16 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
             return ParseResult::Error;
         }
         return ParseResult::Explain(code);
+    }
+
+    if args[0] == "daemon" {
+        return match daemon_cli::parse_daemon_args(&args[1..]) {
+            Ok(invocation) => ParseResult::Daemon(invocation),
+            Err(message) => {
+                eprintln!("Error: {message}");
+                ParseResult::Error
+            }
+        };
     }
 
     // Decide the subcommand first and drop its token, so the option loop below
@@ -2429,6 +2451,10 @@ fn main() {
             print!("{}", render_error_code_explanation(explanation));
             return;
         }
+        // Service controls run before tracing, worker pools, or any source
+        // I/O exist: a service inherits none of a client's global setup, and a
+        // control never compiles (ADR-0085 §5).
+        ParseResult::Daemon(invocation) => std::process::exit(daemon_cli::run(&invocation)),
         ParseResult::Error => std::process::exit(1),
         ParseResult::Exit => return,
     };
@@ -3342,6 +3368,7 @@ mod tests {
             ParseResult::Error => panic!("Expected Options, got Error"),
             ParseResult::Exit => panic!("Expected Options, got Exit"),
             ParseResult::Explain(_) => panic!("Expected Options, got Explain"),
+            ParseResult::Daemon(_) => panic!("Expected Options, got Daemon"),
         }
     }
 
@@ -4860,6 +4887,25 @@ mod tests {
     #[test]
     fn parse_version_short() {
         assert!(is_exit(&parse_args_from(&["-V"])));
+    }
+
+    #[test]
+    fn parse_daemon_dispatches_before_the_ordinary_option_loop() {
+        let ParseResult::Daemon(invocation) =
+            parse_args_from(&["daemon", "status", "--scope", "proj", "--json"])
+        else {
+            panic!("expected a daemon control");
+        };
+        assert_eq!(invocation.command, daemon_cli::DaemonCommand::Status);
+        assert_eq!(invocation.scope.as_deref(), Some("proj"));
+        assert!(invocation.json);
+        // A malformed control is an argument error, never a compile.
+        assert!(is_error(&parse_args_from(&["daemon"])));
+        assert!(is_error(&parse_args_from(&["daemon", "restart"])));
+        // `daemon` is a command only in first position; a root module of that
+        // name is still a source.
+        let options = unwrap_options(parse_args_from(&["./daemon"]));
+        assert_eq!(options.source_path, "./daemon");
     }
 
     #[test]

--- a/crates/rue/src/running_image.rs
+++ b/crates/rue/src/running_image.rs
@@ -68,6 +68,14 @@ impl RunningImageIdentity {
         &self.value
     }
 
+    /// An identity with caller-chosen bytes, so a test can stand for a
+    /// different compiler build without replacing the running executable.
+    #[cfg(test)]
+    pub(crate) fn for_test(value: Vec<u8>) -> Self {
+        Self::new(RunningImageIdentityScheme::LinuxProcSelfExeSha256, value)
+            .expect("test identities are non-empty")
+    }
+
     fn new(
         scheme: RunningImageIdentityScheme,
         value: Vec<u8>,

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,6 +49,18 @@ source discovery or compilation. A well-formed code may not have a long-form
 explanation yet; malformed, unknown, retired, and not-yet-covered codes exit
 unsuccessfully.
 
+`rue daemon start|status|stop` controls the local compiler service
+(ADR-0085). A service is owned by the current user, a scope directory
+(`--scope`, default the current directory) plus an optional `--isolation`
+name, and the exact compiler build; `start` uses the running service for that
+scope or launches one detached, `status` reports it (`--json` for one JSON
+object), and `stop` ends it. Neither `status` nor `stop` starts a service, and
+the scope is only a process grouping: it never changes what a program imports.
+Endpoints live in a user-private directory under `XDG_RUNTIME_DIR` (or the
+system temporary directory); `RUE_DAEMON_ROOT` overrides that root, which is
+how the CLI suite keeps its services apart from yours. The service does not
+yet execute compiler requests; those arrive with the rest of RUE-2128.
+
 The model is exactly one root source file per compile; additional files are
 reached through `@import` and discovered transitively from the root. The legacy
 flat-mode input form — extra `.rue` files listed positionally — was removed


### PR DESCRIPTION
The service skeleton of RUE-2128 (ADR-0085 §2, §5), ahead of request execution: the identity, endpoint, protocol, and lifecycle that compiler requests will later travel over. The service executes no compiler work yet; `status` reports the request and host fields as structural placeholders so a consumer sees the final shape now.

**Identity.** A service is owned by the current user, a canonical scope directory, an optional isolation name, the protocol version, and the verified running compiler image from RUE-2153. Those digest into the service identity; the endpoint directory is named by it and the handshake compares the full record again, so a rebuilt compiler or another worktree never meets an existing service on its socket. The image identity is captured once per process, since hashing the executable is the dominant cost of every control.

**Endpoint.** The root is `RUE_DAEMON_ROOT`, else `XDG_RUNTIME_DIR/rue`, else `rue-daemon-<uid>` under the temporary directory; root and endpoint directory must be owned by the user and 0700, the socket is 0600, the server checks the peer's uid (`SO_PEERCRED` / `getpeereid`) and the client checks the socket's owner. Liveness is a held file lock, never a recorded PID: a live service holds `service.lock` for its whole life, `startup.lock` serializes `start`, and a stale socket or record is recovered only when the service lock is free. Socket paths are checked against the platform bound.

**Protocol.** Length-prefixed JSON frames with a 1 MiB control bound, an explicit protocol version, hello/welcome/rejected, request ids, and ping/status/stop. Oversized, truncated, and malformed frames drop the connection without disturbing the service.

**Lifecycle.** `rue daemon start|status|stop [--scope <dir>] [--isolation <name>] [--idle-timeout-ms <N>] [--json]`. `start` uses the running service or launches a detached `rue daemon serve` (own session, null stdio, cwd at the endpoint root, endpoint root passed explicitly) and waits a bounded time for the handshake; `status` and `stop` never launch and create nothing; an idle service retires itself and clears its endpoint; a second server on a held endpoint yields. Controls dispatch before tracing, worker pools, or any source I/O, so a service inherits none of a client's global setup.

**Coverage.** In-process lifecycle tests (round trip, stale-endpoint recovery, four concurrent starts sharing one launch, identity and protocol rejection, malformed peers, idle retirement, a yielding second server, status creating nothing) plus protocol framing and CLI parsing tests. A new `daemon` CLI scenario kind runs the real driver against a private endpoint root inside the case directory and stops whatever it leaves behind (killing a service that ignores its stop, by the pid its own record published); five cases cover the lifecycle, a four-way start race, scope and isolation selection, and malformed controls. The oracle-diff corpus reader classifies those cases as daemon orchestration.

Each control costs about 3 s in a debug build, essentially all of it the RUE-2153 image hash of the 84 MB executable; release builds hash far faster, and ADR-0085 assigns measuring that cost to RUE-2130.

Verified locally: both driver unit suites, `scripts/rue cli daemon`, the harness, test-runner and oracle-diff unit tests, `//crates/rue-oracle-diff:oracle-diff-test`, and the clippy/fmt gates for `rue`, `rue-cli-tests`, `rue-test-runner`, and `rue-oracle-diff`.

Fixes RUE-2177