### PR TITLE
RUE-1903: record program-order and configuration principles

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -120,6 +120,31 @@ pub fn triple(x: i32) -> i32 {
 args = ["--source-manifest", "sources.manifest", "main.rue", "-o", "prog"]
 stdout = "42\n"
 
+[[case]]
+name = "source_manifest_entry_order_and_const_relocation_preserve_meaning"
+description = "The manifest may list an imported file before the root, and relocating a module-level import constant below `main` preserves its file-scope binding."
+files = [
+    { path = "sources.manifest", source = """
+utils.rue
+main.rue
+""" },
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(utils.triple(14));
+    0
+}
+
+const utils = @import("utils.rue");
+""" },
+    { path = "utils.rue", source = """
+pub fn triple(x: i32) -> i32 {
+    x * 3
+}
+""" },
+]
+args = ["--source-manifest", "sources.manifest", "main.rue", "-o", "prog"]
+stdout = "42\n"
+
 # The manifest membership key and the path import discovery requests are
 # reduced by the same normalizer, so a `.`/`..` spelling of a declared file
 # still declares it.

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -211,7 +211,7 @@ error_contains = "type mismatch"
 
 [[case]]
 name = "forward_reference_same_file"
-spec = ["6.5:7", "6.5:9"]
+spec = ["6.5:7", "6.5:9", "10.5:5"]
 description = "A const may reference a const declared later in the file"
 source = """
 const A: i32 = B + 1;
@@ -224,7 +224,7 @@ exit_code = 21
 
 [[case]]
 name = "forward_reference_across_files"
-spec = ["6.5:7", "6.5:10"]
+spec = ["6.5:7", "6.5:10", "10.5:5"]
 description = "A const may reference a const declared in another (imported) file"
 source = """
 const cfg = @import("cfg.rue");

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -169,7 +169,7 @@ exit_code = 42
 
 [[case]]
 name = "function_forward_reference"
-spec = ["6.1:12"]
+spec = ["6.1:12", "10.5:5"]
 description = "Functions can call other functions regardless of definition order"
 source = """
 fn main() -> i32 { helper() }
@@ -179,7 +179,7 @@ exit_code = 42
 
 [[case]]
 name = "function_mutual_forward_reference"
-spec = ["6.1:12"]
+spec = ["6.1:12", "10.5:5"]
 description = "Functions can have mutual forward references"
 source = """
 fn first(x: i32) -> i32 {

--- a/docs/designs/0092-no-configuration-declarations.md
+++ b/docs/designs/0092-no-configuration-declarations.md
@@ -1,0 +1,41 @@
+---
+id: 0092
+title: "No configuration declarations: target behavior through comptime"
+status: accepted
+tags: [language, semantics, comptime, principle]
+feature-flag: null
+created: 2026-09-10
+accepted: 2026-09-10
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["RUE-1900"]
+---
+
+# ADR-0092: No configuration declarations: target behavior through comptime
+
+## Status
+
+Accepted on 2026-09-10 by Steve.
+
+## Decision
+
+Rue refuses `cfg` attributes, package feature flags, and build-provided symbol
+sets that add or remove source declarations or make declaration resolution vary.
+Target queries such as `@target_os`, `@target_arch`, and
+`@target_data_model` supply comptime values; existing comptime control-flow and
+lazy semantic-analysis rules select and analyze reached bodies, while loaded
+modules are parsed and syntactic import discovery remains the source-loader's
+policy. Optional behavior uses ordinary declarations and explicitly imported
+modules and functions. This principle does not remove compiler target
+selection, optimization or debug options, or ADR-0005 preview gates: preview
+gates control availability of unfinished language facilities, while this ADR
+defines the source declaration boundary.
+
+## References
+
+- [ADR-0005: Preview Features](0005-preview-features.md)
+- [ADR-0034: Per-Target Runtime Archives for Cross-Compilation](0034-cross-target-runtime.md)
+- [ADR-0045: Lazy semantic analysis](0045-lazy-semantic-analysis.md)
+- [ADR-0047: Root-module compilation units and build-system inputs](0047-root-module-build-inputs.md)
+- [ADR-0063: Parallel demand-driven incremental compilation](0063-parallel-demand-driven-incremental-compilation.md)

--- a/docs/designs/0093-order-independent-program-meaning.md
+++ b/docs/designs/0093-order-independent-program-meaning.md
@@ -1,0 +1,43 @@
+---
+id: 0093
+title: "Order-independent program meaning"
+status: accepted
+tags: [language, semantics, modules, principle]
+feature-flag: null
+created: 2026-09-10
+accepted: 2026-09-10
+implemented:
+spec-sections: ["10.5:5"]
+superseded-by:
+relates: ["ADR-0045", "ADR-0063", "ADR-0066", "RUE-1100", "RUE-1903"]
+---
+
+# ADR-0093: Order-independent program meaning
+
+## Status
+
+Accepted on 2026-09-10 by Steve. This ratifies semantic behavior already
+provided by the compiler and adds no implementation phase or preview feature.
+
+## Decision
+
+For a selected target, a program's semantic meaning is determined by its root
+module and the rooted set of declarations reached through each module's
+explicit imports, independent of top-level declaration order, import order,
+which importer or analyzer runs first, lazy body-demand order, or source-
+manifest entry order. Relocating a module-level constant import within its file
+preserves its file-scope binding; local `let` scope remains lexical. This is a
+semantic-meaning guarantee and does not promise byte-identical binaries or
+unchanged source positions after edits. This rule does not change the existing
+ordering semantics of statements, parameters, fields, enum variants, or
+effectful calls. The rule follows the rooted, demand-driven and stable identity
+boundaries of ADR-0045, ADR-0063, and ADR-0066; RUE-1100's explicit module-
+binding syntax remains the authority for import dependencies.
+
+## References
+
+- [Program Composition](../spec/src/10-modules/05-program-composition.md)
+- [ADR-0045: Lazy semantic analysis](0045-lazy-semantic-analysis.md)
+- [ADR-0063: Parallel demand-driven incremental compilation](0063-parallel-demand-driven-incremental-compilation.md)
+- [ADR-0066: Producer-nominal anonymous types and incremental locality](0066-producer-nominal-anonymous-types-and-incremental-locality.md)
+- RUE-1100: explicit module-binding syntax and import discovery authority

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -253,4 +253,6 @@ The table is generated from ADR frontmatter. Run
 | [0088](0088-panic-termination.md) | Panic termination without unwinding or recovery | Accepted | semantics, runtime, ownership, principle |
 | [0089](0089-no-mutable-globals.md) | No mutable globals: immutable module-level values | Accepted | language, semantics, ownership, principle |
 | [0090](0090-no-implicit-conversions.md) | No implicit conversions: typed values cross boundaries explicitly | Accepted | language, types, semantics, principle |
+| [0092](0092-no-configuration-declarations.md) | No configuration declarations: target behavior through comptime | Accepted | language, semantics, comptime, principle |
+| [0093](0093-order-independent-program-meaning.md) | Order-independent program meaning | Accepted | language, semantics, modules, principle |
 <!-- ADR-INDEX:END -->

--- a/docs/spec/src/10-modules/05-program-composition.md
+++ b/docs/spec/src/10-modules/05-program-composition.md
@@ -83,3 +83,16 @@ roots because drop glue is synthesized from the full type pool. ADR-0045
 defines the broader on-demand model; ADR-0047 allows future build-system source
 manifests that constrain which files may be imported without turning every
 declared input into a semantic root.
+
+{{ rule(id="10.5:5", cat="normative") }}
+
+For a selected target, the semantic meaning of a program is determined by its
+root module and the rooted set of declarations reached through the explicit
+imports in that graph. It **MUST** be independent of top-level declaration
+order, import-declaration order, which importer or analyzer runs first, the
+order in which lazy bodies are demanded, and the order of entries in a source
+manifest. Moving a module-level constant import within the same file preserves
+its file-scope binding; this rule does not change the scope of a local `let`.
+This independence concerns semantic meaning only: this rule does not change the
+existing ordering semantics of statements, parameters, fields, enum variants,
+or effectful calls.


### PR DESCRIPTION
Record the accepted principles for program ordering and configuration. ADR-0093 and spec rule 10.5:5 state that reordering top-level declarations, imports, source-manifest entries, or analysis demand preserves a program's semantic meaning. ADR-0092 defines target-dependent behavior through comptime values and the existing lazy-analysis rules, while keeping configuration from adding or removing declarations.

Existing forward-reference cases now cite the program-order rule. A real-driver regression reverses manifest entries and moves a module-level import below its use, preserving the result. The ordering rule preserves the existing semantics of statements, parameters, fields, enum variants, and effectful calls.

Validation:

- Quick suite: 36 targets passed for each issue.
- Program-composition spec cases: 21 passed.
- Module CLI cases: 150 passed.
- CLI and specification differential oracles passed.
- ADR registry, documentation links, traceability, and compiler/spec index passed.

Fixes RUE-1903

Fixes RUE-1900
