### PR TITLE
RUE-2015: report JSON parse error offsets consistently

### DIFF
--- a/std/json.rue
+++ b/std/json.rue
@@ -1,8 +1,7 @@
 // std.json — owned JSON values, parsing, and compact serialization (RUE-690).
 //
-// Numbers are stored as their validated source spelling. Rue does not yet have
-// floating-point types, and retaining the lexeme also makes parse/serialize
-// round trips lossless for large integers and exponent notation.
+// Numbers retain their validated source spelling so parse/serialize round
+// trips remain lossless for large integers and exponent notation.
 
 const arraybuf = @import("arraybuf.rue");
 const option = @import("option.rue");
@@ -24,6 +23,9 @@ pub enum Json {
     Object(Object),
 }
 
+// Error offsets are zero-based byte positions. An error names the first byte
+// the parser could not accept; missing bytes use the input length. Incomplete
+// numbers remain InvalidNumber.
 pub enum ParseError {
     UnexpectedEnd(u64),
     UnexpectedByte(u64),
@@ -87,9 +89,15 @@ fn hex_value(b: u8) -> i32 {
     }
 }
 
-fn parse_hex4(borrow input: StrBuf, inout at: u64) -> result.Result(u64, ParseError) {
+// A first unit rejects a decisive low-surrogate prefix; a required second unit
+// enforces one. Keeping both prefix checks here makes truncated surrogate
+// escapes identify an already decisive hex digit without duplicating parsing.
+fn parse_hex4(
+    borrow input: StrBuf,
+    inout at: u64,
+    require_low_surrogate: bool,
+) -> result.Result(u64, ParseError) {
     let R = result.Result(u64, ParseError);
-    let start = at;
     let mut value: u64 = 0;
     let mut i: u64 = 0;
     while i < 4 {
@@ -98,7 +106,18 @@ fn parse_hex4(borrow input: StrBuf, inout at: u64) -> result.Result(u64, ParseEr
         }
         let digit = hex_value(byte(borrow input, at));
         if digit < 0 {
-            return R.Err(ParseError.InvalidUnicode(start));
+            return R.Err(ParseError.InvalidUnicode(at));
+        }
+        if require_low_surrogate && i == 0 && digit != 13 {
+            return R.Err(ParseError.InvalidUnicode(at));
+        }
+        if i == 1 && value == 13 {
+            if !require_low_surrogate && digit >= 12 {
+                return R.Err(ParseError.InvalidUnicode(at));
+            }
+            if require_low_surrogate && digit < 12 {
+                return R.Err(ParseError.InvalidUnicode(at));
+            }
         }
         value = value * 16 + @intCast(digit);
         at += 1;
@@ -136,26 +155,30 @@ fn parse_unicode_escape(
     position: u64,
 ) -> result.Result((), ParseError) {
     let R = result.Result((), ParseError);
-    let first = match parse_hex4(borrow input, inout at) {
+    let first = match parse_hex4(borrow input, inout at, false) {
         result.Result(u64, ParseError).Ok(v) => v,
         result.Result(u64, ParseError).Err(e) => return R.Err(e),
     };
     if first >= 55296 && first <= 56319 {
-        if at + 2 > input.len() || byte(borrow input, at) != 92 || byte(borrow input, at + 1) != 117 {
-            return R.Err(ParseError.InvalidUnicode(position));
+        if at >= input.len() {
+            return R.Err(ParseError.UnexpectedEnd(input.len()));
+        }
+        if byte(borrow input, at) != 92 {
+            return R.Err(ParseError.InvalidUnicode(at));
+        }
+        if at + 1 >= input.len() {
+            return R.Err(ParseError.UnexpectedEnd(input.len()));
+        }
+        if byte(borrow input, at + 1) != 117 {
+            return R.Err(ParseError.InvalidUnicode(at + 1));
         }
         at += 2;
-        let second = match parse_hex4(borrow input, inout at) {
+        let second = match parse_hex4(borrow input, inout at, true) {
             result.Result(u64, ParseError).Ok(v) => v,
             result.Result(u64, ParseError).Err(e) => return R.Err(e),
         };
-        if second < 56320 || second > 57343 {
-            return R.Err(ParseError.InvalidUnicode(position));
-        }
         let cp = 65536 + (first - 55296) * 1024 + (second - 56320);
         push_codepoint(inout out, cp, position)
-    } else if first >= 56320 && first <= 57343 {
-        R.Err(ParseError.InvalidUnicode(position))
     } else {
         push_codepoint(inout out, first, position)
     }
@@ -184,31 +207,30 @@ fn copy_utf8(
     } else {
         return R.Err(ParseError.InvalidUnicode(position));
     }
-    if needed > input.len() - at {
-        return R.Err(ParseError.UnexpectedEnd(at));
-    }
-    let second = byte(borrow input, at);
-    if !continuation(second) {
-        return R.Err(ParseError.InvalidUnicode(at));
-    }
-    // Exclude overlong encodings, UTF-16 surrogate code points, and values
-    // above U+10FFFF by constraining the second byte of boundary leaders.
-    if lead == 224 && second < 160 {
-        return R.Err(ParseError.InvalidUnicode(position));
-    }
-    if lead == 237 && second > 159 {
-        return R.Err(ParseError.InvalidUnicode(position));
-    }
-    if lead == 240 && second < 144 {
-        return R.Err(ParseError.InvalidUnicode(position));
-    }
-    if lead == 244 && second > 143 {
-        return R.Err(ParseError.InvalidUnicode(position));
-    }
-    let mut i: u64 = 1;
+    let mut i: u64 = 0;
     while i < needed {
-        if !continuation(byte(borrow input, at + i)) {
+        if at + i >= input.len() {
+            return R.Err(ParseError.UnexpectedEnd(input.len()));
+        }
+        let current = byte(borrow input, at + i);
+        if !continuation(current) {
             return R.Err(ParseError.InvalidUnicode(at + i));
+        }
+        if i == 0 {
+            // Exclude overlong encodings, UTF-16 surrogate code points, and
+            // values above U+10FFFF by constraining boundary leaders.
+            if lead == 224 && current < 160 {
+                return R.Err(ParseError.InvalidUnicode(at));
+            }
+            if lead == 237 && current > 159 {
+                return R.Err(ParseError.InvalidUnicode(at));
+            }
+            if lead == 240 && current < 144 {
+                return R.Err(ParseError.InvalidUnicode(at));
+            }
+            if lead == 244 && current > 143 {
+                return R.Err(ParseError.InvalidUnicode(at));
+            }
         }
         i += 1;
     }
@@ -224,8 +246,10 @@ fn copy_utf8(
 
 fn parse_string(borrow input: StrBuf, inout at: u64) -> StringResult {
     let R = StringResult;
-    let start = at;
-    if at >= input.len() || byte(borrow input, at) != 34 {
+    if at >= input.len() {
+        return R.Err(ParseError.UnexpectedEnd(input.len()));
+    }
+    if byte(borrow input, at) != 34 {
         return R.Err(ParseError.UnexpectedByte(at));
     }
     at += 1;
@@ -271,11 +295,11 @@ fn parse_string(borrow input: StrBuf, inout at: u64) -> StringResult {
                     result.Result((), ParseError).Err(err) => return R.Err(err),
                 }
             } else {
-                return R.Err(ParseError.InvalidEscape(escape_at));
+                return R.Err(ParseError.InvalidEscape(at - 1));
             }
         }
     }
-    R.Err(ParseError.UnexpectedEnd(start))
+    R.Err(ParseError.UnexpectedEnd(input.len()))
 }
 
 fn consume_digits(borrow input: StrBuf, inout at: u64) -> u64 {
@@ -292,7 +316,7 @@ fn parse_number(borrow input: StrBuf, inout at: u64) -> ParseResult {
     if byte(borrow input, at) == 45 {
         at += 1;
         if at >= input.len() {
-            return R.Err(ParseError.InvalidNumber(start));
+            return R.Err(ParseError.InvalidNumber(input.len()));
         }
     }
     if byte(borrow input, at) == 48 {
@@ -413,10 +437,10 @@ fn parse_object(borrow input: StrBuf, inout at: u64, depth: u64) -> ParseResult 
 
 fn parse_value(borrow input: StrBuf, inout at: u64, depth: u64) -> ParseResult {
     let R = ParseResult;
+    skip_space(borrow input, inout at);
     if depth > 256 {
         return R.Err(ParseError.NestingTooDeep(at));
     }
-    skip_space(borrow input, inout at);
     if at >= input.len() {
         return R.Err(ParseError.UnexpectedEnd(at));
     }

--- a/tests/std/json_tests.rue
+++ b/tests/std/json_tests.rue
@@ -61,24 +61,89 @@ test "raw UTF-8 in strings passes through" {
     @assert_eq(roundtrip("\"日本語\""), "\"日本語\"");
 }
 
-// RUE-2015: the offset each variant names follows no single convention yet;
-// these pin the observed values and change with that issue.
-test "parse errors name the byte offset" {
+test "parse errors name the first rejected byte" {
     @assert_eq(error_of(""), ParseError.UnexpectedEnd(0));
     @assert_eq(error_of("[1,"), ParseError.UnexpectedEnd(3));
     @assert_eq(error_of("[1 2]"), ParseError.UnexpectedByte(3));
     @assert_eq(error_of("nul"), ParseError.UnexpectedEnd(3));
     @assert_eq(error_of("01"), ParseError.InvalidNumber(1));
     @assert_eq(error_of("1."), ParseError.InvalidNumber(2));
-    @assert_eq(error_of("-"), ParseError.InvalidNumber(0));
+    @assert_eq(error_of("-"), ParseError.InvalidNumber(1));
     @assert_eq(error_of("1e"), ParseError.InvalidNumber(2));
-    @assert_eq(error_of("\"\\x\""), ParseError.InvalidEscape(1));
-    @assert_eq(error_of("\"\\u12\""), ParseError.InvalidUnicode(3));
-    @assert_eq(error_of("\"\\ud800\""), ParseError.InvalidUnicode(1));
+    @assert_eq(error_of("\"\\x\""), ParseError.InvalidEscape(2));
+    @assert_eq(error_of("\"\\u12\""), ParseError.InvalidUnicode(5));
+    @assert_eq(error_of("\"\\ud800\""), ParseError.InvalidUnicode(7));
     @assert_eq(error_of("1 2"), ParseError.TrailingCharacters(2));
     @assert_eq(error_of("{\"a\" 1}"), ParseError.UnexpectedByte(5));
     @assert_eq(error_of("{1:2}"), ParseError.UnexpectedByte(1));
-    @assert_eq(error_of("\"unterminated"), ParseError.UnexpectedEnd(0));
+    @assert_eq(error_of("\"unterminated"), ParseError.UnexpectedEnd(13));
+}
+
+test "truncated and invalid unicode identify the decisive byte" {
+    @assert_eq(error_of("\"\\u12"), ParseError.UnexpectedEnd(5));
+    @assert_eq(error_of("\"\\ud800"), ParseError.UnexpectedEnd(7));
+    @assert_eq(error_of("\"\\ud800x\""), ParseError.InvalidUnicode(7));
+    @assert_eq(error_of("\"\\ud800\\x\""), ParseError.InvalidUnicode(8));
+    @assert_eq(error_of("\"\\udc00\""), ParseError.InvalidUnicode(4));
+    @assert_eq(error_of("\"\\ud800\\u0041\""), ParseError.InvalidUnicode(9));
+    @assert_eq(error_of("\"\\ud800\\ud800\""), ParseError.InvalidUnicode(10));
+    @assert_eq(error_of("\"\\udc"), ParseError.InvalidUnicode(4));
+    @assert_eq(error_of("\"\\ud800\\ud8"), ParseError.InvalidUnicode(10));
+
+    let mut bad_second = StrBuf.new();
+    bad_second.push(34);
+    bad_second.push(226);
+    bad_second.push(40);
+    bad_second.push(161);
+    @assert_eq(error_of(bad_second), ParseError.InvalidUnicode(2));
+
+    let mut bad_second_truncated = StrBuf.new();
+    bad_second_truncated.push(34);
+    bad_second_truncated.push(226);
+    bad_second_truncated.push(40);
+    @assert_eq(error_of(bad_second_truncated), ParseError.InvalidUnicode(2));
+
+    let mut bad_later = StrBuf.new();
+    bad_later.push(34);
+    bad_later.push(226);
+    bad_later.push(130);
+    bad_later.push(40);
+    @assert_eq(error_of(bad_later), ParseError.InvalidUnicode(3));
+
+    let mut bad_later_truncated = StrBuf.new();
+    bad_later_truncated.push(34);
+    bad_later_truncated.push(240);
+    bad_later_truncated.push(144);
+    bad_later_truncated.push(40);
+    @assert_eq(error_of(bad_later_truncated), ParseError.InvalidUnicode(3));
+
+    let mut truncated_utf8 = StrBuf.new();
+    truncated_utf8.push(34);
+    truncated_utf8.push(226);
+    truncated_utf8.push(130);
+    @assert_eq(error_of(truncated_utf8), ParseError.UnexpectedEnd(3));
+
+    let mut utf8_surrogate = StrBuf.new();
+    utf8_surrogate.push(34);
+    utf8_surrogate.push(237);
+    utf8_surrogate.push(160);
+    utf8_surrogate.push(128);
+    @assert_eq(error_of(utf8_surrogate), ParseError.InvalidUnicode(2));
+
+    let mut utf8_surrogate_truncated = StrBuf.new();
+    utf8_surrogate_truncated.push(34);
+    utf8_surrogate_truncated.push(237);
+    utf8_surrogate_truncated.push(160);
+    @assert_eq(error_of(utf8_surrogate_truncated), ParseError.InvalidUnicode(2));
+
+    let mut escape_after_utf8 = StrBuf.new();
+    escape_after_utf8.push(34);
+    escape_after_utf8.push(195);
+    escape_after_utf8.push(169);
+    escape_after_utf8.push(92);
+    escape_after_utf8.push(120);
+    escape_after_utf8.push(34);
+    @assert_eq(error_of(escape_after_utf8), ParseError.InvalidEscape(4));
 }
 
 test "a control byte inside a string is rejected" {
@@ -95,7 +160,7 @@ test "deep nesting is bounded" {
         R.Ok(v) => @assert(false, "expected an error"),
         R.Err(e) => {
             match e {
-                ParseError.NestingTooDeep(at) => @assert(at > 0),
+                ParseError.NestingTooDeep(at) => @assert_eq(at, 257),
                 ParseError.UnexpectedEnd(at) => @assert(false, "ran off the end before the depth limit"),
                 ParseError.UnexpectedByte(at) => @assert(false, "unexpected byte"),
                 ParseError.InvalidNumber(at) => @assert(false, "invalid number"),
@@ -105,6 +170,21 @@ test "deep nesting is bounded" {
             }
         },
     }
+}
+
+test "nesting offsets skip whitespace before the rejected value" {
+    let mut nested = StrBuf.new();
+    let mut i: u64 = 0;
+    while i < 257 {
+        nested.push_str("{\"a\":");
+        i += 1;
+    }
+    nested.push(32);
+    nested.push(9);
+    nested.push(10);
+    nested.push(32);
+    nested.push_str("null");
+    @assert_eq(error_of(nested), ParseError.NestingTooDeep(1289));
 }
 
 test "values built by hand serialize" {


### PR DESCRIPTION
JSON parse errors now consistently report the zero-based position of the first rejected byte, or the input length when a byte is missing. An unterminated string reports its end instead of its opening quote; an invalid escape reports the escape letter; Unicode errors identify the decisive hex or UTF-8 byte. Incomplete numbers retain the `InvalidNumber` variant.

Validate each present UTF-8 continuation and surrogate prefix before reporting a later EOF, and skip whitespace before choosing a nesting-error location. Document the convention on `ParseError` and extend the std contract tests with malformed, truncated, multibyte-prefix, and deeply nested inputs.

Validation: 159 std contract tests, 36 quick-suite targets, and 6 JSON formatter CLI cases passed. The std contract and CLI cases also passed after rebasing onto current trunk. Formatting and `git diff --check` are clean.

Fixes RUE-2015
