### PR TITLE
RUE-1605: a struct with a destructor cannot carry a linear field

### DIFF
--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -491,16 +491,26 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
                 // Check if an equivalent anonymous struct already exists (structural equality)
                 // This now compares fields, method signatures, AND captured comptime values
-                let (struct_ty, is_new) = self.find_or_create_anon_struct(
-                    crate::AnonymousNominalKey {
-                        kind: crate::AnonymousNominalKind::Struct,
-                        producer: ctx.canonical_producer.clone(),
-                        anchor: anchor.clone(),
-                    },
-                    &struct_fields,
-                    &method_sigs,
-                    &ctx.comptime_value_vars,
-                )?;
+                let (struct_ty, is_new) = self
+                    .find_or_create_anon_struct(
+                        crate::AnonymousNominalKey {
+                            kind: crate::AnonymousNominalKind::Struct,
+                            producer: ctx.canonical_producer.clone(),
+                            anchor: anchor.clone(),
+                        },
+                        &struct_fields,
+                        &method_sigs,
+                        &ctx.comptime_value_vars,
+                    )
+                    .map_err(|error| {
+                        // The declaration-shape rejection (3.9:44) is raised
+                        // without a span; the struct expression is its site.
+                        if error.has_span() {
+                            error
+                        } else {
+                            error.with_primary_span(inst.span)
+                        }
+                    })?;
                 if is_new && !descriptors.is_empty() {
                     let struct_id = struct_ty
                         .as_struct()

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1725,9 +1725,20 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if !is_anon || self.has_ctor_type_display(ty) {
             return;
         }
-        let Some(fn_info) = self.function_info(ctor) else {
-            return;
-        };
+        if let Some(display) = self.ctor_type_display(ctor, callee_types, callee_values) {
+            self.record_body_ctor_type_display(ty, display);
+        }
+    }
+
+    /// The `Ctor(args...)` spelling of one constructor application, or `None`
+    /// for a partial substitution or an argument with no source spelling.
+    pub(crate) fn ctor_type_display(
+        &self,
+        ctor: Spur,
+        callee_types: &AHashMap<Spur, Type>,
+        callee_values: &AHashMap<Spur, ConstValue>,
+    ) -> Option<String> {
+        let fn_info = self.function_info(ctor)?;
         let param_names = self.body_param_data(fn_info.params).names().to_vec();
         let mut args: Vec<String> = Vec::with_capacity(param_names.len());
         for param in &param_names {
@@ -1738,19 +1749,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     ConstValue::Integer(i) => args.push(i.to_string()),
                     ConstValue::Bool(b) => args.push(b.to_string()),
                     ConstValue::Type(t) => args.push(self.format_type_name(*t)),
-                    _ => return,
+                    _ => return None,
                 }
             } else {
-                return;
+                return None;
             }
         }
         let source_name = self.source_function_name(ctor);
-        let display = format!(
+        Some(format!(
             "{}({})",
             self.body_interner().resolve(&source_name),
             args.join(", ")
-        );
-        self.record_body_ctor_type_display(ty, display);
+        ))
     }
 
     /// Pre-resolve `let`-bound compile-time type aliases in a function body,

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1525,6 +1525,37 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             .anonymous_struct_identities_mut()
             .insert(identity.clone(), id);
         self.storage.install_canonical_anonymous_type(ty, identity);
+        // An in-body destructor cannot own a linear field (3.9:44, RUE-1605),
+        // for the same reason a named struct's `drop fn` cannot: the field
+        // could only ever be discarded by the glue. Checked after the
+        // registration so the diagnostic names the instantiation
+        // (`Box(Token)`) rather than the digest spelling. The caller anchors
+        // the span, since the type expression is what is being evaluated.
+        if has_destructor
+            && let Some(field) = fields
+                .iter()
+                .find(|field| self.type_carries_linear(field.ty))
+        {
+            return Err(CompileError::without_span(
+                rue_error::ErrorKind::DestructorStructLinearField(Box::new(
+                    rue_error::DestructorStructLinearFieldError {
+                        struct_name: self.format_type_name(ty),
+                        field_name: field.name.clone(),
+                        field_type: self.format_type_name(field.ty),
+                    },
+                )),
+            )
+            .with_note(format!(
+                "the destructor cannot consume `{}` and no other code can move it out of a \
+                 value with a destructor, so the linear value could only ever be discarded by \
+                 the drop glue that runs after the destructor",
+                field.name
+            ))
+            .with_help(
+                "remove the `drop fn` and consume the field explicitly, or give the field a \
+                 type without a linear obligation",
+            ));
+        }
         Ok((ty, true))
     }
     pub(crate) fn find_or_create_anon_enum(

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -494,6 +494,26 @@ where
         )
     };
     host.replace_active_anonymous_producer(previous);
+    // The destructor-shape rejection (3.9:44) is raised while the anonymous
+    // struct is being minted inside this body, before the application that
+    // produced it can record the type's `Ctor(args...)` display, so the
+    // engine could only spell the digest. This specialization is that
+    // application: give the diagnostic the spelling the type would have had.
+    // A nested constructor's specialization already renamed its own struct,
+    // so only the digest spelling is replaced.
+    let analysis = analysis.map_err(|mut error| {
+        if let ErrorKind::DestructorStructLinearField(payload) = &mut error.kind
+            && payload.struct_name.starts_with("__anon_struct_")
+            && let Some(display) = OrdinaryBodyEngine::new(host).ctor_type_display(
+                key.base_name,
+                &type_subst,
+                &value_subst,
+            )
+        {
+            payload.struct_name = display;
+        }
+        error
+    });
     let (
         air,
         num_locals,

--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -175,6 +175,20 @@ compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
 [[case]]
+name = "destructor_linear_field_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0462"]
+compile_only = true
+compile_stdout_contains = [
+  "E0462: Destructor struct linear field",
+  "Give a destructor to a struct with a linear field:",
+  "Drop the destructor and consume the field explicitly:",
+  "docs/spec/src/03-types/09-destructors.md (spec rule 3.9:44)",
+]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
 name = "copy_destructor_code_uses_the_same_compiler_owned_query"
 files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
 args = ["explain", "E0457"]

--- a/crates/rue-cli-tests/cases/destructor_linear_field.toml
+++ b/crates/rue-cli-tests/cases/destructor_linear_field.toml
@@ -1,0 +1,182 @@
+# A struct with a user-defined destructor cannot carry a linear field
+# (RUE-1605, spec 3.9:44).
+#
+# The destructor may not move a field out of `self` (3.9:34), no other code
+# may move a field out of a value with a destructor, and the glue that runs
+# after the destructor would discard the field, so the only disposal was
+# `@drop` of the whole value — the implicit discard linearity exists to
+# forbid. The shape is rejected at the declaration, for named structs and for
+# anonymous structs at each instantiation, with the destructor and the field
+# both labelled.
+
+[section]
+id = "cli.destructor_linear_field"
+name = "Destructor-bearing structs cannot carry linear fields"
+description = "A `drop fn` on a struct that owns a linear value is rejected at the declaration (RUE-1605)."
+
+[[case]]
+name = "destructor_and_linear_field_both_labelled"
+description = "The diagnostic sits on the `drop fn`, labels the field, and explains why no consumer could ever reach the value."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+
+struct Holder {
+    t: Token,
+    n: i32,
+}
+
+drop fn Holder(self) { @dbg(self.n); }
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = [
+    "E0462",
+    "cannot define a destructor for 'Holder': field `t` of type 'Token' carries a linear value",
+    "main.rue:8:1",
+    "destructor defined here",
+    "linear field declared here",
+    "the destructor cannot consume `t`",
+    "remove the `drop fn` and consume the field explicitly",
+]
+
+[[case]]
+name = "drop_fn_before_struct_is_rejected"
+description = "Declaration order does not matter: a `drop fn` before its struct is rejected the same way, still anchored on the `drop fn`."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }
+
+struct Holder { t: Token, n: i32 }
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0462", "main.rue:3:1", "destructor defined here", "linear field declared here"]
+
+[[case]]
+name = "infectious_carrier_field_names_the_carrier_type"
+description = "A field that is linear only by infection is rejected too; the message names the field's own type."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+
+struct Inner { t: Token }
+
+struct Holder { inner: Inner, n: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = [
+    "E0462",
+    "cannot define a destructor for 'Holder': field `inner` of type 'Inner' carries a linear value",
+]
+
+[[case]]
+name = "anonymous_instantiation_in_a_body_is_rejected_at_the_struct_expression"
+description = "An in-body destructor is checked when the anonymous struct is instantiated with a linear field type; the diagnostic names the instantiation."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+
+fn Box(comptime T: type) -> type {
+    struct {
+        value: T,
+        drop fn(self) { @dbg(1); }
+    }
+}
+
+fn main() -> i32 {
+    let B = Box(Token);
+    let b = B { value: Token { v: 1 } };
+    @drop(b);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = [
+    "E0462",
+    "cannot define a destructor for 'Box(Token)': field `value` of type 'Token' carries a linear value",
+]
+
+[[case]]
+name = "anonymous_instantiation_at_file_scope_is_rejected"
+description = "The same check reaches an instantiation evaluated for a file-level constant."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+
+fn Box(comptime T: type) -> type {
+    struct {
+        value: T,
+        drop fn(self) { @dbg(1); }
+    }
+}
+
+const B = Box(Token);
+
+fn main() -> i32 {
+    let b = B { value: Token { v: 1 } };
+    @drop(b);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = [
+    "E0462",
+    "cannot define a destructor for 'Box(Token)': field `value` of type 'Token' carries a linear value",
+]
+
+[[case]]
+name = "whole_value_drop_no_longer_discards_the_field"
+description = "The program the ruling closed: before it, `@drop` of the whole value ran the destructor and let the glue discard the linear field."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+
+struct Holder { t: Token, n: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }
+
+fn main() -> i32 {
+    let h = Holder { t: Token { v: 1 }, n: 7 };
+    @drop(h);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0462"]
+
+[[case]]
+name = "linear_struct_with_destructor_over_affine_fields_runs"
+description = "Control: a `linear` struct whose fields are all affine may have a destructor; `@drop` runs it and satisfies the obligation."
+files = [{ path = "main.rue", source = """
+linear struct Guard { v: i32 }
+
+drop fn Guard(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let g = Guard { v: 9 };
+    @drop(g);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "9\n"
+
+[[case]]
+name = "struct_without_destructor_hands_the_field_to_its_consumer"
+description = "Control: without a destructor the linear field is moved out to a consumer and the residue drops normally."
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+
+struct Bag { t: Token, n: i32 }
+
+fn redeem(t: Token) -> i32 { t.v }
+
+fn main() -> i32 {
+    let b = Bag { t: Token { v: 4 }, n: 1 };
+    redeem(b.t)
+}
+""" }]
+exit_code = 4

--- a/crates/rue-cli-tests/cases/infectious_linear.toml
+++ b/crates/rue-cli-tests/cases/infectious_linear.toml
@@ -421,8 +421,8 @@ stdout = """99
 """
 
 [[case]]
-name = "carrier_with_own_destructor_field_move_rejected"
-description = "A carrier that has its own destructor now reaches the destructor-type field-move rejection (E0456) instead of silently skipping its destructor via whole-value consumption (RUE-1591)."
+name = "carrier_with_own_destructor_rejected_at_declaration"
+description = "A carrier that has its own destructor is rejected where it is declared (E0462, spec 3.9:44, RUE-1605): before that ruling the field move reached E0456 (RUE-1591) and the only discharge was `@drop` of the whole value."
 files = [{ path = "main.rue", source = """
 linear struct L { v: i32 }
 struct C { l: L, n: i32 }
@@ -435,8 +435,8 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = [
-    "E0456",
-    "cannot move field `l` out of a value of type 'C', which has a destructor",
+    "E0462",
+    "cannot define a destructor for 'C': field `l` of type 'L' carries a linear value",
 ]
 
 [[case]]

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1594,6 +1594,10 @@ impl RetainedCharge for rue_error::ErrorKind {
                 .saturating_add(value.struct_name.retained_charge())
                 .saturating_add(value.field_name.retained_charge())
                 .saturating_add(value.field_type.retained_charge()),
+            E::DestructorStructLinearField(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.struct_name.retained_charge())
+                .saturating_add(value.field_name.retained_charge())
+                .saturating_add(value.field_type.retained_charge()),
             E::LinearFieldDroppedByDestructure(value) => (std::mem::size_of_val(value.as_ref())
                 as u64)
                 .saturating_add(value.struct_name.retained_charge())

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -2939,6 +2939,60 @@ pub(in crate::revisioned_query_database) fn resolve_parsed_semantic_signature(
                     }
                 }
             }
+            // A destructor-bearing struct cannot carry a linear field
+            // (3.9:44, RUE-1605): the destructor may not consume it, no user
+            // may move it out (3.9:34), and the glue after the destructor
+            // would discard it. Checked here, where the field types are
+            // resolved, because the shape is wrong at the declaration and
+            // not at any one use. The field walk comes first so that a
+            // struct with no linear field never consults the destructor
+            // namespace, whose ambiguity is the destructor's own report
+            // (3.9:26); the lookup itself is the one the `@copy` rule
+            // (3.9:31) makes on the containment path.
+            let mut linear_field = None;
+            for (field_name, field_ty) in &fields {
+                if provider
+                    .type_carries_linear(field_ty)
+                    .map_err(|error| match error {
+                        rue_air::SemanticProviderError::Abort(abort) => {
+                            ResolveSemanticSignatureError::Abort(abort)
+                        }
+                        rue_air::SemanticProviderError::Failure(failure) => {
+                            ResolveSemanticSignatureError::failure(failure)
+                        }
+                    })?
+                {
+                    linear_field = Some((field_name, field_ty));
+                    break;
+                }
+            }
+            if let Some((field_name, field_ty)) = linear_field
+                && provider
+                    .candidate(
+                        module,
+                        provider.dependency_source.name(),
+                        DefinitionKind::Destructor,
+                    )
+                    .map_err(|error| match error {
+                        rue_air::SemanticProviderError::Abort(abort) => {
+                            ResolveSemanticSignatureError::Abort(abort)
+                        }
+                        rue_air::SemanticProviderError::Failure(failure) => {
+                            ResolveSemanticSignatureError::failure(failure)
+                        }
+                    })?
+                    .is_some()
+            {
+                return Err(diagnostic(
+                    rue_error::ErrorKind::DestructorStructLinearField(Box::new(
+                        rue_error::DestructorStructLinearFieldError {
+                            struct_name: provider.dependency_source.name().to_owned(),
+                            field_name: field_name.to_string(),
+                            field_type: durable_type_diagnostic_name(field_ty),
+                        },
+                    )),
+                ));
+            }
             if *is_repr_c {
                 if !provider
                     .configuration

--- a/crates/rue-compiler/src/session/rooted_projections.rs
+++ b/crates/rue-compiler/src/session/rooted_projections.rs
@@ -3367,6 +3367,55 @@ fn semantic_nucleus_failure_diagnostics(
             return CompileErrors::from(error);
         }
     }
+    if let (Some(declaration), F::Diagnostic(ErrorKind::DestructorStructLinearField(payload))) =
+        (declaration, failure)
+        && let Some(module) = modules
+            .iter()
+            .find(|module| module.module_id() == &declaration.module)
+    {
+        let type_name = payload.struct_name.as_str();
+        let destructor_span = module.ast().items.iter().find_map(|item| match item {
+            rue_parser::ast::Item::DropFn(drop)
+                if module.resolve_raw_symbol(drop.type_name.name) == type_name =>
+            {
+                Some(drop.span)
+            }
+            _ => None,
+        });
+        let field_span = module.ast().items.iter().find_map(|item| match item {
+            rue_parser::ast::Item::Struct(structure)
+                if module.resolve_raw_symbol(structure.name.name) == type_name =>
+            {
+                structure
+                    .fields
+                    .iter()
+                    .find(|field| module.resolve_raw_symbol(field.name.name) == payload.field_name)
+                    .map(|field| field.span)
+            }
+            _ => None,
+        });
+        if let Some(destructor_span) = destructor_span {
+            let mut error = CompileError::new(
+                ErrorKind::DestructorStructLinearField(payload.clone()),
+                destructor_span,
+            )
+            .with_label("destructor defined here", destructor_span)
+            .with_note(format!(
+                "the destructor cannot consume `{field}` and no other code can move it out of a \
+                 value with a destructor, so the linear value could only ever be discarded by \
+                 the drop glue that runs after the destructor",
+                field = payload.field_name
+            ))
+            .with_help(
+                "remove the `drop fn` and consume the field explicitly, or give the field a \
+                 type without a linear obligation",
+            );
+            if let Some(field_span) = field_span {
+                error = error.with_label("linear field declared here", field_span);
+            }
+            return CompileErrors::from(error);
+        }
+    }
     let span = declaration.and_then(|key| {
         modules
             .iter()

--- a/crates/rue-compiler/tests/error_explanation_examples.rs
+++ b/crates/rue-compiler/tests/error_explanation_examples.rs
@@ -37,7 +37,7 @@ fn compiler_owned_explanation_examples_have_the_declared_outcome() {
                 434..=437
                     | 442..=443
                     | 456..=457
-                    | 461
+                    | 461..=462
                     | 474..=475
                     | 478
                     | 480..=497

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1281,6 +1281,15 @@ define_error_codes! {
         ],
         references: [ErrorCodeReference { title: "Constant initializers must be acyclic", path: "docs/spec/src/06-items/05-constants.md", rule: Some("6.5:8") }],
     };
+    DESTRUCTOR_STRUCT_LINEAR_FIELD = 462 => {
+        explanation: "A struct with a user-defined destructor declared a field that carries a linear value. Such a field could never be consumed: the destructor may not move a field out of `self`, no other code may move a field out of a value whose type has a destructor, and the drop glue that runs after the destructor would silently discard it. The only way to dispose of such a value would be to drop it whole, which defeats the obligation the linear field exists to enforce, so the shape is rejected where it is declared.",
+        likely_cause: "A `drop fn` was added to a struct that owns a linear value, or a linear (or linear-carrying) field was added to a struct with a destructor. Remove the destructor and let the code that consumes the struct consume the field explicitly, or give the field an affine type and run its cleanup in the destructor.",
+        examples: [
+            ErrorCodeExample { title: "Give a destructor to a struct with a linear field", source: "linear struct Token { value: i32 }\nstruct Holder { token: Token, n: i32 }\ndrop fn Holder(self) { @dbg(self.n); }\nfn main() -> i32 { 0 }", outcome: ErrorCodeExampleOutcome::EmitsThisCode },
+            ErrorCodeExample { title: "Drop the destructor and consume the field explicitly", source: "linear struct Token { value: i32 }\nstruct Holder { token: Token, n: i32 }\nfn redeem(token: Token) -> i32 { token.value }\nfn main() -> i32 {\n    let holder = Holder { token: Token { value: 42 }, n: 1 };\n    redeem(holder.token)\n}", outcome: ErrorCodeExampleOutcome::Compiles },
+        ],
+        references: [ErrorCodeReference { title: "A destructor-bearing struct cannot carry a linear field", path: "docs/spec/src/03-types/09-destructors.md", rule: Some("3.9:44") }],
+    };
     // 462-473 are reserved by in-flight work.
     LINEAR_FIELD_DROPPED_BY_DESTRUCTURE = 474 => {
         explanation: "A field access on a struct declared `linear` consumes and destructures the smallest enclosing declared-linear place. Rue rejects that access when the residue contains another linear value, because destroying the residue would silently discard its must-consume obligation. A struct that is only linear by infection instead uses ordinary partial-move rules.",
@@ -2437,6 +2446,19 @@ pub struct MissingFieldsError {
 /// Payload for `ErrorKind::CopyStructNonCopyField`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CopyStructNonCopyFieldError {
+    pub struct_name: String,
+    pub field_name: String,
+    pub field_type: String,
+}
+
+/// Payload for `ErrorKind::DestructorStructLinearField`.
+///
+/// A struct with a user-defined destructor declared a field that carries a
+/// linear value (RUE-1605, spec 3.9:44). `field_type` is the field's own
+/// type; when the field is linear only by infection the diagnostic's note
+/// names the component that made it so.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DestructorStructLinearFieldError {
     pub struct_name: String,
     pub field_name: String,
     pub field_type: String,
@@ -3615,6 +3637,13 @@ pub enum ErrorKind {
     /// logical resource.
     #[error("cannot define a destructor for '{type_name}': `@copy` types cannot have destructors")]
     CopyStructWithDestructor { type_name: String },
+    /// A struct with a user-defined destructor cannot carry a linear field
+    /// (RUE-1605). The destructor may not consume the field (3.9:34), no user
+    /// may move it out (3.9:34), and the drop glue that follows the destructor
+    /// would discard it, so the field's must-consume obligation could never
+    /// reach a consumer.
+    #[error("cannot define a destructor for '{struct_name}': field `{field_name}` of type '{field_type}' carries a linear value", struct_name = .0.struct_name, field_name = .0.field_name, field_type = .0.field_type)]
+    DestructorStructLinearField(Box<DestructorStructLinearFieldError>),
 
     // Control flow errors
     #[error("'break' outside of loop")]
@@ -4184,6 +4213,7 @@ impl ErrorKind {
                 ErrorCode::MOVE_FIELD_OUT_OF_DESTRUCTOR_TYPE
             }
             ErrorKind::CopyStructWithDestructor { .. } => ErrorCode::COPY_STRUCT_WITH_DESTRUCTOR,
+            ErrorKind::DestructorStructLinearField(_) => ErrorCode::DESTRUCTOR_STRUCT_LINEAR_FIELD,
 
             // Control flow errors (E0500-E0599)
             ErrorKind::BreakOutsideLoop => ErrorCode::BREAK_OUTSIDE_LOOP,

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -1019,6 +1019,176 @@ compile_fail = true
 error_contains = "`@copy` types cannot have destructors"
 
 [[case]]
+name = "destructor_struct_linear_field_rejected"
+spec = ["3.9:44"]
+description = "A struct with a destructor cannot declare a field of a linear struct type (E0462): the destructor could never consume it and the glue would discard it"
+source = """
+linear struct Token { v: i32 }
+
+struct Holder { t: Token, n: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "cannot define a destructor for 'Holder': field `t` of type 'Token' carries a linear value"
+
+[[case]]
+name = "destructor_struct_infectious_field_rejected"
+spec = ["3.9:44"]
+description = "The rule follows infection (3.8:58): a field whose type merely contains a linear value, at any nesting depth, is rejected the same way"
+source = """
+linear struct Token { v: i32 }
+
+struct Inner { t: Token }
+
+struct Mid { inner: Inner }
+
+struct Holder { m: Mid, n: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "cannot define a destructor for 'Holder': field `m` of type 'Mid' carries a linear value"
+
+[[case]]
+name = "destructor_struct_linear_array_field_rejected"
+spec = ["3.9:44"]
+description = "A fixed array of linear elements carries a linear value, so it is rejected as a field of a destructor-bearing struct"
+source = """
+linear struct Token { v: i32 }
+
+struct Holder { ts: [Token; 2], n: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "cannot define a destructor for 'Holder': field `ts` of type '[Token; 2]' carries a linear value"
+
+[[case]]
+name = "destructor_struct_order_independent_rejected"
+spec = ["3.9:44"]
+description = "Declaration order does not matter: a `drop fn` written before its struct is rejected the same way"
+source = """
+linear struct Token { v: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }
+
+struct Holder { t: Token, n: i32 }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "cannot define a destructor for 'Holder'"
+
+[[case]]
+name = "anonymous_destructor_struct_linear_field_rejected"
+spec = ["3.9:44", "3.9:42"]
+description = "An anonymous struct with an in-body destructor is checked at each instantiation: instantiating it with a linear field type is rejected"
+source = """
+linear struct Token { v: i32 }
+
+fn Box(comptime T: type) -> type {
+    struct {
+        value: T,
+        drop fn(self) { @dbg(1); }
+    }
+}
+
+fn main() -> i32 {
+    let B = Box(Token);
+    let b = B { value: Token { v: 1 } };
+    @drop(b);
+    0
+}
+"""
+compile_fail = true
+error_contains = "cannot define a destructor for 'Box(Token)': field `value` of type 'Token' carries a linear value"
+
+[[case]]
+name = "anonymous_destructor_struct_affine_instantiation_ok"
+spec = ["3.9:44", "3.9:42"]
+description = "The same constructor instantiated with an affine field type is unaffected: the destructor runs at scope exit"
+source = """
+fn Box(comptime T: type) -> type {
+    struct {
+        value: T,
+        drop fn(self) { @dbg(7); }
+    }
+}
+
+fn main() -> i32 {
+    let B = Box(i32);
+    let b = B { value: 3 };
+    b.value
+}
+"""
+exit_code = 3
+expected_stdout = "7\n"
+
+[[case]]
+name = "linear_struct_with_destructor_and_affine_fields_ok"
+spec = ["3.9:44"]
+description = "A `linear` struct may have a destructor when none of its fields carries a linear value; `@drop` runs it and satisfies the obligation"
+source = """
+linear struct Guard { v: i32, n: i32 }
+
+drop fn Guard(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let g = Guard { v: 5, n: 2 };
+    @drop(g);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "5\n"
+
+[[case]]
+name = "struct_without_destructor_carries_linear_field_ok"
+spec = ["3.9:44", "3.9:46"]
+description = "A struct without a destructor may carry a linear field: the field is moved out to its consumer"
+source = """
+linear struct Token { v: i32 }
+
+struct Bag { t: Token, n: i32 }
+
+fn redeem(t: Token) -> i32 { t.v }
+
+fn main() -> i32 {
+    let b = Bag { t: Token { v: 3 }, n: 1 };
+    redeem(b.t)
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "destructor_struct_field_with_own_destructor_ok"
+spec = ["3.9:44"]
+description = "Control: an affine field whose own type has a destructor is not a linear value; the outer destructor runs before the field's"
+source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) { @dbg(self.v); }
+
+struct Outer { f: Inner, n: i32 }
+
+drop fn Outer(self) { @dbg(self.n); }
+
+fn main() -> i32 {
+    let o = Outer { f: Inner { v: 1 }, n: 2 };
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "2\n1\n"
+
+[[case]]
 name = "destructor_moves_self_rejected"
 spec = ["3.9:33"]
 description = "Moving `self` out of a destructor body is rejected (E0442): the new owner's drop would re-enter the destructor"

--- a/crates/rue-ui-tests/cases/diagnostics/destructor-linear-field.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/destructor-linear-field.toml
@@ -1,0 +1,71 @@
+[section]
+id = "diagnostics.destructor-linear-field"
+name = "Destructor-bearing struct with a linear field"
+description = "A struct with a user-defined destructor cannot declare a field that carries a linear value (spec 3.9:44, RUE-1605). These cases pin the diagnostic's anchor, labels, note and help."
+
+[[case]]
+name = "named_struct_labels_destructor_and_field"
+description = "The error is anchored on the `drop fn`, labels the field, and the help names both repairs."
+source = """
+linear struct Token { v: i32 }
+
+struct Holder { t: Token, n: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "[E0462]",
+    "cannot define a destructor for 'Holder': field `t` of type 'Token' carries a linear value",
+    "5:1",
+    "destructor defined here",
+    "linear field declared here",
+    "the destructor cannot consume `t` and no other code can move it out of a value with a destructor",
+    "remove the `drop fn` and consume the field explicitly, or give the field a type without a linear obligation",
+]
+
+[[case]]
+name = "array_field_of_linear_elements"
+description = "A fixed array of linear elements is a linear-carrying field; the message spells the array type."
+source = """
+linear struct Token { v: i32 }
+
+struct Holder { ts: [Token; 3] }
+
+drop fn Holder(self) { @dbg(1); }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "[E0462]",
+    "field `ts` of type '[Token; 3]' carries a linear value",
+]
+
+[[case]]
+name = "anonymous_instantiation_names_the_constructor_application"
+description = "For an anonymous struct the diagnostic names the instantiation rather than an internal spelling, and sits on the struct expression."
+source = """
+linear struct Token { v: i32 }
+
+fn Box(comptime T: type) -> type {
+    struct {
+        value: T,
+        drop fn(self) { @dbg(1); }
+    }
+}
+
+fn main() -> i32 {
+    let B = Box(Token);
+    let b = B { value: Token { v: 1 } };
+    @drop(b);
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0462]",
+    "cannot define a destructor for 'Box(Token)': field `value` of type 'Token' carries a linear value",
+]

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -252,6 +252,63 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="3.9:44", cat="legality-rule") }}
+
+A struct type with a user-defined destructor **MUST NOT** declare a field
+whose type carries a linear value (3.8:58): neither a field of a `linear`
+struct type nor a field of a type that is linear by infection, through any
+depth of struct nesting or fixed-array element. A compile-time error is
+raised at the declaration, naming the destructor and the offending field,
+whether the struct is named (its `drop fn` is a top-level item) or anonymous
+(its `drop fn` is in the struct body and the check runs at each
+instantiation, 3.9:42). A `linear` struct **MAY** have a destructor when none
+of its fields carries a linear value, and a struct without a destructor
+**MAY** carry linear fields.
+
+{{ rule(id="3.9:45", cat="informative") }}
+
+The shape is rejected because the field's obligation could never be met. A
+linear value must reach a consumer (3.8:32), and there are only two ways to
+get a field out of a value: move it out, or let the drop glue dispose of it.
+The first is forbidden for a type with a destructor (3.9:34), including
+within the destructor body itself, and the second is exactly the implicit
+discard that linearity exists to forbid. What remained before this rule was
+`@drop` of the whole value (3.9:37), which ran the destructor and then had the
+glue discard the linear field; every other use, consuming the value whole,
+only moved the same undischargeable obligation to a new owner (RUE-1605).
+Rejecting the declaration reports the mistake where it is made instead of at
+each use.
+
+Other languages with linear or non-copyable types reach the same place by
+different routes. Rust has no linear types, but a type that implements `Drop`
+forbids moving a field out (E0509), which is 3.9:34. Austral has no
+destructors at all: a linear value is consumed only by an explicit call or by
+destructuring, so the conflict cannot arise. Swift's non-copyable structs
+with a `deinit` forbid partially consuming `self`, and offer `discard self`
+inside a consuming method to skip the deinitializer so fields can be consumed
+one by one. Rue takes the declaration-time rejection rather than a
+skip-the-destructor escape: a destructor that may not run is a destructor a
+reader cannot rely on.
+
+{{ rule(id="3.9:46", cat="example") }}
+
+```rue
+linear struct Token { v: i32 }
+
+struct Holder { t: Token, n: i32 }
+
+drop fn Holder(self) { @dbg(self.n); }  // ERROR: field `t` carries a linear value
+
+struct Bag { t: Token, n: i32 }          // OK: no destructor, so `t` can be consumed
+
+fn redeem(t: Token) -> i32 { t.v }
+
+fn main() -> i32 {
+    let b = Bag { t: Token { v: 3 }, n: 1 };
+    redeem(b.t)
+}
+```
+
 ## The `@drop` intrinsic
 
 {{ rule(id="3.9:37", cat="normative") }}
@@ -319,7 +376,8 @@ that value is dropped (at scope exit or via `@drop`), before the automatic
 dropping of the value's fields. All destructor legality rules (3.9:26 — at most
 one per type; 3.9:31 — a `@copy` type cannot have one, so a struct with an
 in-body `drop fn` is never `@copy`; 3.9:33 — `self` may not be moved out;
-3.9:34 — a field may not be moved out) apply unchanged.
+3.9:34 — a field may not be moved out; 3.9:44 — no field may carry a linear
+value, checked at each instantiation) apply unchanged.
 
 {{ rule(id="3.9:43", cat="example") }}
 


### PR DESCRIPTION
A struct that declares its own `drop fn` could hold a field of a linear type, or of a type that carries one. The field could never reach a consumer: the destructor may not move a field out of `self` (3.9:34), no other code may move a field out of a value with a destructor (E0456), and the drop glue that runs after the destructor discards it. The one thing that compiled was `@drop` of the whole value, which ran the destructor and then had the glue throw the linear value away, the implicit discard linearity exists to forbid. The ruling on the issue was to reject the shape where it is declared.

- **Spec.** 3.9:44 states the rule (named and anonymous structs, any nesting depth, fixed-array elements), 3.9:45 gives the rationale and what Rust (E0509), Austral (no destructors) and Swift (`discard self`) do at the same spot, and 3.9:46 shows the repair. 3.9:42's list of destructor rules that reach anonymous structs gains the new one.
- **Compiler.** A named struct is checked when its signature resolves, after the fields are typed; the field walk runs before the destructor lookup so a struct with no linear field never consults the destructor namespace. The new E0462 is anchored on the `drop fn` with the field labelled, plus a note and a help naming both repairs. An anonymous struct with an in-body `drop fn` is checked at each instantiation, anchored on the struct expression; the diagnostic is named after the constructor application (`Box(Token)`) rather than the digest spelling, which the specialization that produced the struct fills in.
- **Tests.** Spec cases in `types/destructors.toml` cover the linear, infectious, array and anonymous shapes and the controls (a `linear` struct with a destructor over affine fields, a struct without a destructor carrying a linear field, an affine field with its own destructor). CLI cases in `destructor_linear_field.toml` pin the labels, both declaration orders and both anonymous instantiation sites; UI cases in `diagnostics/destructor-linear-field.toml` pin the diagnostic text; the explain corpus knows E0462. The RUE-1591 carrier case, which pinned E0456 at the field move, now pins E0462 at the declaration.

Verified locally: rue-error, rue-air and rue-compiler unit tests; the explanation-example test; the full spec suite (2971 pass); the full UI suite (457 pass); CLI `destructor_linear`, `infectious_linear`, `explain`, `copy_destructor`, `drop_intrinsic`, `linear_must_consume`, `nested_linear`, `multifile_errors` and `diagnostic_json`; the spec traceability, machine-index, tutorial-snippet, frontend-diff and ADR-registry gates.

Fixes RUE-1605