### PR TITLE
RUE-2179: compile executables through the compiler service with --daemon

### DIFF
--- a/crates/rue-cli-tests/cases/daemon.toml
+++ b/crates/rue-cli-tests/cases/daemon.toml
@@ -1,16 +1,18 @@
-# The local compiler service's controls (ADR-0085 §2, RUE-2128): `rue daemon
-# start|status|stop`. Every case runs against a private endpoint root inside
-# its own directory, so no case shares a service with another or with the
-# developer's real runtime directory, and the harness stops what a case leaves
-# running. The service executes no compiler requests yet; these cases pin the
-# lifecycle contract the request path will rely on: `status` and `stop` never
-# start a service, `start` is idempotent and race-safe, and a scope selects
-# exactly one service.
+# The local compiler service (ADR-0085, RUE-2128): the `rue daemon
+# start|status|stop` controls and `--daemon=auto|required` builds. Every case
+# runs against a private endpoint root inside its own directory, so no case
+# shares a service with another or with the developer's real runtime
+# directory, and the harness stops what a case leaves running. The lifecycle
+# cases pin that `status` and `stop` never start a service, `start` is
+# idempotent and race-safe, and a scope selects exactly one service; the build
+# cases pin that a build through the service publishes a working program,
+# reports a rejected one exactly as direct mode does, and follows the support
+# table.
 
 [section]
 id = "cli.daemon"
-name = "rue daemon lifecycle controls"
-description = "start/status/stop over a user-private endpoint scoped by directory, isolation, and compiler build."
+name = "rue daemon controls and service builds"
+description = "start/status/stop and --daemon builds over a user-private endpoint scoped by directory, isolation, and compiler build."
 
 [[case]]
 name = "status_and_stop_without_a_service_start_nothing"
@@ -80,4 +82,74 @@ daemon = { steps = [
   { args = ["daemon", "start", "--scope", "missing"], exit_code = 1, stderr_contains = ["daemon scope directory", "is not usable"] },
   { args = ["daemon", "start", "--isolation", "no spaces"], exit_code = 1, stderr_contains = ["daemon isolation name"] },
   { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+] }
+
+[[case]]
+name = "required_builds_run_through_the_service"
+description = "--daemon=required compiles through the service: the client publishes a working program, the service retains the host, and a second build of the same root reuses it."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(41 + 1);
+    0
+}
+""" }]
+daemon = { steps = [
+  { args = ["--daemon=required", "main.rue", "-o", "app"], exit_code = 0, stdout_contains = ["Compiled main.rue -> app (target:"], run_output = "app", run_output_stdout_contains = ["42\n"] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["rue daemon: running", "  active request: none", "  queued requests: 0", "  retained hosts: 1"] },
+  { args = ["--daemon", "required", "main.rue", "-o", "app2"], exit_code = 0, stdout_contains = ["Compiled main.rue -> app2"], run_output = "app2", run_output_stdout_contains = ["42\n"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+] }
+
+[[case]]
+name = "service_diagnostics_match_direct_mode"
+description = "A rejected program is reported through the service exactly as directly: the same diagnostic text, the same JSON object, the same exit status, and nothing published."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = "nope";
+    x
+}
+""" }]
+daemon = { steps = [
+  { args = ["main.rue", "-o", "direct"], exit_code = 1, stderr_contains = ["error: [E0206]: type mismatch: expected string type, found i32", " --> main.rue:2:5"] },
+  { args = ["--daemon=required", "main.rue", "-o", "app"], exit_code = 1, stderr_contains = ["error: [E0206]: type mismatch: expected string type, found i32", " --> main.rue:2:5"] },
+  { args = ["--daemon=required", "--error-format", "json", "main.rue", "-o", "app"], exit_code = 1, stderr_contains = ["\"code\":\"E0206\"", "\"file\":\"main.rue\""] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["  retained hosts: 1"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+] }
+
+[[case]]
+name = "the_support_table_decides_between_service_and_direct"
+description = "Requests outside the support table run directly under auto and are refused before any work under required; a refused request starts no service."
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
+daemon = { steps = [
+  { args = ["--daemon=required", "--emit", "air", "main.rue"], exit_code = 1, stderr_contains = ["Error: --daemon=required: --emit runs directly"] },
+  { args = ["--daemon=required", "--error-format", "json", "--emit", "air", "main.rue"], exit_code = 1, stderr_contains = ["\"code\":\"E1503\"", "--emit runs directly"] },
+  { args = ["--daemon=required", "--watch", "main.rue"], exit_code = 1, stderr_contains = ["Error: --daemon=required: --watch runs directly"] },
+  { args = ["--daemon=required", "--linker", "cc", "main.rue"], exit_code = 1, stderr_contains = ["a system linker runs directly"] },
+  { args = ["--daemon=required", "--time-passes", "main.rue"], exit_code = 1, stderr_contains = ["--time-passes runs directly"] },
+  { args = ["--daemon=required", "--log-level", "debug", "main.rue"], exit_code = 1, stderr_contains = ["compiler tracing (--log-level) runs directly"] },
+  { args = ["--daemon=required", "test", "main.rue"], exit_code = 2, stderr_contains = ["`rue test` runs directly"] },
+  { args = ["--daemon=auto", "--emit", "deps", "main.rue"], exit_code = 0, stdout_contains = ["main.rue"] },
+  { args = ["--daemon=sometimes", "main.rue"], exit_code = 1, stderr_contains = ["unknown --daemon mode `sometimes`"] },
+  { args = ["--daemon-scope", ".", "main.rue"], exit_code = 1, stderr_contains = ["--daemon-scope requires --daemon=auto or --daemon=required"] },
+  { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+] }
+
+[[case]]
+name = "auto_starts_the_service_its_scope_selects"
+description = "--daemon=auto starts the service for the root's directory; --daemon-scope and --daemon-isolation select the same service the controls address."
+files = [
+  { path = "main.rue", source = "fn main() -> i32 { 0 }\n" },
+  { path = "sub/main.rue", source = "fn main() -> i32 { 0 }\n" },
+]
+daemon = { steps = [
+  { args = ["--daemon=auto", "main.rue", "-o", "app"], exit_code = 0, stdout_contains = ["Compiled main.rue -> app"], run_output = "app" },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["rue daemon: running", "  retained hosts: 1"] },
+  { args = ["--daemon=auto", "sub/main.rue", "-o", "sub/app"], exit_code = 0, stdout_contains = ["Compiled sub/main.rue -> sub/app"], run_output = "sub/app" },
+  { args = ["daemon", "status", "--scope", "sub"], exit_code = 0, stdout_contains = ["rue daemon: running"] },
+  { args = ["--daemon=auto", "--daemon-scope", ".", "--daemon-isolation", "ci", "sub/main.rue", "-o", "sub/app2"], exit_code = 0, run_output = "sub/app2" },
+  { args = ["daemon", "status", "--isolation", "ci"], exit_code = 0, stdout_contains = ["  isolation: ci", "  retained hosts: 1"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+  { args = ["daemon", "stop", "--scope", "sub"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+  { args = ["daemon", "stop", "--isolation", "ci"], exit_code = 0, stdout_contains = ["stopped service pid"] },
 ] }

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -3211,6 +3211,48 @@ fn run_daemon_steps(
             }
             check_daemon_step_output(&label, step, &stdout, &stderr)?;
         }
+        if let Some(program) = &step.run_output {
+            run_daemon_step_output(case, contract, dir, index, step, program)?;
+        }
+    }
+    Ok(())
+}
+
+/// Run the program a daemon step produced and check it behaves.
+fn run_daemon_step_output(
+    case: &Case,
+    contract: &ExecutionContract,
+    dir: &Path,
+    index: usize,
+    step: &DaemonStep,
+    program: &str,
+) -> TestResult {
+    let path = dir.join(program);
+    let mut command = Command::new(&path);
+    command.current_dir(dir);
+    apply_case_environment(&mut command, &case.env, Path::new(""));
+    let output = run_phase_with_timeout(
+        command,
+        ProcessPhase::ProducedProgram,
+        contract.runtime_timeout(),
+        None,
+    )?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let label = format!("daemon step {index} output `{program}`");
+    let code = output.status.code().unwrap_or(-1);
+    if code != step.run_output_exit_code {
+        return Err(TestFailure::assertion(format!(
+            "{label}: expected exit {}, got {code}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+            step.run_output_exit_code
+        )));
+    }
+    for expected in &step.run_output_stdout_contains {
+        if !stdout.contains(expected.as_str()) {
+            return Err(TestFailure::assertion(format!(
+                "{label}: stdout missing {expected:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )));
+        }
     }
     Ok(())
 }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -2273,6 +2273,10 @@ define_error_codes! {
     DRIVER_TOOLCHAIN_INTEGRITY = 1501;
     /// Hermetic policy denied a trusted toolchain input during acquisition.
     DRIVER_HERMETIC_DENIAL = 1502;
+    /// The local compiler service (ADR-0085) could not run a request:
+    /// unavailable, incompatible, refused, or lost after acceptance. Never a
+    /// source error.
+    DRIVER_DAEMON = 1503;
 
     // ========================================================================
     // Internal compiler errors (E9000-E9999)
@@ -5560,6 +5564,7 @@ mod tests {
                 "DRIVER_SOURCE_LOAD",
                 "DRIVER_TOOLCHAIN_INTEGRITY",
                 "DRIVER_HERMETIC_DENIAL",
+                "DRIVER_DAEMON",
             ])
         );
         declared.retain(|name| !name.starts_with("DRIVER_"));
@@ -6456,6 +6461,7 @@ mod tests {
         assert_eq!(ErrorCode::DRIVER_SOURCE_LOAD, ErrorCode(1500));
         assert_eq!(ErrorCode::DRIVER_TOOLCHAIN_INTEGRITY, ErrorCode(1501));
         assert_eq!(ErrorCode::DRIVER_HERMETIC_DENIAL, ErrorCode(1502));
+        assert_eq!(ErrorCode::DRIVER_DAEMON, ErrorCode(1503));
         assert_ne!(
             ErrorCode::DRIVER_SOURCE_LOAD,
             ErrorCode::DRIVER_TOOLCHAIN_INTEGRITY

--- a/crates/rue-test-runner/src/cli_corpus.rs
+++ b/crates/rue-test-runner/src/cli_corpus.rs
@@ -377,6 +377,16 @@ pub struct DaemonStep {
     /// step's expectations; it is how a start race is staged.
     #[serde(default = "one")]
     pub concurrency: usize,
+    /// After the invocation, run this executable from the case directory and
+    /// require `run_output_exit_code` and `run_output_stdout_contains` of it.
+    /// It is how a build the service performed is shown to have produced a
+    /// working program.
+    #[serde(default)]
+    pub run_output: Option<String>,
+    #[serde(default)]
+    pub run_output_exit_code: i32,
+    #[serde(default)]
+    pub run_output_stdout_contains: Vec<String>,
 }
 
 fn one() -> usize {

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -760,7 +760,7 @@ fn linked_executable(
     }
 }
 
-fn announce(
+pub(crate) fn announce(
     announcement: Announcement,
     source_path: &str,
     output_path: &str,
@@ -784,6 +784,134 @@ fn linker_name(linker: &LinkerMode) -> &str {
     match linker {
         LinkerMode::Internal => "internal",
         LinkerMode::System(command) => command,
+    }
+}
+
+/// One executable cycle's owned answer in the form that crosses the service
+/// boundary (ADR-0085 §5): the diagnostic stream rendered once, by the
+/// canonical formatter under the client's own format and color policy, and
+/// the linked bytes with everything the client's publication needs.
+pub(crate) struct CycleTransport {
+    /// Everything the direct compile would have written to stderr up to the
+    /// point the client takes over.
+    pub(crate) stderr: String,
+    pub(crate) outcome: TransportOutcome,
+}
+
+pub(crate) enum TransportOutcome {
+    /// The program was rejected or the destination refused.
+    Rejected,
+    Canceled,
+    Ready {
+        target: rue_target::Target,
+        bytes: Vec<u8>,
+        destination: PublicationDestination,
+        /// The accepted observations the client revalidates before the
+        /// rename, as a watch cycle does.
+        inputs: Vec<WatchInput>,
+    },
+}
+
+/// Produce one executable cycle for a service request: the destination
+/// preflight against the accepted-read closure, a cancellable compile, and
+/// the rendering of everything but publication, which belongs to the client.
+pub(crate) fn produce_transport(
+    host: &mut FilesystemCompilerHost,
+    options: &CompileOptions,
+    error_format: ErrorFormat,
+    color: rue_compiler::unstable::ColorChoice,
+    source_path: &str,
+    output_path: &Path,
+    cancellation: CompilationCancellation,
+) -> CycleTransport {
+    let inputs = host.watch_inputs();
+    // An ordinary invocation is never superseded: a newer command does not
+    // cancel an older one merely because they share a root (ADR-0085 §6).
+    let never = || false;
+    let response = produce::<CompileOutput>(
+        host,
+        options,
+        error_format,
+        Some(source_path),
+        output_path,
+        CycleObservation::Watch {
+            inputs,
+            cancellation,
+            superseded: &never,
+        },
+    );
+    response.into_transport(color)
+}
+
+impl OwnedCycleResponse<CompileOutput> {
+    fn into_transport(self, color: rue_compiler::unstable::ColorChoice) -> CycleTransport {
+        let OwnedCycleResponse {
+            source_snapshot,
+            error_format,
+            options,
+            result,
+            ..
+        } = self;
+        let source_infos = source_snapshot
+            .files()
+            .map(|source| {
+                (
+                    source.file_id,
+                    rue_compiler::unstable::SourceInfo::new(source.source, source.path),
+                )
+            })
+            .collect();
+        let diagnostics = DiagnosticOutput::with_color(error_format, source_infos, color);
+        let mut stderr = String::new();
+        // Each rendering is one `eprintln!` in the direct path, so each ends
+        // in exactly one newline here.
+        let mut line = |rendered: String| {
+            stderr.push_str(&rendered);
+            stderr.push('\n');
+        };
+        match result {
+            OwnedCycleResult::Ready {
+                artifact,
+                destination,
+                observation,
+            } => {
+                let inputs = match observation {
+                    PublicationObservation::Watch(inputs) => inputs,
+                    PublicationObservation::OneShot => Vec::new(),
+                };
+                if !artifact.warnings.is_empty() {
+                    line(diagnostics.render_warnings(&artifact.warnings));
+                }
+                CycleTransport {
+                    stderr,
+                    outcome: TransportOutcome::Ready {
+                        target: options.target,
+                        bytes: artifact.elf,
+                        destination,
+                        inputs,
+                    },
+                }
+            }
+            OwnedCycleResult::Failed {
+                errors,
+                publication,
+            } => {
+                if let Some(errors) = errors {
+                    line(diagnostics.render_prepared_errors(&errors));
+                }
+                if let Some(error) = publication {
+                    line(diagnostics.render_error(&error.into_compile_error()));
+                }
+                CycleTransport {
+                    stderr,
+                    outcome: TransportOutcome::Rejected,
+                }
+            }
+            OwnedCycleResult::Superseded(_) | OwnedCycleResult::Canceled => CycleTransport {
+                stderr,
+                outcome: TransportOutcome::Canceled,
+            },
+        }
     }
 }
 

--- a/crates/rue/src/daemon/client.rs
+++ b/crates/rue/src/daemon/client.rs
@@ -1,5 +1,5 @@
-//! The client half of the service protocol: connect, prove identity, and issue
-//! control requests.
+//! The client half of the service protocol: connect, prove identity, issue
+//! control requests, and submit and await builds.
 
 use std::io;
 use std::os::unix::fs::MetadataExt;
@@ -8,8 +8,9 @@ use std::path::Path;
 use std::time::Duration;
 
 use super::protocol::{
-    Hello, HelloReply, MAX_CONTROL_FRAME_BYTES, Request, RequestBody, Response, ResponseBody,
-    ServiceInfo, StatusReport, read_frame, write_frame,
+    BuildReply, BuildRequest, BuildResult, Hello, HelloReply, MAX_CONTROL_FRAME_BYTES,
+    MAX_RESULT_FRAME_BYTES, Request, RequestBody, Response, ResponseBody, ServiceInfo,
+    StatusReport, read_chunks, read_frame, write_frame,
 };
 
 /// Why a connection could not be established or used.
@@ -168,6 +169,109 @@ impl Connection {
             other => Err(unexpected("a stop acknowledgement", &other)),
         }
     }
+
+    /// Submit a build. The answer says whether the service admitted it; an
+    /// admitted build is then awaited with [`Self::await_build`] on this same
+    /// connection, which carries nothing else afterwards.
+    pub fn submit_build(&mut self, request: BuildRequest) -> Result<Submission, SubmitError> {
+        let id = self.next_id;
+        self.next_id += 1;
+        // Until the frame is written the service knows nothing of the
+        // request, so a failure here proves no work began. Once it is
+        // written, a failure is ambiguous: the service may have admitted and
+        // started the request (ADR-0085 §6).
+        write_frame(
+            &mut self.stream,
+            &Request {
+                id,
+                body: RequestBody::Build(Box::new(request)),
+            },
+        )
+        .map_err(|error| SubmitError::BeforeSubmission(ConnectError::Io(error)))?;
+        let response: Response = read_frame(&mut self.stream, MAX_CONTROL_FRAME_BYTES)
+            .map_err(|error| SubmitError::Ambiguous(error.into()))?
+            .ok_or_else(|| {
+                SubmitError::Ambiguous(ConnectError::Protocol(
+                    "the service closed without answering the submission".into(),
+                ))
+            })?;
+        if response.id != id {
+            return Err(SubmitError::Ambiguous(ConnectError::Protocol(format!(
+                "the service answered request {} while {id} was pending",
+                response.id
+            ))));
+        }
+        match response.body {
+            ResponseBody::Accepted {
+                ticket,
+                queued_ahead,
+            } => Ok(Submission::Accepted {
+                ticket,
+                queued_ahead,
+            }),
+            ResponseBody::Rejected { reason } => Ok(Submission::Rejected { reason }),
+            other => Err(SubmitError::Ambiguous(unexpected(
+                "an admission answer",
+                &other,
+            ))),
+        }
+    }
+
+    /// Wait for an admitted build's result and, when it is ready, its linked
+    /// bytes. There is no read timeout: the request may legitimately queue
+    /// and compile for as long as the program takes, and the process ending
+    /// is what cancels it.
+    pub fn await_build(&mut self, ticket: u64) -> Result<(BuildResult, Vec<u8>), ConnectError> {
+        self.stream.set_read_timeout(None)?;
+        let reply: BuildReply = read_frame(&mut self.stream, MAX_RESULT_FRAME_BYTES)?
+            .ok_or_else(|| ConnectError::Protocol("the service closed mid-request".into()))?;
+        if reply.ticket != ticket {
+            return Err(ConnectError::Protocol(format!(
+                "the service answered ticket {} while {ticket} was pending",
+                reply.ticket
+            )));
+        }
+        let bytes = match &reply.result {
+            BuildResult::Ready { bytes, .. } => read_chunks(&mut self.stream, *bytes)?,
+            _ => Vec::new(),
+        };
+        Ok((reply.result, bytes))
+    }
+}
+
+/// Why a submission produced no admission answer.
+#[derive(Debug)]
+pub enum SubmitError {
+    /// The request never reached the service; no work began.
+    BeforeSubmission(ConnectError),
+    /// The request was written but its answer was lost; the service may have
+    /// started it.
+    Ambiguous(ConnectError),
+}
+
+impl std::fmt::Display for SubmitError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BeforeSubmission(error) => write!(formatter, "{error}"),
+            Self::Ambiguous(error) => write!(
+                formatter,
+                "{error} after the request was submitted; whether the service started it is unknown"
+            ),
+        }
+    }
+}
+
+/// The service's admission answer to a build.
+#[derive(Debug)]
+pub enum Submission {
+    Accepted {
+        ticket: u64,
+        queued_ahead: u32,
+    },
+    /// Refused before any work began.
+    Rejected {
+        reason: String,
+    },
 }
 
 fn unexpected(expected: &str, actual: &ResponseBody) -> ConnectError {

--- a/crates/rue/src/daemon/mod.rs
+++ b/crates/rue/src/daemon/mod.rs
@@ -30,8 +30,12 @@ use std::time::{Duration, Instant};
 use sha2::{Digest, Sha256};
 
 use crate::running_image::{RunningImageIdentity, running_image_identity};
-pub use protocol::{DAEMON_PROTOCOL_VERSION, IdentityRecord, ServiceInfo, StatusReport};
-pub use service::ServeExit;
+pub use client::{ConnectError, Connection, Submission, SubmitError};
+pub use protocol::{
+    BuildRequest, BuildResult, CrashRecord, DAEMON_PROTOCOL_VERSION, DestinationRecord,
+    DiagnosticFormat, IdentityRecord, InputRecord, RequestSummary, ServiceInfo, StatusReport,
+};
+pub use service::{BuildExecutor, BuildOutput, MAX_QUEUED_REQUESTS, ServeExit};
 
 /// How long an idle service lives by default before retiring itself. A
 /// calibrated policy belongs to the qualification phase (ADR-0085 §7); this is
@@ -425,6 +429,14 @@ impl Endpoint {
     /// Remove the socket and record a dead service left behind. Only valid
     /// while the caller holds proof nobody is alive (the service lock, or the
     /// startup lock plus a free service lock).
+    /// The record a service left when a compiler panic ended it, if any. A
+    /// crash record outlives the service it describes so the client whose
+    /// request it ended can still read it; the next crash overwrites it.
+    pub fn crash_record(&self) -> Option<CrashRecord> {
+        let bytes = fs::read(self.directory.join(service::CRASH_RECORD_FILE)).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
     fn clear_stale(&self) -> Result<(), DaemonError> {
         for path in [&self.socket, &self.record] {
             match fs::remove_file(path) {
@@ -588,6 +600,31 @@ pub fn start(
     options: &StartOptions,
     launcher: &dyn ServiceLauncher,
 ) -> Result<StartOutcome, DaemonError> {
+    let started = start_connection(scope, root, options, launcher)?;
+    Ok(StartOutcome {
+        service: started.connection.service().clone(),
+        launched: started.launched,
+    })
+}
+
+/// A live, identity-checked connection to the service `start_connection`
+/// used or launched, ready to carry one build.
+pub struct StartedConnection {
+    pub connection: Connection,
+    pub launched: bool,
+    /// The endpoint the service holds, where a crash record would be found.
+    pub endpoint: Endpoint,
+}
+
+/// [`start`], keeping the handshake's connection for the caller's request
+/// instead of closing it: the client that compiles through the service
+/// submits on the very connection that proved the service is the right one.
+pub fn start_connection(
+    scope: DaemonScope,
+    root: &EndpointRoot,
+    options: &StartOptions,
+    launcher: &dyn ServiceLauncher,
+) -> Result<StartedConnection, DaemonError> {
     let identity = ServiceIdentity::current(scope)?;
     let endpoint = Endpoint::prepare(root, &identity)?;
     let began = Instant::now();
@@ -602,9 +639,10 @@ pub fn start(
     loop {
         match probe(&endpoint, &identity)? {
             Probe::Live(connection) => {
-                return Ok(StartOutcome {
-                    service: connection.service().clone(),
+                return Ok(StartedConnection {
+                    connection: *connection,
                     launched: launched.is_some(),
+                    endpoint,
                 });
             }
             Probe::Absent => match launched.as_mut() {
@@ -723,14 +761,17 @@ pub fn serve(
     scope: DaemonScope,
     root: &EndpointRoot,
     idle_timeout: Duration,
+    executor: Box<dyn BuildExecutor>,
 ) -> Result<ServeExit, DaemonError> {
     let identity = ServiceIdentity::current(scope)?;
     let endpoint = Endpoint::prepare(root, &identity)?;
     let Some(_service_lock) = FileLock::try_exclusive(&endpoint.service_lock)? else {
         return Ok(ServeExit::AlreadyRunning);
     };
-    // Holding the service lock proves whatever socket is there is dead.
+    // Holding the service lock proves whatever socket is there is dead, and
+    // that any crash record there describes a service that is gone.
     endpoint.clear_stale()?;
+    service::install_panic_recorder(endpoint.directory.clone());
     let listener = std::os::unix::net::UnixListener::bind(&endpoint.socket).map_err(|error| {
         DaemonError::io(format!("binding {}", endpoint.socket.display()), error)
     })?;
@@ -747,7 +788,7 @@ pub fn serve(
         started_at_unix_ms: unix_millis(),
     };
     write_record(&endpoint, &info)?;
-    let exit = service::run(listener, info, idle_timeout);
+    let exit = service::run(listener, info, idle_timeout, executor);
     endpoint.clear_stale()?;
     Ok(exit)
 }

--- a/crates/rue/src/daemon/protocol.rs
+++ b/crates/rue/src/daemon/protocol.rs
@@ -21,6 +21,17 @@ pub const DAEMON_PROTOCOL_VERSION: u32 = 1;
 /// peer, and the connection is dropped instead of allocating for it.
 pub const MAX_CONTROL_FRAME_BYTES: usize = 1 << 20;
 
+/// The largest result frame a client accepts. A result carries the rendered
+/// diagnostics of one request, which a pathological program can make large;
+/// linked bytes never travel inside it.
+pub const MAX_RESULT_FRAME_BYTES: usize = 64 << 20;
+
+/// The largest raw chunk of linked bytes either side sends or accepts. The
+/// result frame announces the total, so a reader knows how many chunks to
+/// expect and never holds more than one unread chunk beyond the bytes it has
+/// already accepted.
+pub const MAX_CHUNK_BYTES: usize = 4 << 20;
+
 /// Why a frame could not be read.
 #[derive(Debug)]
 pub enum FrameError {
@@ -94,6 +105,73 @@ pub fn read_frame<T: DeserializeOwned>(
         .map_err(|error| FrameError::Malformed(error.to_string()))
 }
 
+/// Write one raw byte chunk as a frame: the same length prefix, an opaque body.
+pub fn write_bytes_frame(stream: &mut impl Write, bytes: &[u8]) -> io::Result<()> {
+    let length = u32::try_from(bytes.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "a frame cannot exceed 4 GiB"))?;
+    stream.write_all(&length.to_be_bytes())?;
+    stream.write_all(bytes)?;
+    stream.flush()
+}
+
+/// Read one raw byte chunk, or `None` when the peer closed the connection
+/// cleanly between frames. A chunk longer than `limit` is refused before any
+/// of its body is read.
+pub fn read_bytes_frame(
+    stream: &mut impl Read,
+    limit: usize,
+) -> Result<Option<Vec<u8>>, FrameError> {
+    let mut header = [0u8; 4];
+    match stream.read_exact(&mut header) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(FrameError::Io(error)),
+    }
+    let announced = u32::from_be_bytes(header) as usize;
+    if announced > limit {
+        return Err(FrameError::Oversized { announced, limit });
+    }
+    let mut body = vec![0u8; announced];
+    stream.read_exact(&mut body).map_err(|error| {
+        if error.kind() == io::ErrorKind::UnexpectedEof {
+            FrameError::Truncated
+        } else {
+            FrameError::Io(error)
+        }
+    })?;
+    Ok(Some(body))
+}
+
+/// Write `bytes` as a sequence of bounded chunks. The receiver knows the
+/// total from the result frame that preceded them.
+pub fn write_chunks(stream: &mut impl Write, bytes: &[u8]) -> io::Result<()> {
+    for chunk in bytes.chunks(MAX_CHUNK_BYTES) {
+        write_bytes_frame(stream, chunk)?;
+    }
+    Ok(())
+}
+
+/// Read exactly `total` bytes sent as bounded chunks.
+pub fn read_chunks(stream: &mut impl Read, total: u64) -> Result<Vec<u8>, FrameError> {
+    let total = usize::try_from(total).map_err(|_| FrameError::Oversized {
+        announced: usize::MAX,
+        limit: usize::MAX,
+    })?;
+    let mut bytes = Vec::with_capacity(total.min(MAX_CHUNK_BYTES));
+    while bytes.len() < total {
+        let remaining = total - bytes.len();
+        let chunk = read_bytes_frame(stream, MAX_CHUNK_BYTES.min(remaining))?
+            .ok_or(FrameError::Truncated)?;
+        if chunk.is_empty() {
+            return Err(FrameError::Malformed(
+                "an empty chunk inside a transfer".into(),
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
 /// The running compiler image and service scope a peer claims, in a form
 /// both ends can compare byte for byte.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -151,6 +229,55 @@ pub enum RequestBody {
     /// End the service. It answers [`ResponseBody::Stopping`] and then exits;
     /// the caller observes completion by the socket disappearing.
     Stop,
+    /// Compile an executable through the service's retained host (ADR-0085
+    /// §3, §5). The service answers [`ResponseBody::Accepted`] or
+    /// [`ResponseBody::Rejected`] before any work begins; an accepted request
+    /// is followed on the same connection by one [`BuildReply`] frame and,
+    /// when it carries linked bytes, by those bytes in raw chunks. The
+    /// connection then carries nothing else.
+    Build(Box<BuildRequest>),
+}
+
+/// How the client wants diagnostics rendered. The service renders once with
+/// the canonical formatter under the client's own policy, so the text on the
+/// client's stderr is byte for byte what a direct compile would have written.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticFormat {
+    Text,
+    Json,
+}
+
+/// An executable build captured at the client boundary (ADR-0085 §3): every
+/// path is carried as the command line spelled it together with the
+/// directory it was spelled in, so the service resolves it exactly as the
+/// client's own process would have, without ever changing its own cwd.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BuildRequest {
+    /// The client's invocation directory.
+    pub working_directory: String,
+    /// The root source as written.
+    pub root_source: String,
+    /// The output path as written.
+    pub output_path: String,
+    /// `--source-manifest` as written.
+    pub source_manifest_path: Option<String>,
+    /// `RUE_STD_PATH` as captured; `None` when unset, `Some("")` when empty,
+    /// each keeping its direct-mode meaning.
+    pub std_root: Option<String>,
+    /// Compiler workers; `0` selects the automatic policy.
+    pub workers: usize,
+    /// The target name as `Target` prints it.
+    pub target: String,
+    /// The optimization level as `-O<n>` spells it, without the `-O`.
+    pub opt_level: String,
+    /// Preview feature names, as `--preview` accepts them.
+    pub preview_features: Vec<String>,
+    /// `--link-archive` paths anchored at the working directory.
+    pub link_archives: Vec<String>,
+    pub error_format: DiagnosticFormat,
+    /// Whether the client's stderr wants color.
+    pub color: bool,
 }
 
 /// One response, carrying the id of the request it answers.
@@ -164,15 +291,104 @@ pub struct Response {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ResponseBody {
     Pong,
-    Status { report: Box<StatusReport> },
+    Status {
+        report: Box<StatusReport>,
+    },
     Stopping,
-    Error { message: String },
+    Error {
+        message: String,
+    },
+    /// The build was admitted. `ticket` names it service-wide, which is how a
+    /// client attributes a crash record to its own request; `queued_ahead`
+    /// is how many admitted requests precede it.
+    Accepted {
+        ticket: u64,
+        queued_ahead: u32,
+    },
+    /// The build was refused before any work began, so the client may run it
+    /// directly (ADR-0085 §6).
+    Rejected {
+        reason: String,
+    },
+}
+
+/// The one result frame an accepted build produces.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BuildReply {
+    pub ticket: u64,
+    pub result: BuildResult,
+}
+
+/// How an accepted build ended. `stderr` is everything the direct compile
+/// would have written to its diagnostic stream up to the point where the
+/// client takes over: source-load failures, program diagnostics, a refused
+/// destination, or the warnings of a successful compile.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BuildResult {
+    /// The program was rejected or the destination refused; nothing to publish.
+    Rejected { stderr: String },
+    /// The executable is linked. `bytes` raw chunk bytes follow this frame;
+    /// the client publishes them at `destination` after revalidating
+    /// `inputs`, exactly as a watch cycle does.
+    Ready {
+        stderr: String,
+        target: String,
+        destination: DestinationRecord,
+        inputs: Vec<InputRecord>,
+        bytes: u64,
+    },
+    /// The request's cancellation was observed; nothing was produced.
+    Canceled,
+    /// The service could not run the request. `internal` marks a compiler
+    /// defect (an internal compiler error) as opposed to an infrastructure
+    /// failure.
+    Failed { message: String, internal: bool },
+}
+
+/// The publication destination as the service's preflight validated it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DestinationRecord {
+    pub path: String,
+    pub display_path: String,
+    pub source_paths: Vec<String>,
+}
+
+/// One accepted filesystem observation, in the shape the watch publication
+/// guard revalidates before the rename.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InputRecord {
+    pub requested_path: String,
+    pub canonical_path: String,
+    /// `None` records an expected absence.
+    pub fingerprint: Option<u64>,
+    pub symlink_boundary: Option<String>,
+    /// `(volume, file)` identities along the expected symlink route.
+    pub symlink_route: Vec<(u64, u64)>,
+}
+
+/// A request the service is executing or holding, as status reports it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestSummary {
+    pub ticket: u64,
+    pub root_source: String,
+    pub working_directory: String,
+    pub elapsed_ms: u64,
+}
+
+/// What a service records when a compiler panic ends it during a request, so
+/// the client whose request it was can report the defect (ADR-0085 §6).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrashRecord {
+    pub pid: u32,
+    /// The request that was active, if any.
+    pub ticket: Option<u64>,
+    pub message: String,
+    pub location: Option<String>,
 }
 
 /// What `rue daemon status` reports (ADR-0085 §2): identity, PID, scope,
 /// active request, queue, retained hosts, and the resource policy in force.
-/// The request and host fields are structural placeholders until the service
-/// executes compiler requests; a status consumer sees the same shape then.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StatusReport {
     pub service: ServiceInfo,
@@ -180,7 +396,7 @@ pub struct StatusReport {
     pub idle_timeout_ms: u64,
     /// Connections open right now, this one included.
     pub connections: u32,
-    pub active_request: Option<String>,
+    pub active_request: Option<RequestSummary>,
     pub queued_requests: u32,
     pub retained_hosts: u32,
 }
@@ -255,6 +471,29 @@ mod tests {
         wire.truncate(wire.len() - 3);
         let mut reader = wire.as_slice();
         let error = read_frame::<Hello>(&mut reader, MAX_CONTROL_FRAME_BYTES).unwrap_err();
+        assert!(matches!(error, FrameError::Truncated), "{error}");
+    }
+
+    #[test]
+    fn chunked_bytes_round_trip_under_the_chunk_bound() {
+        let bytes: Vec<u8> = (0..(2 * MAX_CHUNK_BYTES + 17)).map(|i| i as u8).collect();
+        let mut wire = Vec::new();
+        write_chunks(&mut wire, &bytes).unwrap();
+        // Three chunks: two full, one of 17 bytes.
+        assert_eq!(wire.len(), bytes.len() + 3 * 4);
+        let mut reader = wire.as_slice();
+        assert_eq!(read_chunks(&mut reader, bytes.len() as u64).unwrap(), bytes);
+
+        let mut wire = Vec::new();
+        write_bytes_frame(&mut wire, &vec![1u8; MAX_CHUNK_BYTES + 1]).unwrap();
+        let mut reader = wire.as_slice();
+        let error = read_chunks(&mut reader, (MAX_CHUNK_BYTES + 1) as u64).unwrap_err();
+        assert!(matches!(error, FrameError::Oversized { .. }), "{error}");
+
+        let mut wire = Vec::new();
+        write_chunks(&mut wire, &[1, 2, 3]).unwrap();
+        let mut reader = wire.as_slice();
+        let error = read_chunks(&mut reader, 5).unwrap_err();
         assert!(matches!(error, FrameError::Truncated), "{error}");
     }
 

--- a/crates/rue/src/daemon/service.rs
+++ b/crates/rue/src/daemon/service.rs
@@ -1,24 +1,30 @@
 //! The service loop: accept connections, verify the peer, answer control
-//! requests, and retire on stop or idleness.
+//! requests, run build requests through one compiler owner, and retire on
+//! stop or idleness.
 //!
 //! Control messages must stay serviceable while compiler work runs
 //! (ADR-0085 §6), so every connection is handled on its own thread and the
-//! accept loop never blocks on one. The compiler owner and its admission queue
-//! arrive with request execution; the loop here is shaped for them: one shared
-//! state, connection threads that only submit and wait, and a stop flag every
-//! thread observes.
+//! accept loop never blocks on one. Compiler work is another matter: exactly
+//! one request compiles at a time, on the owner thread that holds the
+//! retained host, and admitted requests wait in a bounded FIFO queue. A
+//! connection thread only submits, watches its peer for disconnection, and
+//! relays the owner's answer.
 
 use std::io;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::sync::{Arc, Mutex};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use rue_compiler::unstable::CompilationCancellation;
+
 use super::protocol::{
-    DAEMON_PROTOCOL_VERSION, Hello, HelloReply, MAX_CONTROL_FRAME_BYTES, Request, RequestBody,
-    Response, ResponseBody, ServiceInfo, StatusReport, read_frame, write_frame,
+    BuildReply, BuildRequest, BuildResult, CrashRecord, DAEMON_PROTOCOL_VERSION, Hello, HelloReply,
+    MAX_CONTROL_FRAME_BYTES, Request, RequestBody, RequestSummary, Response, ResponseBody,
+    ServiceInfo, StatusReport, read_frame, write_chunks, write_frame,
 };
 
 /// Why the service loop returned.
@@ -36,6 +42,64 @@ pub enum ServeExit {
 const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(5);
 /// How often the accept loop wakes to check for stop and idleness.
 const ACCEPT_POLL: Duration = Duration::from_millis(25);
+/// How many admitted requests may wait for the compiler owner. One compiles;
+/// this many more are accepted; the next is rejected before any work so its
+/// client may compile directly (ADR-0085 §6).
+pub const MAX_QUEUED_REQUESTS: u32 = 8;
+
+/// The name of the file a service writes when a compiler panic ends it.
+pub(super) const CRASH_RECORD_FILE: &str = "crash.json";
+
+/// What executes admitted build requests: the retained-host compile path the
+/// command-line driver supplies. The service owns the queue, the connection,
+/// and the cancellation; the executor owns the compiler.
+pub trait BuildExecutor: Send {
+    /// Run one request to its owned result. The executor observes
+    /// `cancellation` through the compiler's own checkpoints and reports
+    /// [`BuildResult::Canceled`] when it fires.
+    fn build(
+        &mut self,
+        request: &BuildRequest,
+        cancellation: &CompilationCancellation,
+    ) -> BuildOutput;
+
+    /// How many compiler hosts the executor retains right now.
+    fn retained_hosts(&self) -> u32;
+}
+
+/// An executor's answer: the result frame and the bytes that follow it when
+/// the result is [`BuildResult::Ready`].
+pub struct BuildOutput {
+    pub result: BuildResult,
+    pub bytes: Vec<u8>,
+}
+
+impl BuildOutput {
+    pub fn failed(message: impl Into<String>) -> Self {
+        Self {
+            result: BuildResult::Failed {
+                message: message.into(),
+                internal: false,
+            },
+            bytes: Vec::new(),
+        }
+    }
+}
+
+/// One admitted request on its way to the compiler owner.
+struct Job {
+    ticket: u64,
+    request: BuildRequest,
+    cancellation: CompilationCancellation,
+    reply: mpsc::Sender<BuildOutput>,
+}
+
+struct ActiveRequest {
+    ticket: u64,
+    root_source: String,
+    working_directory: String,
+    started: Instant,
+}
 
 struct Shared {
     info: ServiceInfo,
@@ -44,7 +108,19 @@ struct Shared {
     stop: AtomicBool,
     connections: AtomicU32,
     last_activity: Mutex<Instant>,
+    /// Where admitted jobs go; `None` once the service is stopping, so a late
+    /// request is rejected rather than accepted and abandoned.
+    jobs: Mutex<Option<mpsc::Sender<Job>>>,
+    next_ticket: AtomicU64,
+    /// Admitted requests the owner has not started yet.
+    queued: AtomicU32,
+    active: Mutex<Option<ActiveRequest>>,
+    retained_hosts: AtomicU32,
 }
+
+/// The ticket of the request the compiler owner is executing, `0` when none,
+/// read by the panic recorder so a crash names the request it ended.
+static ACTIVE_TICKET: AtomicU64 = AtomicU64::new(0);
 
 impl Shared {
     fn touch(&self) {
@@ -62,21 +138,48 @@ impl Shared {
     }
 
     fn report(&self) -> StatusReport {
+        let active = self
+            .active
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_ref()
+            .map(|active| RequestSummary {
+                ticket: active.ticket,
+                root_source: active.root_source.clone(),
+                working_directory: active.working_directory.clone(),
+                elapsed_ms: active.started.elapsed().as_millis() as u64,
+            });
         StatusReport {
             service: self.info.clone(),
             uptime_ms: self.started.elapsed().as_millis() as u64,
             idle_timeout_ms: self.idle_timeout.as_millis() as u64,
             connections: self.connections.load(Ordering::Acquire),
-            active_request: None,
-            queued_requests: 0,
-            retained_hosts: 0,
+            active_request: active,
+            queued_requests: self.queued.load(Ordering::Acquire),
+            retained_hosts: self.retained_hosts.load(Ordering::Acquire),
         }
+    }
+
+    fn set_active(&self, active: Option<ActiveRequest>) {
+        ACTIVE_TICKET.store(
+            active.as_ref().map_or(0, |active| active.ticket),
+            Ordering::Release,
+        );
+        *self
+            .active
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = active;
     }
 }
 
 /// Serve `listener` until stopped or idle. The listener is already bound and
 /// secured; the caller owns the endpoint lock for the whole call.
-pub(super) fn run(listener: UnixListener, info: ServiceInfo, idle_timeout: Duration) -> ServeExit {
+pub(super) fn run(
+    listener: UnixListener,
+    info: ServiceInfo,
+    idle_timeout: Duration,
+    executor: Box<dyn BuildExecutor>,
+) -> ServeExit {
     // A client that vanishes mid-write must be a failed connection, never a
     // dead service.
     // SAFETY: changing this process's SIGPIPE disposition has no preconditions.
@@ -86,6 +189,7 @@ pub(super) fn run(listener: UnixListener, info: ServiceInfo, idle_timeout: Durat
     if listener.set_nonblocking(true).is_err() {
         return ServeExit::Idle;
     }
+    let (jobs, queue) = mpsc::channel::<Job>();
     let shared = Arc::new(Shared {
         info,
         started: Instant::now(),
@@ -93,11 +197,20 @@ pub(super) fn run(listener: UnixListener, info: ServiceInfo, idle_timeout: Durat
         stop: AtomicBool::new(false),
         connections: AtomicU32::new(0),
         last_activity: Mutex::new(Instant::now()),
+        jobs: Mutex::new(Some(jobs)),
+        next_ticket: AtomicU64::new(0),
+        queued: AtomicU32::new(0),
+        active: Mutex::new(None),
+        retained_hosts: AtomicU32::new(executor.retained_hosts()),
     });
+    let owner = {
+        let shared = Arc::clone(&shared);
+        thread::spawn(move || compiler_owner(queue, executor, &shared))
+    };
     let mut handlers: Vec<thread::JoinHandle<()>> = Vec::new();
-    loop {
+    let exit = loop {
         if shared.stop.load(Ordering::Acquire) {
-            break;
+            break ServeExit::Stopped;
         }
         match listener.accept() {
             Ok((stream, _)) => {
@@ -110,19 +223,109 @@ pub(super) fn run(listener: UnixListener, info: ServiceInfo, idle_timeout: Durat
                 if shared.connections.load(Ordering::Acquire) == 0
                     && shared.idle_for() >= shared.idle_timeout
                 {
-                    return ServeExit::Idle;
+                    break ServeExit::Idle;
                 }
                 thread::sleep(ACCEPT_POLL);
             }
             Err(_) => thread::sleep(ACCEPT_POLL),
         }
-    }
-    // Let the stopping client's acknowledgement and any other in-flight
-    // control reply finish before the endpoint is torn down.
+    };
+    // No further admissions; the owner drains what was admitted (answering
+    // it as a stopping service) and ends when the last sender is gone.
+    shared.stop.store(true, Ordering::Release);
+    drop(
+        shared
+            .jobs
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .take(),
+    );
+    // Let the stopping client's acknowledgement, every in-flight control
+    // reply, and the active request's answer finish before the endpoint is
+    // torn down.
     for handle in handlers {
         let _ = handle.join();
     }
-    ServeExit::Stopped
+    let _ = owner.join();
+    exit
+}
+
+/// The compiler owner: one request at a time, in admission order.
+fn compiler_owner(
+    queue: mpsc::Receiver<Job>,
+    mut executor: Box<dyn BuildExecutor>,
+    shared: &Shared,
+) {
+    for job in queue {
+        shared.queued.fetch_sub(1, Ordering::AcqRel);
+        if shared.stop.load(Ordering::Acquire) {
+            let _ = job
+                .reply
+                .send(BuildOutput::failed("the compiler service is stopping"));
+            continue;
+        }
+        if job.cancellation.is_canceled() {
+            // The client left before its turn: cancel queued work without
+            // starting it (ADR-0085 §6).
+            let _ = job.reply.send(BuildOutput {
+                result: BuildResult::Canceled,
+                bytes: Vec::new(),
+            });
+            continue;
+        }
+        shared.set_active(Some(ActiveRequest {
+            ticket: job.ticket,
+            root_source: job.request.root_source.clone(),
+            working_directory: job.request.working_directory.clone(),
+            started: Instant::now(),
+        }));
+        let output = executor.build(&job.request, &job.cancellation);
+        shared.set_active(None);
+        shared
+            .retained_hosts
+            .store(executor.retained_hosts(), Ordering::Release);
+        shared.touch();
+        let _ = job.reply.send(output);
+    }
+}
+
+/// Install a panic hook that records the panic, and the request it ended,
+/// beside the endpoint before the process aborts (ADR-0085 §6). The compiler
+/// is built to abort on panic, so the record is the only account the request's
+/// client can get of what happened.
+pub(super) fn install_panic_recorder(directory: PathBuf) {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let ticket = ACTIVE_TICKET.load(Ordering::Acquire);
+        let record = CrashRecord {
+            pid: std::process::id(),
+            ticket: (ticket != 0).then_some(ticket),
+            message: panic_message(info.payload()),
+            location: info.location().map(|location| location.to_string()),
+        };
+        write_crash_record(&directory, &record);
+        previous(info);
+    }));
+}
+
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "panic with a non-string payload".to_string()
+    }
+}
+
+fn write_crash_record(directory: &Path, record: &CrashRecord) {
+    let Ok(body) = serde_json::to_vec_pretty(record) else {
+        return;
+    };
+    let pending = directory.join(format!("{CRASH_RECORD_FILE}.pending"));
+    if std::fs::write(&pending, body).is_ok() {
+        let _ = std::fs::rename(&pending, directory.join(CRASH_RECORD_FILE));
+    }
 }
 
 /// A connection counted for the whole time its thread runs.
@@ -180,8 +383,8 @@ fn handle_connection(stream: UnixStream, shared: &Shared) {
     {
         return;
     }
-    // Requests may legitimately wait: a later compile request holds the
-    // connection for its whole run.
+    // Requests may legitimately wait: a build request holds the connection
+    // for its whole run.
     if stream.set_read_timeout(None).is_err() {
         return;
     }
@@ -200,6 +403,11 @@ fn handle_connection(stream: UnixStream, shared: &Shared) {
                 false,
             ),
             RequestBody::Stop => (ResponseBody::Stopping, true),
+            RequestBody::Build(build) => {
+                // A build is the last thing a connection carries.
+                serve_build(stream, request.id, *build, shared);
+                return;
+            }
         };
         let written = write_frame(
             &mut stream,
@@ -215,6 +423,113 @@ fn handle_connection(stream: UnixStream, shared: &Shared) {
         if written.is_err() {
             return;
         }
+    }
+}
+
+/// Admit or reject one build, then relay the owner's answer. Between the two,
+/// a watcher thread reads the connection so a client that disconnects trips
+/// the request's cancellation whether it is queued or compiling.
+fn serve_build(mut stream: UnixStream, request_id: u64, request: BuildRequest, shared: &Shared) {
+    let sender = shared
+        .jobs
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    let refuse = |stream: &mut UnixStream, reason: String| {
+        let _ = write_frame(
+            stream,
+            &Response {
+                id: request_id,
+                body: ResponseBody::Rejected { reason },
+            },
+        );
+    };
+    let Some(sender) = sender else {
+        refuse(&mut stream, "the compiler service is stopping".into());
+        return;
+    };
+    // Reserve a queue place before answering, so two connections cannot both
+    // be admitted into the last one.
+    let mut queued_before = shared.queued.load(Ordering::Acquire);
+    loop {
+        if queued_before >= MAX_QUEUED_REQUESTS {
+            refuse(
+                &mut stream,
+                format!("the compiler service already has {MAX_QUEUED_REQUESTS} requests waiting"),
+            );
+            return;
+        }
+        match shared.queued.compare_exchange(
+            queued_before,
+            queued_before + 1,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => break,
+            Err(current) => queued_before = current,
+        }
+    }
+    let ticket = shared.next_ticket.fetch_add(1, Ordering::AcqRel) + 1;
+    let active = u32::from(
+        shared
+            .active
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .is_some(),
+    );
+    let cancellation = CompilationCancellation::new();
+    let (reply, answer) = mpsc::channel();
+    let job = Job {
+        ticket,
+        request,
+        cancellation: cancellation.clone(),
+        reply,
+    };
+    if sender.send(job).is_err() {
+        shared.queued.fetch_sub(1, Ordering::AcqRel);
+        refuse(&mut stream, "the compiler service is stopping".into());
+        return;
+    }
+    if write_frame(
+        &mut stream,
+        &Response {
+            id: request_id,
+            body: ResponseBody::Accepted {
+                ticket,
+                queued_ahead: queued_before + active,
+            },
+        },
+    )
+    .is_err()
+    {
+        cancellation.cancel();
+        return;
+    }
+    // The client sends nothing more until it has its answer, so the next
+    // thing the watcher reads is the end of the connection.
+    if let Ok(mut reader) = stream.try_clone() {
+        let cancellation = cancellation.clone();
+        thread::spawn(move || {
+            loop {
+                match read_frame::<Request>(&mut reader, MAX_CONTROL_FRAME_BYTES) {
+                    Ok(Some(_)) => continue,
+                    Ok(None) | Err(_) => break,
+                }
+            }
+            cancellation.cancel();
+        });
+    }
+    let output = match answer.recv() {
+        Ok(output) => output,
+        Err(_) => BuildOutput::failed("the compiler service ended before answering"),
+    };
+    let BuildOutput { result, bytes } = output;
+    let ready = matches!(result, BuildResult::Ready { .. });
+    if write_frame(&mut stream, &BuildReply { ticket, result }).is_err() {
+        return;
+    }
+    if ready {
+        let _ = write_chunks(&mut stream, &bytes);
     }
 }
 

--- a/crates/rue/src/daemon/tests.rs
+++ b/crates/rue/src/daemon/tests.rs
@@ -2,10 +2,12 @@ use std::fs;
 use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
+
+use rue_compiler::unstable::CompilationCancellation;
 
 use super::*;
 
@@ -14,13 +16,96 @@ use super::*;
 /// services were brought up.
 struct ThreadLauncher {
     launches: Arc<AtomicUsize>,
+    stub: Arc<Stub>,
 }
 
 impl ThreadLauncher {
     fn new() -> Self {
+        Self::with_stub(Stub::default())
+    }
+
+    fn with_stub(stub: Stub) -> Self {
         Self {
             launches: Arc::new(AtomicUsize::new(0)),
+            stub: Arc::new(stub),
         }
+    }
+}
+
+/// What the in-process service's executor does with a build: answer with
+/// bytes right away, or hold the request until it is canceled or released.
+#[derive(Default)]
+struct Stub {
+    /// Builds the executor has started.
+    started: AtomicUsize,
+    /// Builds that ended because their cancellation fired.
+    canceled: AtomicUsize,
+    /// Hold every build until `release` is set or the request is canceled.
+    hold: AtomicBool,
+    release: AtomicBool,
+}
+
+struct StubExecutor(Arc<Stub>);
+
+impl BuildExecutor for StubExecutor {
+    fn build(
+        &mut self,
+        request: &BuildRequest,
+        cancellation: &CompilationCancellation,
+    ) -> BuildOutput {
+        self.0.started.fetch_add(1, Ordering::AcqRel);
+        while self.0.hold.load(Ordering::Acquire) && !self.0.release.load(Ordering::Acquire) {
+            if cancellation.is_canceled() {
+                self.0.canceled.fetch_add(1, Ordering::AcqRel);
+                return BuildOutput {
+                    result: BuildResult::Canceled,
+                    bytes: Vec::new(),
+                };
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        // A deterministic payload longer than one chunk, so the transfer is
+        // exercised, derived from the request so a client can check it got
+        // its own answer.
+        let seed = request.root_source.len() as u8;
+        let bytes: Vec<u8> = (0..(protocol::MAX_CHUNK_BYTES + 3))
+            .map(|i| (i as u8).wrapping_add(seed))
+            .collect();
+        BuildOutput {
+            result: BuildResult::Ready {
+                stderr: format!("warning: stub built {}\n", request.root_source),
+                target: request.target.clone(),
+                destination: DestinationRecord {
+                    path: request.output_path.clone(),
+                    display_path: request.output_path.clone(),
+                    source_paths: vec![request.root_source.clone()],
+                },
+                inputs: Vec::new(),
+                bytes: bytes.len() as u64,
+            },
+            bytes,
+        }
+    }
+
+    fn retained_hosts(&self) -> u32 {
+        1
+    }
+}
+
+fn build_request(root_source: &str) -> BuildRequest {
+    BuildRequest {
+        working_directory: "/w".into(),
+        root_source: root_source.into(),
+        output_path: "out".into(),
+        source_manifest_path: None,
+        std_root: None,
+        workers: 1,
+        target: "x86_64-linux".into(),
+        opt_level: "0".into(),
+        preview_features: Vec::new(),
+        link_archives: Vec::new(),
+        error_format: DiagnosticFormat::Text,
+        color: false,
     }
 }
 
@@ -47,8 +132,9 @@ impl ServiceLauncher for ThreadLauncher {
         let scope = plan.scope.clone();
         let root = plan.root.clone();
         let idle_timeout = plan.idle_timeout;
+        let stub = Arc::clone(&self.stub);
         Ok(Box::new(LaunchedThread(Some(thread::spawn(move || {
-            serve(scope, &root, idle_timeout)
+            serve(scope, &root, idle_timeout, Box::new(StubExecutor(stub)))
         })))))
     }
 }
@@ -226,7 +312,7 @@ fn start_status_and_stop_round_trip() {
     assert_eq!(report.service, started.service);
     assert!(report.connections >= 1, "the status connection counts");
     assert_eq!(report.active_request, None);
-    assert_eq!(report.retained_hosts, 0);
+    assert_eq!(report.retained_hosts, 1);
     assert_eq!(report.idle_timeout_ms, 60_000);
 
     let again = start(
@@ -404,7 +490,14 @@ fn an_idle_service_retires_itself_and_clears_its_endpoint() {
     let fixture = Fixture::new();
     let scope = fixture.scope();
     let root = fixture.root.clone();
-    let server = thread::spawn(move || serve(scope, &root, Duration::from_millis(1500)));
+    let server = thread::spawn(move || {
+        serve(
+            scope,
+            &root,
+            Duration::from_millis(1500),
+            Box::new(StubExecutor(Arc::new(Stub::default()))),
+        )
+    });
     let identity = ServiceIdentity::current(fixture.scope()).unwrap();
     let endpoint = Endpoint::locate(&fixture.root, &identity).unwrap();
     assert!(wait_until(Duration::from_secs(10), || status(
@@ -430,10 +523,186 @@ fn a_second_server_on_a_held_endpoint_yields() {
     )
     .unwrap();
     assert_eq!(
-        serve(fixture.scope(), &fixture.root, Duration::from_secs(60)).unwrap(),
+        serve(
+            fixture.scope(),
+            &fixture.root,
+            Duration::from_secs(60),
+            Box::new(StubExecutor(Arc::new(Stub::default()))),
+        )
+        .unwrap(),
         ServeExit::AlreadyRunning
     );
     let report = status(fixture.scope(), &fixture.root).unwrap().unwrap();
     assert_eq!(report.service.pid, std::process::id());
     stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap();
+}
+
+#[test]
+fn a_build_is_admitted_answered_and_its_bytes_streamed() {
+    let fixture = Fixture::new();
+    let launcher = ThreadLauncher::new();
+    let mut started = start_connection(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    let submission = started
+        .connection
+        .submit_build(build_request("main.rue"))
+        .unwrap();
+    let Submission::Accepted {
+        ticket,
+        queued_ahead,
+    } = submission
+    else {
+        panic!("a quiet service admits a build: {submission:?}");
+    };
+    assert_eq!(queued_ahead, 0);
+    let (result, bytes) = started.connection.await_build(ticket).unwrap();
+    let BuildResult::Ready {
+        stderr,
+        bytes: announced,
+        destination,
+        ..
+    } = result
+    else {
+        panic!("the stub answers ready: {result:?}");
+    };
+    assert_eq!(stderr, "warning: stub built main.rue\n");
+    assert_eq!(announced, bytes.len() as u64);
+    assert_eq!(bytes.len(), protocol::MAX_CHUNK_BYTES + 3);
+    assert_eq!(bytes[0], "main.rue".len() as u8);
+    assert_eq!(destination.path, "out");
+    assert_eq!(launcher.stub.started.load(Ordering::Acquire), 1);
+    drop(started);
+
+    let report = status(fixture.scope(), &fixture.root)
+        .unwrap()
+        .expect("the service is still up");
+    assert_eq!(report.active_request, None);
+    assert_eq!(report.queued_requests, 0);
+    stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap();
+}
+
+#[test]
+fn admission_is_bounded_and_a_departed_client_cancels_its_request() {
+    let fixture = Fixture::new();
+    let stub = Stub::default();
+    stub.hold.store(true, Ordering::Release);
+    let launcher = ThreadLauncher::with_stub(stub);
+    // One active build, held by the stub.
+    let mut active = start_connection(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    let Submission::Accepted {
+        ticket: active_ticket,
+        ..
+    } = active
+        .connection
+        .submit_build(build_request("active.rue"))
+        .unwrap()
+    else {
+        panic!("the first build is admitted");
+    };
+    assert!(wait_until(Duration::from_secs(10), || {
+        launcher.stub.started.load(Ordering::Acquire) == 1
+    }));
+    let report = status(fixture.scope(), &fixture.root).unwrap().unwrap();
+    let summary = report.active_request.expect("the held build is active");
+    assert_eq!(summary.ticket, active_ticket);
+    assert_eq!(summary.root_source, "active.rue");
+    assert_eq!(report.queued_requests, 0);
+
+    // Fill the queue behind it.
+    let mut queued = Vec::new();
+    for index in 0..MAX_QUEUED_REQUESTS {
+        let mut connection = start_connection(
+            fixture.scope(),
+            &fixture.root,
+            &fixture.options(),
+            &launcher,
+        )
+        .unwrap();
+        let ticket = match connection
+            .connection
+            .submit_build(build_request(&format!("queued{index}.rue")))
+            .unwrap()
+        {
+            Submission::Accepted {
+                ticket,
+                queued_ahead,
+            } => {
+                assert_eq!(queued_ahead, index + 1, "the active build counts as ahead");
+                ticket
+            }
+            Submission::Rejected { reason } => panic!("queue place {index} refused: {reason}"),
+        };
+        queued.push((connection, ticket));
+    }
+    let report = status(fixture.scope(), &fixture.root).unwrap().unwrap();
+    assert_eq!(report.queued_requests, MAX_QUEUED_REQUESTS);
+
+    // One more is refused before any work, so its client may go direct.
+    let mut overflow = start_connection(
+        fixture.scope(),
+        &fixture.root,
+        &fixture.options(),
+        &launcher,
+    )
+    .unwrap();
+    match overflow
+        .connection
+        .submit_build(build_request("overflow.rue"))
+        .unwrap()
+    {
+        Submission::Rejected { reason } => assert!(reason.contains("waiting"), "{reason}"),
+        Submission::Accepted { .. } => panic!("the queue bound admitted one too many"),
+    }
+    drop(overflow);
+
+    // A queued client that leaves is canceled without being started; the
+    // active client that leaves has its compile canceled.
+    drop(queued.pop());
+    drop(active);
+    assert!(wait_until(Duration::from_secs(10), || {
+        launcher.stub.canceled.load(Ordering::Acquire) == 1
+    }));
+    // The remaining queued builds now run; the stub still holds them, so
+    // release it and let them finish.
+    launcher.stub.release.store(true, Ordering::Release);
+    for (mut connection, ticket) in queued {
+        let (result, _) = connection.connection.await_build(ticket).unwrap();
+        assert!(matches!(result, BuildResult::Ready { .. }), "{result:?}");
+    }
+    // Exactly one queued build was never started: the one whose client left.
+    assert!(wait_until(Duration::from_secs(10), || {
+        launcher.stub.started.load(Ordering::Acquire) as u32 == MAX_QUEUED_REQUESTS
+    }));
+    stop(fixture.scope(), &fixture.root, Duration::from_secs(10)).unwrap();
+}
+
+#[test]
+fn a_crash_record_names_the_request_it_ended() {
+    let fixture = Fixture::new();
+    let identity = ServiceIdentity::current(fixture.scope()).unwrap();
+    let endpoint = Endpoint::prepare(&fixture.root, &identity).unwrap();
+    assert!(endpoint.crash_record().is_none());
+    let record = CrashRecord {
+        pid: 42,
+        ticket: Some(7),
+        message: "index out of bounds".into(),
+        location: Some("crates/x.rs:1:1".into()),
+    };
+    fs::write(
+        endpoint.directory().join(service::CRASH_RECORD_FILE),
+        serde_json::to_vec(&record).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(endpoint.crash_record(), Some(record));
 }

--- a/crates/rue/src/daemon_cli.rs
+++ b/crates/rue/src/daemon_cli.rs
@@ -180,9 +180,12 @@ fn execute(invocation: &DaemonInvocation) -> Result<i32, DaemonError> {
                 Ok(0)
             }
         },
-        DaemonCommand::Serve => match daemon::serve(scope, &root, idle_timeout)? {
-            ServeExit::Stopped | ServeExit::Idle | ServeExit::AlreadyRunning => Ok(0),
-        },
+        DaemonCommand::Serve => {
+            let executor = Box::new(crate::daemon_service::Executor::new());
+            match daemon::serve(scope, &root, idle_timeout, executor)? {
+                ServeExit::Stopped | ServeExit::Idle | ServeExit::AlreadyRunning => Ok(0),
+            }
+        }
     }
 }
 
@@ -212,10 +215,13 @@ fn render_status(report: &StatusReport) -> String {
     text.push_str(&format!("  uptime: {} ms\n", report.uptime_ms));
     text.push_str(&format!("  idle timeout: {} ms\n", report.idle_timeout_ms));
     text.push_str(&format!("  connections: {}\n", report.connections));
-    text.push_str(&format!(
-        "  active request: {}\n",
-        report.active_request.as_deref().unwrap_or("none")
-    ));
+    match &report.active_request {
+        Some(active) => text.push_str(&format!(
+            "  active request: #{} {} (in {}, {} ms)\n",
+            active.ticket, active.root_source, active.working_directory, active.elapsed_ms
+        )),
+        None => text.push_str("  active request: none\n"),
+    }
     text.push_str(&format!("  queued requests: {}\n", report.queued_requests));
     text.push_str(&format!("  retained hosts: {}\n", report.retained_hosts));
     text

--- a/crates/rue/src/daemon_client.rs
+++ b/crates/rue/src/daemon_client.rs
@@ -1,0 +1,362 @@
+//! The client side of compiling through the local compiler service
+//! (ADR-0085 §2, §3, §5, §6): decide whether this invocation may use the
+//! service, capture the request at the process boundary, submit it, and
+//! publish what comes back exactly as the direct path would have.
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use rue_compiler::{CompileOptions, LinkerMode};
+use rue_driver::daemon::{
+    self, BuildRequest, BuildResult, DaemonScope, DiagnosticFormat, EndpointRoot, InputRecord,
+    ProcessLauncher, StartOptions, Submission, SubmitError,
+};
+use rue_driver::{HostPathContext, WatchInput, WatchInputParts};
+use rue_error::ErrorCode;
+
+use crate::compile::{Announcement, announce};
+use crate::output::{PublicationDestination, PublishRequest, publish_watch_executable};
+use crate::{
+    DiagnosticOutput, DriverMode, ErrorFormat, Options, VERSION, compile_pool_jobs,
+    driver_failure_exit_code, ice_diagnostic, render_driver_error, render_internal_error,
+};
+
+/// `--daemon=<mode>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum DaemonMode {
+    /// Compile in this process; never discover or contact a service.
+    #[default]
+    Off,
+    /// Use or start the service for supported requests; run the rest, and a
+    /// request the service refuses before any work, directly.
+    Auto,
+    /// The service must run the request; anything else is an error.
+    Required,
+}
+
+impl DaemonMode {
+    pub(crate) fn all_names() -> &'static str {
+        "off, auto, required"
+    }
+}
+
+impl std::str::FromStr for DaemonMode {
+    type Err = String;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        match text {
+            "off" => Ok(Self::Off),
+            "auto" => Ok(Self::Auto),
+            "required" => Ok(Self::Required),
+            other => Err(format!(
+                "unknown --daemon mode `{other}` (valid modes: {})",
+                Self::all_names()
+            )),
+        }
+    }
+}
+
+/// Why an invocation cannot run through the service, if it cannot. This is
+/// the support table of ADR-0085 §2: each of these keeps its existing direct
+/// stream and lifecycle contract until its own slice moves it.
+pub(crate) fn unsupported_reason(options: &Options) -> Option<&'static str> {
+    if options.mode == DriverMode::Test {
+        return Some("`rue test` runs directly until its service slice lands");
+    }
+    if options.watch {
+        return Some("--watch runs directly");
+    }
+    if !options.emit_stages.is_empty() {
+        return Some("--emit runs directly");
+    }
+    if !matches!(options.linker, LinkerMode::Internal) {
+        return Some("a system linker runs directly");
+    }
+    if options.time_passes {
+        return Some("--time-passes runs directly");
+    }
+    if options.benchmark_json {
+        return Some("--benchmark-json runs directly");
+    }
+    if options.log_level != crate::LogLevel::Off {
+        return Some("compiler tracing (--log-level) runs directly");
+    }
+    if std::env::var_os("RUST_LOG").is_some_and(|value| !value.is_empty()) {
+        return Some("compiler tracing (RUST_LOG) runs directly");
+    }
+    None
+}
+
+/// How a service attempt ended.
+pub(crate) enum Outcome {
+    /// The invocation is complete; exit with this status.
+    Exit(i32),
+    /// The service did not take the request and no work began; compile
+    /// directly.
+    Direct,
+}
+
+/// Compile `options` through the service, or report why not.
+pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome {
+    let format = options.error_format;
+    let failure_exit = driver_failure_exit_code(&options.mode);
+    let fail = |message: String| -> Outcome {
+        eprintln!("{}", render_daemon_error(format, message));
+        Outcome::Exit(failure_exit)
+    };
+    // Falling through to the direct path is only ever allowed while it is
+    // proven that no work began (ADR-0085 §6).
+    let fallback = |reason: String| -> Outcome {
+        match options.daemon {
+            DaemonMode::Required => fail(format!("--daemon=required: {reason}")),
+            DaemonMode::Auto | DaemonMode::Off => Outcome::Direct,
+        }
+    };
+
+    if let Some(reason) = unsupported_reason(options) {
+        return fallback(format!(
+            "{reason}; this invocation is not supported by the service"
+        ));
+    }
+
+    let request = capture(options, path_context);
+    let scope_dir = match &options.daemon_scope {
+        Some(scope) => path_context.anchor(Path::new(scope)),
+        None => {
+            let root = path_context.anchor(Path::new(&options.source_path));
+            root.parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| path_context.working_directory().to_path_buf())
+        }
+    };
+    let scope = match DaemonScope::new(&scope_dir, options.daemon_isolation.as_deref()) {
+        Ok(scope) => scope,
+        Err(error) => return fallback(format!("no service scope: {error}")),
+    };
+    let root = match EndpointRoot::resolve() {
+        Ok(root) => root,
+        Err(error) => return fallback(format!("no service endpoint: {error}")),
+    };
+    let launcher = match ProcessLauncher::current_executable() {
+        Ok(launcher) => launcher,
+        Err(error) => return fallback(format!("no service launcher: {error}")),
+    };
+    let mut started =
+        match daemon::start_connection(scope, &root, &StartOptions::default(), &launcher) {
+            Ok(started) => started,
+            Err(error) => return fallback(format!("the service is unavailable: {error}")),
+        };
+    let ticket = match started.connection.submit_build(request) {
+        Ok(Submission::Accepted { ticket, .. }) => ticket,
+        Ok(Submission::Rejected { reason }) => {
+            return fallback(format!("the service refused the request: {reason}"));
+        }
+        Err(SubmitError::BeforeSubmission(error)) => {
+            return fallback(format!("the request could not be submitted: {error}"));
+        }
+        // The service may have started the request: not a fallback, however
+        // the invocation was configured (ADR-0085 §6).
+        Err(error @ SubmitError::Ambiguous(_)) => return fail(error.to_string()),
+    };
+    let (result, bytes) = match started.connection.await_build(ticket) {
+        Ok(answer) => answer,
+        Err(error) => {
+            // A compiler panic aborts the service; it leaves a record naming
+            // the request it ended, which is the client's only account of
+            // the defect.
+            let pid = started.connection.service().pid;
+            if let Some(record) = started.endpoint.crash_record()
+                && record.pid == pid
+                && record.ticket == Some(ticket)
+            {
+                eprintln!(
+                    "{}",
+                    render_service_panic(format, &record.message, record.location)
+                );
+                return Outcome::Exit(failure_exit);
+            }
+            return fail(format!(
+                "the compiler service ended the request without an answer: {error}"
+            ));
+        }
+    };
+    drop(started);
+
+    match result {
+        BuildResult::Rejected { stderr } => {
+            eprint!("{stderr}");
+            Outcome::Exit(1)
+        }
+        BuildResult::Canceled => fail("the compiler service canceled the request".into()),
+        BuildResult::Failed { message, internal } => {
+            if internal {
+                eprintln!("{}", render_internal_error(format, message));
+                Outcome::Exit(failure_exit)
+            } else {
+                fail(message)
+            }
+        }
+        BuildResult::Ready {
+            stderr,
+            target,
+            destination,
+            inputs,
+            ..
+        } => {
+            eprint!("{stderr}");
+            let target = match target.parse::<rue_target::Target>() {
+                Ok(target) => target,
+                Err(error) => return fail(format!("the service named target `{target}`: {error}")),
+            };
+            let inputs: Vec<WatchInput> = inputs.into_iter().map(watch_input).collect();
+            let destination = PublicationDestination::from_parts(
+                PathBuf::from(destination.path),
+                PathBuf::from(destination.display_path),
+                destination
+                    .source_paths
+                    .into_iter()
+                    .map(PathBuf::from)
+                    .collect(),
+            );
+            let publication = {
+                let _span = tracing::info_span!("output_write", driver_phase = true).entered();
+                publish_watch_executable(
+                    PublishRequest {
+                        destination,
+                        bytes: &bytes,
+                        target,
+                    },
+                    &inputs,
+                )
+            };
+            match publication {
+                Ok(()) => {
+                    announce(
+                        Announcement::Completed,
+                        &options.source_path,
+                        &options.output_path,
+                        &CompileOptions {
+                            target,
+                            linker: LinkerMode::Internal,
+                            ..CompileOptions::default()
+                        },
+                    );
+                    Outcome::Exit(0)
+                }
+                // `InputsChanged` included: a source that changed between
+                // the compile and the rename is refused, not installed, and
+                // the last successfully published file stays (ADR-0085 §5).
+                Err(error) => {
+                    let diagnostics = DiagnosticOutput::new(format, Vec::new());
+                    eprintln!("{}", diagnostics.render_error(&error.into_compile_error()));
+                    Outcome::Exit(1)
+                }
+            }
+        }
+    }
+}
+
+/// A service failure as a driver diagnostic: the text form carries the
+/// driver's `Error:` prefix like every other driver failure; the JSON form is
+/// the E1503 diagnostic object (docs/process/diagnostics.md).
+fn render_daemon_error(format: ErrorFormat, message: String) -> String {
+    match format {
+        ErrorFormat::Text => format!("Error: {message}"),
+        ErrorFormat::Json => render_driver_error(ErrorCode::DRIVER_DAEMON, message, format),
+    }
+}
+
+/// Capture this invocation as the service will see it (ADR-0085 §3): every
+/// path as written together with the directory it was written in, and the
+/// terminal policy of this process's stderr.
+fn capture(options: &Options, path_context: &HostPathContext) -> BuildRequest {
+    let mut preview_features: Vec<String> = options
+        .preview_features
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    preview_features.sort();
+    BuildRequest {
+        working_directory: path_context.working_directory().display().to_string(),
+        root_source: options.source_path.clone(),
+        output_path: options.output_path.clone(),
+        source_manifest_path: options.source_manifest_path.clone(),
+        std_root: std::env::var_os("RUE_STD_PATH")
+            .map(|value| value.to_string_lossy().into_owned()),
+        workers: compile_pool_jobs(&options.mode, options.jobs),
+        target: options.target.to_string(),
+        opt_level: options.opt_level.name().to_owned(),
+        preview_features,
+        link_archives: options
+            .link_archives
+            .iter()
+            .map(|path| path_context.anchor(path).display().to_string())
+            .collect(),
+        error_format: match options.error_format {
+            ErrorFormat::Text => DiagnosticFormat::Text,
+            ErrorFormat::Json => DiagnosticFormat::Json,
+        },
+        color: std::io::stderr().is_terminal(),
+    }
+}
+
+fn watch_input(record: InputRecord) -> WatchInput {
+    WatchInput::from_parts(WatchInputParts {
+        requested_path: PathBuf::from(record.requested_path),
+        canonical_path: PathBuf::from(record.canonical_path),
+        fingerprint: record.fingerprint,
+        symlink_boundary: record.symlink_boundary.map(PathBuf::from),
+        symlink_route: record.symlink_route,
+    })
+}
+
+/// Render a panic that ended the service during this request the way the
+/// direct compiler's own panic hook would have presented it.
+fn render_service_panic(format: ErrorFormat, message: &str, location: Option<String>) -> String {
+    match format {
+        ErrorFormat::Json => format!("[{}]", ice_diagnostic(message, location).to_json()),
+        ErrorFormat::Text => {
+            let mut text = String::new();
+            text.push_str(
+                "error: internal compiler error: the compiler panicked; this is a bug in rue\n",
+            );
+            text.push_str(&format!("note: the compiler service panicked: {message}\n"));
+            if let Some(location) = location {
+                text.push_str(&format!("note: panic at {location}\n"));
+            }
+            text.push_str(&format!("note: rue version {VERSION}\n"));
+            text.push_str(
+                "note: please report this at https://github.com/rue-language/rue/issues\n",
+            );
+            text.push_str("note: re-run with --daemon=off and RUST_BACKTRACE=1 for a backtrace");
+            text
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_modes_parse() {
+        assert_eq!("off".parse::<DaemonMode>().unwrap(), DaemonMode::Off);
+        assert_eq!("auto".parse::<DaemonMode>().unwrap(), DaemonMode::Auto);
+        assert_eq!(
+            "required".parse::<DaemonMode>().unwrap(),
+            DaemonMode::Required
+        );
+        let error = "always".parse::<DaemonMode>().unwrap_err();
+        assert!(error.contains("off, auto, required"), "{error}");
+    }
+
+    #[test]
+    fn a_service_panic_renders_as_an_ice_in_both_formats() {
+        let text = render_service_panic(ErrorFormat::Text, "boom", Some("x.rs:1:2".into()));
+        assert!(text.starts_with("error: internal compiler error"));
+        assert!(text.contains("panic at x.rs:1:2"));
+        let json = render_service_panic(ErrorFormat::Json, "boom", None);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed[0]["code"], "E9000");
+    }
+}

--- a/crates/rue/src/daemon_service.rs
+++ b/crates/rue/src/daemon_service.rs
@@ -1,0 +1,423 @@
+//! The compiler service's executor: one retained filesystem host, and each
+//! admitted build run through the very cycle the direct driver uses
+//! (ADR-0085 §1, §3, §4).
+//!
+//! The service never changes its own working directory or environment: a
+//! request carries the client's cwd and every path as the client spelled it,
+//! and a `HostPathContext` for that cwd resolves them exactly as the client's
+//! own process would have.
+
+use std::path::{Path, PathBuf};
+
+use rue_compiler::PreviewFeature;
+use rue_compiler::unstable::{ColorChoice, CompilationCancellation};
+use rue_compiler::{CompileOptions, CompilerSessionConfig, LinkerMode, RootSelection};
+use rue_driver::daemon::{
+    BuildExecutor, BuildOutput, BuildRequest, BuildResult, DestinationRecord, DiagnosticFormat,
+    InputRecord,
+};
+use rue_driver::{FilesystemCompilerHost, HostOpenRequest, HostPathContext, SourceLoadError};
+
+use crate::compile::{CycleTransport, TransportOutcome, produce_transport};
+use crate::{ErrorFormat, render_source_load_error_with_color};
+
+/// What selects a retained host (ADR-0085 §3): the requested root and its
+/// resolution context, the manifest selection, the configured standard
+/// library root, and the compiler resource policy. A request with a
+/// different key gets a different host; a same-key request reobserves the
+/// retained one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HostKey {
+    working_directory: String,
+    root_source: String,
+    source_manifest_path: Option<String>,
+    std_root: Option<String>,
+    workers: usize,
+}
+
+struct RetainedHost {
+    key: HostKey,
+    host: FilesystemCompilerHost,
+}
+
+/// The one-host executor of this slice. Bounded multi-host retention is the
+/// qualification phase's (ADR-0085 §7, RUE-2129).
+pub(crate) struct Executor {
+    retained: Option<RetainedHost>,
+}
+
+impl Executor {
+    pub(crate) fn new() -> Self {
+        Self { retained: None }
+    }
+}
+
+/// The parts of a request that must parse before any host is touched.
+struct Parsed {
+    options: CompileOptions,
+    format: ErrorFormat,
+    color: ColorChoice,
+    compiler_config: CompilerSessionConfig,
+    path_context: HostPathContext,
+}
+
+fn parse(request: &BuildRequest) -> Result<Parsed, String> {
+    let target = request
+        .target
+        .parse::<rue_target::Target>()
+        .map_err(|error| format!("target `{}`: {error}", request.target))?;
+    let opt_level = request
+        .opt_level
+        .parse::<rue_compiler::OptLevel>()
+        .map_err(|error| format!("optimization level `{}`: {error}", request.opt_level))?;
+    let preview_features = request
+        .preview_features
+        .iter()
+        .map(|name| {
+            name.parse::<PreviewFeature>()
+                .map_err(|error| format!("preview feature `{name}`: {error}"))
+        })
+        .collect::<Result<_, _>>()?;
+    let compiler_config = CompilerSessionConfig::with_workers(request.workers)
+        .map_err(|error| format!("workers {}: {error}", request.workers))?;
+    let path_context = HostPathContext::from_working_directory(&request.working_directory)
+        .map_err(|error| format!("working directory: {error}"))?;
+    Ok(Parsed {
+        options: CompileOptions {
+            target,
+            linker: LinkerMode::Internal,
+            opt_level,
+            preview_features,
+            link_archives: request.link_archives.iter().map(PathBuf::from).collect(),
+            root_selection: RootSelection::Executable,
+        },
+        format: match request.error_format {
+            DiagnosticFormat::Text => ErrorFormat::Text,
+            DiagnosticFormat::Json => ErrorFormat::Json,
+        },
+        color: if request.color {
+            ColorChoice::Always
+        } else {
+            ColorChoice::Never
+        },
+        compiler_config,
+        path_context,
+    })
+}
+
+impl Executor {
+    /// The host for `key`: the retained one reobserved when the key matches,
+    /// a fresh one otherwise. A failed observation is the request's answer
+    /// (rendered like the direct path's) and leaves no half-open host behind.
+    fn host(
+        &mut self,
+        key: HostKey,
+        request: &BuildRequest,
+        parsed: &Parsed,
+    ) -> Result<&mut FilesystemCompilerHost, SourceLoadError> {
+        let reuse = self
+            .retained
+            .as_ref()
+            .is_some_and(|retained| retained.key == key);
+        if reuse {
+            let retained = self.retained.as_mut().expect("checked above");
+            // A pre-commit failure keeps the prior coherent closure, so the
+            // host stays retained; the request is answered with the failure.
+            retained.host.reobserve()?;
+            return Ok(&mut retained.host);
+        }
+        self.retained = None;
+        let host = FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: &request.root_source,
+            source_manifest_path: request.source_manifest_path.as_deref(),
+            std_root: request.std_root.as_deref().map(Path::new),
+            compiler_config: parsed.compiler_config.clone(),
+            path_context: &parsed.path_context,
+        })?;
+        let retained = self.retained.insert(RetainedHost { key, host });
+        Ok(&mut retained.host)
+    }
+}
+
+impl BuildExecutor for Executor {
+    fn build(
+        &mut self,
+        request: &BuildRequest,
+        cancellation: &CompilationCancellation,
+    ) -> BuildOutput {
+        let parsed = match parse(request) {
+            Ok(parsed) => parsed,
+            Err(message) => return BuildOutput::failed(format!("invalid request: {message}")),
+        };
+        let key = HostKey {
+            working_directory: request.working_directory.clone(),
+            root_source: request.root_source.clone(),
+            source_manifest_path: request.source_manifest_path.clone(),
+            std_root: request.std_root.clone(),
+            workers: request.workers,
+        };
+        let rejected = |error: SourceLoadError| BuildOutput {
+            result: BuildResult::Rejected {
+                stderr: format!(
+                    "{}\n",
+                    render_source_load_error_with_color(error, parsed.format, parsed.color)
+                ),
+            },
+            bytes: Vec::new(),
+        };
+        let host = match self.host(key, request, &parsed) {
+            Ok(host) => host,
+            Err(error) => return rejected(error),
+        };
+        match host.acquire_reached_toolchain_modules_cancellable(&parsed.options, cancellation) {
+            Ok(()) => {}
+            Err(SourceLoadError::Superseded) => {
+                return BuildOutput {
+                    result: BuildResult::Canceled,
+                    bytes: Vec::new(),
+                };
+            }
+            Err(error) => return rejected(error),
+        }
+        let CycleTransport { stderr, outcome } = produce_transport(
+            host,
+            &parsed.options,
+            parsed.format,
+            parsed.color,
+            &request.root_source,
+            Path::new(&request.output_path),
+            cancellation.clone(),
+        );
+        match outcome {
+            TransportOutcome::Rejected => BuildOutput {
+                result: BuildResult::Rejected { stderr },
+                bytes: Vec::new(),
+            },
+            TransportOutcome::Canceled => BuildOutput {
+                result: BuildResult::Canceled,
+                bytes: Vec::new(),
+            },
+            TransportOutcome::Ready {
+                target,
+                bytes,
+                destination,
+                inputs,
+            } => {
+                let (path, display_path, source_paths) = destination.into_parts();
+                BuildOutput {
+                    result: BuildResult::Ready {
+                        stderr,
+                        target: target.to_string(),
+                        destination: DestinationRecord {
+                            path: path.display().to_string(),
+                            display_path: display_path.display().to_string(),
+                            source_paths: source_paths
+                                .into_iter()
+                                .map(|path| path.display().to_string())
+                                .collect(),
+                        },
+                        inputs: inputs.into_iter().map(input_record).collect(),
+                        bytes: bytes.len() as u64,
+                    },
+                    bytes,
+                }
+            }
+        }
+    }
+
+    fn retained_hosts(&self) -> u32 {
+        u32::from(self.retained.is_some())
+    }
+}
+
+fn input_record(input: rue_driver::WatchInput) -> InputRecord {
+    let parts = input.into_parts();
+    InputRecord {
+        requested_path: parts.requested_path.display().to_string(),
+        canonical_path: parts.canonical_path.display().to_string(),
+        fingerprint: parts.fingerprint,
+        symlink_boundary: parts
+            .symlink_boundary
+            .map(|path| path.display().to_string()),
+        symlink_route: parts.symlink_route,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    struct Project {
+        directory: tempfile::TempDir,
+    }
+
+    impl Project {
+        fn new(source: &str) -> Self {
+            let directory = tempfile::tempdir().unwrap();
+            fs::write(directory.path().join("main.rue"), source).unwrap();
+            Self { directory }
+        }
+
+        fn write(&self, source: &str) {
+            fs::write(self.directory.path().join("main.rue"), source).unwrap();
+        }
+
+        fn request(&self, output: &str) -> BuildRequest {
+            BuildRequest {
+                working_directory: self.directory.path().display().to_string(),
+                root_source: "main.rue".into(),
+                output_path: output.into(),
+                source_manifest_path: None,
+                std_root: None,
+                workers: 1,
+                target: rue_target::Target::host().unwrap().to_string(),
+                opt_level: "O0".into(),
+                preview_features: Vec::new(),
+                link_archives: Vec::new(),
+                error_format: DiagnosticFormat::Text,
+                color: false,
+            }
+        }
+    }
+
+    const GOOD: &str = "fn main() -> i32 { 0 }\n";
+    const BROKEN: &str = "fn main() -> i32 {\n    let x: i32 = \"nope\";\n    x\n}\n";
+
+    #[test]
+    fn a_retained_host_serves_edit_fix_and_revert_with_fresh_parity() {
+        let project = Project::new(GOOD);
+        let mut executor = Executor::new();
+        let cancellation = CompilationCancellation::new();
+        assert_eq!(executor.retained_hosts(), 0);
+
+        let first = executor.build(&project.request("app"), &cancellation);
+        let BuildResult::Ready {
+            stderr,
+            bytes: announced,
+            destination,
+            inputs,
+            ..
+        } = &first.result
+        else {
+            panic!("a good program is ready: {:?}", first.result);
+        };
+        assert_eq!(stderr, "");
+        assert_eq!(*announced, first.bytes.len() as u64);
+        assert!(!first.bytes.is_empty());
+        assert_eq!(destination.display_path, "app");
+        assert!(
+            destination.path.ends_with("/app"),
+            "the destination is anchored at the request's cwd: {}",
+            destination.path
+        );
+        assert!(
+            inputs
+                .iter()
+                .any(|input| input.requested_path.ends_with("main.rue")),
+            "the root is an observed input"
+        );
+        assert_eq!(executor.retained_hosts(), 1);
+        assert!(
+            !project.directory.path().join("app").exists(),
+            "the service publishes nothing; the client does"
+        );
+
+        // An edit that breaks the program is answered exactly as a fresh
+        // host answers it.
+        project.write(BROKEN);
+        let broken = executor.build(&project.request("app"), &cancellation);
+        let BuildResult::Rejected { stderr } = &broken.result else {
+            panic!("a broken program is rejected: {:?}", broken.result);
+        };
+        assert!(stderr.contains("E0206"), "{stderr}");
+        let fresh = Executor::new().build(&project.request("app"), &cancellation);
+        let BuildResult::Rejected {
+            stderr: fresh_stderr,
+        } = &fresh.result
+        else {
+            panic!("fresh host: {:?}", fresh.result);
+        };
+        assert_eq!(stderr, fresh_stderr);
+        assert_eq!(
+            executor.retained_hosts(),
+            1,
+            "a rejected program keeps the host"
+        );
+
+        // The fix, then the revert, over the same host.
+        project.write(GOOD);
+        let fixed = executor.build(&project.request("app"), &cancellation);
+        assert!(matches!(fixed.result, BuildResult::Ready { .. }));
+        assert_eq!(
+            fixed.bytes, first.bytes,
+            "the same program links to the same bytes"
+        );
+        assert_eq!(executor.retained_hosts(), 1);
+    }
+
+    #[test]
+    fn a_changed_host_key_replaces_the_host_and_a_bad_request_touches_none() {
+        let project = Project::new(GOOD);
+        let mut executor = Executor::new();
+        let cancellation = CompilationCancellation::new();
+        let mut bad = project.request("app");
+        bad.target = "z80-cpm".into();
+        let answer = executor.build(&bad, &cancellation);
+        assert!(
+            matches!(
+                &answer.result,
+                BuildResult::Failed { message, internal: false } if message.contains("target `z80-cpm`")
+            ),
+            "{:?}",
+            answer.result
+        );
+        assert_eq!(executor.retained_hosts(), 0);
+
+        let first = executor.build(&project.request("app"), &cancellation);
+        assert!(matches!(first.result, BuildResult::Ready { .. }));
+        let mut other_policy = project.request("app");
+        other_policy.workers = 2;
+        let second = executor.build(&other_policy, &cancellation);
+        assert!(matches!(second.result, BuildResult::Ready { .. }));
+        assert_eq!(
+            executor.retained_hosts(),
+            1,
+            "one host at a time: the new key replaced the old host"
+        );
+        assert_eq!(first.bytes, second.bytes);
+    }
+
+    #[test]
+    fn a_canceled_request_produces_nothing_and_the_host_recovers() {
+        let project = Project::new(GOOD);
+        let mut executor = Executor::new();
+        let canceled = CompilationCancellation::new();
+        canceled.cancel();
+        let answer = executor.build(&project.request("app"), &canceled);
+        assert!(
+            matches!(answer.result, BuildResult::Canceled),
+            "{:?}",
+            answer.result
+        );
+        assert!(answer.bytes.is_empty());
+        let live = executor.build(&project.request("app"), &CompilationCancellation::new());
+        assert!(matches!(live.result, BuildResult::Ready { .. }));
+    }
+
+    #[test]
+    fn a_missing_root_is_the_direct_source_load_failure() {
+        let project = Project::new(GOOD);
+        let mut executor = Executor::new();
+        let mut request = project.request("app");
+        request.root_source = "absent.rue".into();
+        let answer = executor.build(&request, &CompilationCancellation::new());
+        let BuildResult::Rejected { stderr } = &answer.result else {
+            panic!("{:?}", answer.result);
+        };
+        assert!(stderr.contains("absent.rue"), "{stderr}");
+        assert!(stderr.ends_with('\n'));
+        assert_eq!(executor.retained_hosts(), 0);
+    }
+}

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -20,8 +20,9 @@ pub use running_image::{
 };
 pub use source_loader::{
     AttemptedRead, HermeticDenialError, SourceLoadError, ToolchainIntegrityError, WatchFingerprint,
-    WatchInput, watch_input_fingerprints, watch_inputs_changed, watch_inputs_changed_with_reader,
-    with_import_migration_helps, with_import_migration_helps_batches,
+    WatchInput, WatchInputParts, watch_input_fingerprints, watch_inputs_changed,
+    watch_inputs_changed_with_reader, with_import_migration_helps,
+    with_import_migration_helps_batches,
 };
 pub use test_candidates::{
     load_declared_candidates, load_declared_candidates_at, load_declared_candidates_with_context,

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -17,6 +17,8 @@ mod compile;
 #[cfg(not(rue_benchmark_allocations))]
 mod compiler_allocator;
 mod daemon_cli;
+mod daemon_client;
+mod daemon_service;
 mod emit;
 mod output;
 mod platform_signing;
@@ -28,7 +30,7 @@ use emit::EmitStage;
 #[cfg(test)]
 use emit::{EmitFrontendRoute, build_emit_frontend, emit_frontend_route, emit_requires_semantic};
 use rue_compiler::unstable::{
-    JsonDiagnostic, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
+    ColorChoice, JsonDiagnostic, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
 };
 #[cfg(test)]
 use rue_compiler::unstable::{Span, update_for_presentation};
@@ -245,6 +247,13 @@ struct Options {
     /// Whether `-o`/`--output` named the output explicitly. Compile mode warns
     /// when `--emit` ignores it; test mode refuses it outright.
     explicit_output: bool,
+    /// Whether to compile through the local compiler service (ADR-0085 §2).
+    daemon: daemon_client::DaemonMode,
+    /// `--daemon-scope`: the service scope directory as written; the default
+    /// is the root source's parent directory.
+    daemon_scope: Option<String>,
+    /// `--daemon-isolation`: the service isolation name.
+    daemon_isolation: Option<String>,
 }
 
 /// Version string for the rue compiler (single-sourced from rue-error so the
@@ -278,6 +287,8 @@ Usage: rue [options] <root.rue> [output]
 
 The compiler takes exactly one root source file and discovers every other
 file through its @import graph; pass build-system inputs with --source-manifest.
+An ordinary internal-linker build can run through the local compiler service
+with --daemon=auto or --daemon=required (ADR-0085); the default is off.
 
 Commands:
   explain <E####>      Show the compiler-owned explanation for an error code
@@ -357,6 +368,16 @@ Options:
                        (schema: docs/process/diagnostics.md)
   --time-passes        Show timing for each compilation pass
   --benchmark-json     Output timing as JSON (for benchmarking)
+  --daemon <mode>      off (default): compile in this process; auto: use or
+                       start the compiler service for supported requests and
+                       compile directly otherwise; required: the service must
+                       run it. Supported: ordinary internal-linker builds.
+                       --watch, --emit, --linker, --time-passes,
+                       --benchmark-json, rue test, and compiler tracing run
+                       directly under auto and are refused under required.
+  --daemon-scope <dir> The service scope directory (default: the root source's
+                       directory); --daemon-isolation <name> selects a
+                       separate service within it. Both match `rue daemon`.
   --watch              Recompile when the accepted source closure changes
                        With `rue test`, re-run the tests instead
   --version            Show version information
@@ -536,7 +557,7 @@ enum DriverMode {
 /// status is `1` and stays that way. Every such site maps through here rather
 /// than repeating the match, so the two modes cannot drift apart one site at a
 /// time.
-fn driver_failure_exit_code(mode: &DriverMode) -> i32 {
+pub(crate) fn driver_failure_exit_code(mode: &DriverMode) -> i32 {
     match mode {
         DriverMode::Test => test_mode::TestExitCode::RunnerError.code(),
         DriverMode::Compile => 1,
@@ -613,6 +634,9 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     let mut link_archives: Vec<std::path::PathBuf> = Vec::new();
     let mut test = test_mode::TestOptions::default();
     let mut test_flags_given: Vec<&'static str> = Vec::new();
+    let mut daemon: Option<daemon_client::DaemonMode> = None;
+    let mut daemon_scope: Option<String> = None;
+    let mut daemon_isolation: Option<String> = None;
     let mut positional = Vec::new();
     let mut args_iter = args.iter().peekable();
 
@@ -856,6 +880,43 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
             "--watch" => {
                 watch = true;
             }
+            "--daemon" => {
+                let Some(mode_str) = args_iter.next() else {
+                    eprintln!("Error: --daemon requires a value");
+                    eprintln!("Valid modes: {}", daemon_client::DaemonMode::all_names());
+                    return ParseResult::Error;
+                };
+                match mode_str.parse::<daemon_client::DaemonMode>() {
+                    Ok(mode) => daemon = Some(mode),
+                    Err(error) => {
+                        eprintln!("Error: {error}");
+                        return ParseResult::Error;
+                    }
+                }
+            }
+            "--daemon-scope" => {
+                let Some(dir) = args_iter.next() else {
+                    eprintln!("Error: --daemon-scope requires a directory");
+                    return ParseResult::Error;
+                };
+                daemon_scope = Some((*dir).to_owned());
+            }
+            "--daemon-isolation" => {
+                let Some(name) = args_iter.next() else {
+                    eprintln!("Error: --daemon-isolation requires a name");
+                    return ParseResult::Error;
+                };
+                daemon_isolation = Some((*name).to_owned());
+            }
+            _ if arg.starts_with("--daemon=") => {
+                match arg["--daemon=".len()..].parse::<daemon_client::DaemonMode>() {
+                    Ok(mode) => daemon = Some(mode),
+                    Err(error) => {
+                        eprintln!("Error: {error}");
+                        return ParseResult::Error;
+                    }
+                }
+            }
             "--help" | "-h" => {
                 // Explicit help request: success, so write to stdout (RUE-518).
                 print_help();
@@ -986,6 +1047,21 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         );
     }
 
+    let daemon = daemon.unwrap_or_default();
+    if daemon == daemon_client::DaemonMode::Off {
+        if let Some(flag) = [
+            daemon_scope.as_ref().map(|_| "--daemon-scope"),
+            daemon_isolation.as_ref().map(|_| "--daemon-isolation"),
+        ]
+        .into_iter()
+        .flatten()
+        .next()
+        {
+            eprintln!("Error: {flag} requires --daemon=auto or --daemon=required");
+            return ParseResult::Error;
+        }
+    }
+
     let Some(final_target) = target.or_else(Target::host) else {
         eprintln!(
             "Error: no --target specified and this host ({}) is not a supported Rue target",
@@ -997,6 +1073,9 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     };
 
     ParseResult::Options(Box::new(Options {
+        daemon,
+        daemon_scope,
+        daemon_isolation,
         source_path,
         source_manifest_path,
         test_candidates_path,
@@ -1092,7 +1171,7 @@ fn test_mode_jobs(jobs: usize) -> usize {
 /// auto-detection. Without this, `rue test --jobs 1` — the way to isolate a
 /// test that interferes with its neighbors — would also single-thread a
 /// compilation the isolation question says nothing about.
-fn compile_pool_jobs(mode: &DriverMode, jobs: usize) -> usize {
+pub(crate) fn compile_pool_jobs(mode: &DriverMode, jobs: usize) -> usize {
     match mode {
         DriverMode::Test => 0,
         DriverMode::Compile => jobs,
@@ -1246,14 +1325,27 @@ enum DiagnosticRenderer<'a> {
 
 impl<'a> DiagnosticOutput<'a> {
     fn new(format: ErrorFormat, sources: Vec<(FileId, SourceInfo<'a>)>) -> Self {
+        Self::with_color(format, sources, ColorChoice::Auto)
+    }
+
+    /// An output whose text rendering follows an explicit color policy
+    /// instead of asking whether this process's stderr is a terminal. The
+    /// compiler service renders for a client whose terminal it cannot see
+    /// (ADR-0085 §5).
+    pub(crate) fn with_color(
+        format: ErrorFormat,
+        sources: Vec<(FileId, SourceInfo<'a>)>,
+        color: ColorChoice,
+    ) -> Self {
         let paths = sources
             .iter()
             .map(|(file_id, info)| (*file_id, info.path))
             .collect();
         let renderer = match format {
-            ErrorFormat::Text => {
-                DiagnosticRenderer::Text(MultiFileFormatter::new(sources.iter().cloned()))
-            }
+            ErrorFormat::Text => DiagnosticRenderer::Text(MultiFileFormatter::with_color_choice(
+                sources.iter().cloned(),
+                color,
+            )),
             ErrorFormat::Json => {
                 DiagnosticRenderer::Json(MultiFileJsonFormatter::new(sources.iter().cloned()))
             }
@@ -1357,7 +1449,7 @@ impl<'a> DiagnosticOutput<'a> {
     /// shape rather than switching on object-vs-array (RUE-436). The
     /// single-error paths (output publication, watch-cycle publication) used
     /// to emit a bare object here while every batch path emitted an array.
-    fn render_error(&self, error: &CompileError) -> String {
+    pub(crate) fn render_error(&self, error: &CompileError) -> String {
         match self.format {
             ErrorFormat::Text => match &self.renderer {
                 DiagnosticRenderer::Text(formatter) => formatter.format_error(error),
@@ -1396,7 +1488,7 @@ impl<'a> DiagnosticOutput<'a> {
         }
     }
 
-    fn render_warnings(&self, warnings: &[CompileWarning]) -> String {
+    pub(crate) fn render_warnings(&self, warnings: &[CompileWarning]) -> String {
         let warnings: Vec<CompileWarning> = self
             .in_source_order(warnings)
             .into_iter()
@@ -1667,7 +1759,7 @@ fn benchmark_report(
 /// reads have already completed. `std::process::exit` preserves the platform
 /// atexit path while avoiding a second full destruction walk of that retained
 /// state. This is deliberately not used for watch, emit, or any failure path.
-fn exit_successful_native_compile() -> ! {
+pub(crate) fn exit_successful_native_compile() -> ! {
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
     std::process::exit(0);
@@ -2233,6 +2325,14 @@ pub(crate) fn render_source_load_error(
     error: SourceLoadError,
     error_format: ErrorFormat,
 ) -> String {
+    render_source_load_error_with_color(error, error_format, ColorChoice::Auto)
+}
+
+pub(crate) fn render_source_load_error_with_color(
+    error: SourceLoadError,
+    error_format: ErrorFormat,
+    color: ColorChoice,
+) -> String {
     match error {
         SourceLoadError::Message(message) => {
             render_driver_error(ErrorCode::DRIVER_SOURCE_LOAD, message, error_format)
@@ -2270,7 +2370,7 @@ pub(crate) fn render_source_load_error(
                         .collect()
                 })
                 .unwrap_or_default();
-            let diagnostics = DiagnosticOutput::new(error_format, infos);
+            let diagnostics = DiagnosticOutput::with_color(error_format, infos, color);
             if errors.is_empty() {
                 render_internal_error(
                     error_format,
@@ -2283,7 +2383,7 @@ pub(crate) fn render_source_load_error(
     }
 }
 
-fn render_driver_error(code: ErrorCode, message: String, format: ErrorFormat) -> String {
+pub(crate) fn render_driver_error(code: ErrorCode, message: String, format: ErrorFormat) -> String {
     match format {
         ErrorFormat::Text => message,
         ErrorFormat::Json => {
@@ -2301,7 +2401,7 @@ fn render_driver_error(code: ErrorCode, message: String, format: ErrorFormat) ->
     }
 }
 
-fn render_internal_error(format: ErrorFormat, message: impl Into<String>) -> String {
+pub(crate) fn render_internal_error(format: ErrorFormat, message: impl Into<String>) -> String {
     let diagnostics = DiagnosticOutput::new(format, Vec::new());
     diagnostics.render_error(&rue_error::ice_error!(message.into()))
 }
@@ -2364,7 +2464,7 @@ fn ice_panic_diagnostic(info: &std::panic::PanicHookInfo<'_>) -> JsonDiagnostic 
 /// graceful `ice_error!` ICE carries — so a consumer filters both halves of
 /// the ICE surface on one code. The diagnostic has no spans: a panic has no
 /// source location in the *user's* program, and inventing one would be a lie.
-fn ice_diagnostic(payload: &str, panic_site: Option<String>) -> JsonDiagnostic {
+pub(crate) fn ice_diagnostic(payload: &str, panic_site: Option<String>) -> JsonDiagnostic {
     let mut notes = vec![format!("rue version {VERSION}")];
     if let Some(site) = panic_site {
         notes.push(format!("panic at {site}"));
@@ -2529,6 +2629,23 @@ fn main() {
         }
         None => None,
     };
+
+    // A supported request under `--daemon=auto|required` runs through the
+    // local compiler service from here: every argument and declared-input
+    // check above has run, and nothing below has opened a host, a worker
+    // pool, or a source file (ADR-0085 §2, §3). Under `auto` a request the
+    // service rejects before any work began falls through to the direct
+    // path; under `required` it is an error.
+    if options.daemon != daemon_client::DaemonMode::Off {
+        match daemon_client::run(&options, &path_context) {
+            daemon_client::Outcome::Exit(code) => {
+                let _ = std::io::stdout().flush();
+                let _ = std::io::stderr().flush();
+                std::process::exit(code);
+            }
+            daemon_client::Outcome::Direct => {}
+        }
+    }
 
     // Build the immutable compiler resource configuration before opening the
     // filesystem host. In test mode `--jobs` bounds test processes instead,
@@ -4562,7 +4679,7 @@ mod tests {
         assert!(production.contains("match format"));
         assert_eq!(
             production
-                .matches("MultiFileFormatter::new(sources.iter().cloned())")
+                .matches("MultiFileFormatter::with_color_choice(\n                sources.iter().cloned(),")
                 .count(),
             1,
             "text formatter construction must be selected, not duplicated"

--- a/crates/rue/src/output.rs
+++ b/crates/rue/src/output.rs
@@ -23,6 +23,28 @@ pub(crate) struct PublicationDestination {
     source_paths: Vec<PathBuf>,
 }
 
+impl PublicationDestination {
+    /// A destination the service's preflight already validated, carried to
+    /// the client that publishes it (ADR-0085 §5). The publication guard
+    /// revalidates it against the same source set before the rename.
+    pub(crate) fn from_parts(
+        path: PathBuf,
+        display_path: PathBuf,
+        source_paths: Vec<PathBuf>,
+    ) -> Self {
+        Self {
+            path,
+            display_path,
+            source_paths,
+        }
+    }
+
+    /// `(path, display_path, source_paths)`.
+    pub(crate) fn into_parts(self) -> (PathBuf, PathBuf, Vec<PathBuf>) {
+        (self.path, self.display_path, self.source_paths)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum PublishError {
     /// The destination is, or became, one of the program's own input sources.

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -51,6 +51,16 @@ use crate::host::HostPathContext;
 pub struct WatchFingerprint(u64);
 
 impl WatchFingerprint {
+    /// The fingerprint's raw value, for carrying it as plain data.
+    pub fn value(self) -> u64 {
+        self.0
+    }
+
+    /// A fingerprint from its raw value.
+    pub fn from_value(value: u64) -> Self {
+        Self(value)
+    }
+
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let mut hash = 0xcbf29ce484222325_u64;
         for byte in bytes {
@@ -78,6 +88,18 @@ pub struct WatchInput {
     expected_fingerprint: Option<WatchFingerprint>,
     symlink_boundary: Option<PathBuf>,
     expected_symlink_route: Arc<[PhysicalFileIdentity]>,
+}
+
+/// The plain-data form of a [`WatchInput`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WatchInputParts {
+    pub requested_path: PathBuf,
+    pub canonical_path: PathBuf,
+    /// `None` records an expected absence.
+    pub fingerprint: Option<u64>,
+    pub symlink_boundary: Option<PathBuf>,
+    /// `(volume, file)` identities along the expected symlink route.
+    pub symlink_route: Vec<(u64, u64)>,
 }
 
 impl WatchInput {
@@ -134,6 +156,38 @@ impl WatchInput {
 
     pub fn expected_fingerprint(&self) -> Option<WatchFingerprint> {
         self.expected_fingerprint
+    }
+
+    /// Reassemble an input from the parts [`Self::into_parts`] produced, so an
+    /// observation can cross a process boundary and still be revalidated by
+    /// the same publication guard (ADR-0085 §5).
+    pub fn from_parts(parts: WatchInputParts) -> Self {
+        Self {
+            requested_path: parts.requested_path,
+            canonical_path: parts.canonical_path,
+            expected_fingerprint: parts.fingerprint.map(WatchFingerprint::from_value),
+            symlink_boundary: parts.symlink_boundary,
+            expected_symlink_route: parts
+                .symlink_route
+                .into_iter()
+                .map(|(volume, file)| PhysicalFileIdentity::new(volume, file))
+                .collect(),
+        }
+    }
+
+    /// Every field of this observation as plain data.
+    pub fn into_parts(self) -> WatchInputParts {
+        WatchInputParts {
+            requested_path: self.requested_path,
+            canonical_path: self.canonical_path,
+            fingerprint: self.expected_fingerprint.map(WatchFingerprint::value),
+            symlink_boundary: self.symlink_boundary,
+            symlink_route: self
+                .expected_symlink_route
+                .iter()
+                .map(|identity| (identity.volume(), identity.file()))
+                .collect(),
+        }
     }
 
     fn symlink_route_changed(&self) -> bool {

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,8 +66,29 @@ object), and `stop` ends it. Neither `status` nor `stop` starts a service, and
 the scope is only a process grouping: it never changes what a program imports.
 Endpoints live in a user-private directory under `XDG_RUNTIME_DIR` (or the
 system temporary directory); `RUE_DAEMON_ROOT` overrides that root, which is
-how the CLI suite keeps its services apart from yours. The service does not
-yet execute compiler requests; those arrive with the rest of RUE-2128.
+how the CLI suite keeps its services apart from yours.
+
+`--daemon=off|auto|required` decides whether a compilation runs through that
+service. The default is `off`. Under `auto` a supported request uses or starts
+the service for the root source's directory (`--daemon-scope <dir>` and
+`--daemon-isolation <name>` select another, matching the controls' `--scope`
+and `--isolation`); under `required` the service must run it. The service
+compiles through the same host and cycle the direct path uses and hands back
+owned results: the client publishes the executable itself, after revalidating
+the observed inputs, so diagnostics, the success line, and exit statuses are
+those of a direct compile. A request the service refuses before any work
+began, or one outside the support table, runs directly under `auto`; under
+`required` it is an `E1503` error. Once the service has accepted a request,
+any failure is the invocation's failure and nothing is retried.
+
+| Request | `auto` | `required` |
+| --- | --- | --- |
+| Ordinary internal-linker build | service | service |
+| `rue test`, `rue test --list` | direct (its own slice of RUE-2128) | refused |
+| `--watch`, any `--emit`, `--linker <cmd>` | direct | refused |
+| `--time-passes`, `--benchmark-json` | direct | refused |
+| Tracing via `--log-level` or `RUST_LOG` | direct | refused |
+| `--help`, `--version`, `explain`, `rue daemon` | local | local |
 
 The model is exactly one root source file per compile; additional files are
 reached through `@import` and discovered transitively from the root. The legacy

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -190,6 +190,7 @@ The canonical driver/host registry is the E1500-E1599 range in
 | `E1500` | ordinary source load | Root/source discovery, ordinary filesystem I/O, or ordinary root/source policy setup failure. |
 | `E1501` | toolchain integrity | A required trusted standard-library input is missing, unreadable, malformed, or otherwise fails the toolchain contract. |
 | `E1502` | hermetic build denial | `SourceLoadError::HermeticDenial`: trusted toolchain acquisition is denied by the source manifest or canonical containment policy; the remedy is build configuration rather than toolchain repair. |
+| `E1503` | compiler service | The local compiler service (ADR-0085) could not run a `--daemon` request: it was unavailable or incompatible under `required`, refused the request, or was lost after accepting it. Never a source error; the program was not judged. |
 
 These codes are stable consumer identifiers and are distinct from compiler
 input errors (`E1400-E1499`) and internal compiler errors


### PR DESCRIPTION
The first request-execution slice of RUE-2128 (ADR-0085 §2, §3, §5, §6), on the service skeleton from RUE-2177 and the cancellation audit from RUE-2174: ordinary internal-linker executable builds run through the local service. `rue test`, `rue test --list` and analysis-only `--emit air` follow as their own slices over the same pieces.

**Mode and support table.** `--daemon=off|auto|required` (default `off`), with `--daemon-scope <dir>` and `--daemon-isolation <name>` selecting the service the `rue daemon` controls address; the default scope is the root source's directory. Under `auto`, `rue test`, `--watch`, any `--emit`, a system linker, `--time-passes`, `--benchmark-json` and compiler tracing (`--log-level`, `RUST_LOG`) run directly; under `required` they are refused before any work as the new `E1503` driver diagnostic (`docs/process/diagnostics.md`). The table is in `docs/development.md` and pinned by a CLI case.

**Client.** The request is captured at the process boundary: the invocation directory with every path exactly as written, `RUE_STD_PATH` as captured (unset and empty keep their meanings), workers, target, optimization, preview features, anchored link archives, the error format and whether stderr is a terminal. The client submits on the connection that proved the service's identity. Direct fallback happens only when the request was refused or never reached the service; a lost admission answer, and anything after acceptance, is the invocation's failure and is never retried. The client publishes the linked bytes through the existing `output`/`platform_signing` path, revalidating the observed inputs before the rename exactly as a watch cycle does, then prints the same success line and exits with the same statuses as a direct compile.

**Service.** One compiler owner thread over one retained `FilesystemCompilerHost` keyed by root, manifest, standard-library root and worker policy (a different key replaces it; multi-host retention is RUE-2129), a bounded FIFO admission queue (`MAX_QUEUED_REQUESTS`), and control messages serviceable throughout. Each admitted request reobserves, acquires reached toolchain modules and compiles through the same `compile` cycle direct mode uses, under a `CompilationCancellation` a watcher thread trips when the client disconnects; a queued request whose client left is canceled without starting. The service never changes its cwd or environment: a `HostPathContext` for the request's cwd resolves paths as the client's process would have.

**Protocol.** `Build` request → explicit `Accepted { ticket, queued_ahead }` or `Rejected { reason }` before any work → one result frame (`Rejected`, `Ready`, `Canceled`, `Failed`) → for `Ready`, the linked bytes in raw chunks bounded at 4 MiB. The result carries the diagnostics rendered once by the canonical formatter under the client's format and color policy (migration helps frozen on the service), the validated destination and the observed-input records, so stderr is byte for byte the direct compile's. `status` now reports the active request, queue depth and retained hosts.

**Crash.** The compiler is built to abort on panic, so a panic during a request ends the service; a panic hook writes a crash record naming the ticket beside the endpoint, and the client whose request it was reports it as an internal compiler error. Other clients see the request lost and a later invocation starts a fresh service.

**Coverage.** In-process service tests over a stub executor: admission and chunked byte transfer, a full queue rejecting the next request before any work, a departed queued client canceled without starting and a departed active client's compile canceled, the crash record. Executor tests over a real host: edit/fix/revert reuse with the rejected diagnostics identical to a fresh host's, host replacement on a key change with an invalid request touching no host, cancellation before work with recovery, and a missing root rendered as the direct source-load failure. CLI cases: `--daemon=required` builds that publish a working program and reuse the host, diagnostic parity with direct mode in text and JSON, the support table under `auto` and `required` (a refused request starts no service), and `auto` starting the service its scope selects. The `daemon` scenario steps gained `run_output` so a build's program is executed.

Verified locally: both driver unit suites, `scripts/rue cli daemon`, the harness, test-runner, error and oracle-diff unit tests, `//crates/rue-oracle-diff:oracle-diff-test`, and the clippy/fmt gates for `rue`, `rue-cli-tests`, `rue-test-runner` and `rue-error`.

Fixes RUE-2179