### PR TITLE
RUE-2181: run rue test and rue test --list through the compiler service

### DIFF
--- a/crates/rue-cli-tests/cases/daemon.toml
+++ b/crates/rue-cli-tests/cases/daemon.toml
@@ -128,7 +128,7 @@ daemon = { steps = [
   { args = ["--daemon=required", "--linker", "cc", "main.rue"], exit_code = 1, stderr_contains = ["a system linker runs directly"] },
   { args = ["--daemon=required", "--time-passes", "main.rue"], exit_code = 1, stderr_contains = ["--time-passes runs directly"] },
   { args = ["--daemon=required", "--log-level", "debug", "main.rue"], exit_code = 1, stderr_contains = ["compiler tracing (--log-level) runs directly"] },
-  { args = ["--daemon=required", "test", "main.rue"], exit_code = 2, stderr_contains = ["`rue test` runs directly"] },
+  { args = ["--daemon=required", "test", "--watch", "main.rue"], exit_code = 2, stderr_contains = ["Error: --daemon=required: --watch runs directly"] },
   { args = ["--daemon=auto", "--emit", "deps", "main.rue"], exit_code = 0, stdout_contains = ["main.rue"] },
   { args = ["--daemon=sometimes", "main.rue"], exit_code = 1, stderr_contains = ["unknown --daemon mode `sometimes`"] },
   { args = ["--daemon-scope", ".", "main.rue"], exit_code = 1, stderr_contains = ["--daemon-scope requires --daemon=auto or --daemon=required"] },
@@ -152,4 +152,32 @@ daemon = { steps = [
   { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["stopped service pid"] },
   { args = ["daemon", "stop", "--scope", "sub"], exit_code = 0, stdout_contains = ["stopped service pid"] },
   { args = ["daemon", "stop", "--isolation", "ci"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+] }
+
+[[case]]
+name = "test_runs_and_listings_go_through_the_service"
+description = "rue test and rue test --list under --daemon=required: the service links the image and answers the inventory, the client runs the tests; verdicts, diagnostics, events and exit statuses are direct mode's, and one host serves the test, listing and executable requests of the root."
+files = [
+  { path = "main.rue", source = """
+fn add(a: i32, b: i32) -> i32 { a + b }
+test "adds" { @assert(add(1, 2) == 3); }
+test "fails" { @assert(add(1, 2) == 4); }
+test "broken" { let x: i32 = "nope"; @assert(x == 1); }
+fn main() -> i32 { @dbg(add(20, 22)); 0 }
+""" },
+  { path = "extra_tests.rue", source = "test \"never imported\" { }\n" },
+  { path = "candidates.txt", source = "main.rue\nextra_tests.rue\n" },
+]
+daemon = { steps = [
+  { args = ["test", "--daemon=required", "--seed", "1", "main.rue"], exit_code = 1, stdout_contains = ["FAIL main.rue::fails", "COMPILE ERROR main.rue::broken", "1 passed, 1 failed, 1 compile error"], stderr_contains = ["error: [E0206]: type mismatch: expected string type, found i32", " --> main.rue:4:17"] },
+  { args = ["test", "--daemon=required", "--format", "json", "--seed", "1", "--filter", "adds", "main.rue"], exit_code = 0, stdout_contains = ["\"event\":\"run_started\"", "\"plan\":{\"selected\":1,\"total\":3}", "\"id\":\"main.rue::adds\"", "\"verdict\":\"pass\"", "\"event\":\"run_finished\""], stdout_not_contains = ["main.rue::fails"] },
+  { args = ["test", "--daemon=required", "--seed", "1", "--filter", "broken", "--format", "json", "main.rue"], exit_code = 1, stdout_contains = ["\"verdict\":\"compile_error\"", "\"payload\":\"E0206: type mismatch: expected string type, found i32\"", "\"location\":{\"column\":17,\"file\":\"main.rue\",\"line\":4}"] },
+  { args = ["test", "--daemon=required", "--list", "main.rue"], exit_code = 0, stdout_contains = ["main.rue::adds\nmain.rue::broken\nmain.rue::fails\n"], stderr_contains = ["error: [E0206]"] },
+  { args = ["test", "--daemon=required", "--list", "--filter", "nomatch", "main.rue"], exit_code = 3, stderr_contains = ["error: no tests matched the selection"] },
+  { args = ["test", "--daemon=required", "--seed", "1", "--filter", "adds", "--test-candidates", "candidates.txt", "main.rue"], exit_code = 0, stdout_contains = ["1 passed"], stderr_contains = ["extra_tests.rue"] },
+  { args = ["test", "--daemon=required", "--seed", "1", "--test-candidates", "missing.txt", "main.rue"], exit_code = 2, stderr_contains = ["missing.txt"] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["  retained hosts: 1", "  active request: none"] },
+  { args = ["--daemon=required", "main.rue", "-o", "app"], exit_code = 0, stdout_contains = ["Compiled main.rue -> app"], run_output = "app", run_output_stdout_contains = ["42\n"] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["  retained hosts: 1"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["stopped service pid"] },
 ] }

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -270,10 +270,8 @@ pub(crate) trait CycleArtifact: Sized {
     /// Diagnostics the companion carries, printed after the warnings and
     /// before the publication outcome so a failed publication cannot discard
     /// them. The executable has none.
-    fn print_companion_diagnostics(
-        _companion: &Self::Companion,
-        _diagnostics: &DiagnosticOutput<'_>,
-    ) {
+    fn companion_diagnostics(_companion: &Self::Companion) -> Option<&CompileErrors> {
+        None
     }
 
     fn published(
@@ -512,7 +510,9 @@ impl<Artifact: CycleArtifact> OwnedCycleResponse<Artifact> {
             linked.publish()
         };
         diagnostics.print_warnings(&publication.warnings);
-        Artifact::print_companion_diagnostics(&companion, &diagnostics);
+        if let Some(errors) = Artifact::companion_diagnostics(&companion) {
+            diagnostics.print_prepared_errors(errors);
+        }
         match publication.result {
             Ok(executable) => {
                 if let Some(announcement) = announcement {
@@ -641,13 +641,8 @@ impl CycleArtifact for TestImage {
     /// root set, and a filtered run that silently swallowed a broken test file
     /// would be the papercut the unimported-test-file warning exists to
     /// prevent.
-    fn print_companion_diagnostics(
-        companion: &TestImageCompanion,
-        diagnostics: &DiagnosticOutput<'_>,
-    ) {
-        if !companion.failure_diagnostics.is_empty() {
-            diagnostics.print_prepared_errors(&companion.failure_diagnostics);
-        }
+    fn companion_diagnostics(companion: &TestImageCompanion) -> Option<&CompileErrors> {
+        (!companion.failure_diagnostics.is_empty()).then_some(&companion.failure_diagnostics)
     }
 
     fn prepare(mut self) -> Self {
@@ -787,18 +782,20 @@ fn linker_name(linker: &LinkerMode) -> &str {
     }
 }
 
-/// One executable cycle's owned answer in the form that crosses the service
-/// boundary (ADR-0085 §5): the diagnostic stream rendered once, by the
-/// canonical formatter under the client's own format and color policy, and
-/// the linked bytes with everything the client's publication needs.
-pub(crate) struct CycleTransport {
+/// One cycle's owned answer in the form that crosses the service boundary
+/// (ADR-0085 §5): the diagnostic stream rendered once, by the canonical
+/// formatter under the client's own format and color policy, and the linked
+/// bytes with everything the client's publication needs. `Published` is what
+/// the artifact's cycle promises beside its bytes: nothing an executable
+/// needs, the runner's companion for a test image.
+pub(crate) struct CycleTransport<Published> {
     /// Everything the direct compile would have written to stderr up to the
     /// point the client takes over.
     pub(crate) stderr: String,
-    pub(crate) outcome: TransportOutcome,
+    pub(crate) outcome: TransportOutcome<Published>,
 }
 
-pub(crate) enum TransportOutcome {
+pub(crate) enum TransportOutcome<Published> {
     /// The program was rejected or the destination refused.
     Rejected,
     Canceled,
@@ -809,7 +806,23 @@ pub(crate) enum TransportOutcome {
         /// The accepted observations the client revalidates before the
         /// rename, as a watch cycle does.
         inputs: Vec<WatchInput>,
+        published: Published,
     },
+}
+
+/// How a service request observes its cycle: the accepted-read closure and
+/// the request's cancellation, never superseded, because an ordinary
+/// invocation is independent of every other (ADR-0085 §6).
+fn service_observation<'a>(
+    host: &FilesystemCompilerHost,
+    cancellation: CompilationCancellation,
+    never: &'a dyn Fn() -> bool,
+) -> CycleObservation<'a> {
+    CycleObservation::Watch {
+        inputs: host.watch_inputs(),
+        cancellation,
+        superseded: never,
+    }
 }
 
 /// Produce one executable cycle for a service request: the destination
@@ -823,33 +836,58 @@ pub(crate) fn produce_transport(
     source_path: &str,
     output_path: &Path,
     cancellation: CompilationCancellation,
-) -> CycleTransport {
-    let inputs = host.watch_inputs();
-    // An ordinary invocation is never superseded: a newer command does not
-    // cancel an older one merely because they share a root (ADR-0085 §6).
+) -> CycleTransport<PublishedExecutable> {
     let never = || false;
+    let observation = service_observation(host, cancellation, &never);
     let response = produce::<CompileOutput>(
         host,
         options,
         error_format,
         Some(source_path),
         output_path,
-        CycleObservation::Watch {
-            inputs,
-            cancellation,
-            superseded: &never,
-        },
+        observation,
     );
     response.into_transport(color)
 }
 
-impl OwnedCycleResponse<CompileOutput> {
-    fn into_transport(self, color: rue_compiler::unstable::ColorChoice) -> CycleTransport {
+/// [`produce_transport`] for a test image: the same cycle over the request's
+/// test root set, carrying the runner's companion (ADR-0083 §3).
+pub(crate) fn produce_test_transport(
+    host: &mut FilesystemCompilerHost,
+    options: &CompileOptions,
+    error_format: ErrorFormat,
+    color: rue_compiler::unstable::ColorChoice,
+    candidates: Option<&TestCandidateInventory>,
+    image_path: &Path,
+    cancellation: CompilationCancellation,
+) -> CycleTransport<PublishedTestImage> {
+    let never = || false;
+    let observation = service_observation(host, cancellation, &never);
+    let response = produce_test_cycle(TestCycleRequest {
+        host,
+        options,
+        error_format,
+        candidates,
+        image_path,
+        observation,
+    });
+    response.into_transport(color)
+}
+
+impl<Artifact: CycleArtifact> OwnedCycleResponse<Artifact> {
+    fn into_transport(
+        self,
+        color: rue_compiler::unstable::ColorChoice,
+    ) -> CycleTransport<Artifact::Published> {
         let OwnedCycleResponse {
             source_snapshot,
             error_format,
             options,
             result,
+            unimported_test_files,
+            accepted_reads,
+            attempted_reads,
+            watch_inputs,
             ..
         } = self;
         let source_infos = source_snapshot
@@ -879,16 +917,36 @@ impl OwnedCycleResponse<CompileOutput> {
                     PublicationObservation::Watch(inputs) => inputs,
                     PublicationObservation::OneShot => Vec::new(),
                 };
-                if !artifact.warnings.is_empty() {
-                    line(diagnostics.render_warnings(&artifact.warnings));
+                let (output, companion) = artifact.into_parts();
+                // The same order `complete` prints in: warnings, then the
+                // companion's own diagnostics.
+                if !output.warnings.is_empty() {
+                    line(diagnostics.render_warnings(&output.warnings));
                 }
+                if let Some(errors) = Artifact::companion_diagnostics(&companion) {
+                    line(diagnostics.render_prepared_errors(errors));
+                }
+                let metrics = output.unstable_metrics();
+                let published = Artifact::published(
+                    companion,
+                    PublishedExecutable { metrics },
+                    unimported_test_files,
+                    source_snapshot.clone(),
+                    error_format,
+                    OwnedCycleObservations {
+                        accepted_reads,
+                        attempted_reads,
+                        watch_inputs,
+                    },
+                );
                 CycleTransport {
                     stderr,
                     outcome: TransportOutcome::Ready {
                         target: options.target,
-                        bytes: artifact.elf,
+                        bytes: output.elf,
                         destination,
                         inputs,
+                        published,
                     },
                 }
             }

--- a/crates/rue/src/daemon/mod.rs
+++ b/crates/rue/src/daemon/mod.rs
@@ -32,8 +32,10 @@ use sha2::{Digest, Sha256};
 use crate::running_image::{RunningImageIdentity, running_image_identity};
 pub use client::{ConnectError, Connection, Submission, SubmitError};
 pub use protocol::{
-    BuildRequest, BuildResult, CrashRecord, DAEMON_PROTOCOL_VERSION, DestinationRecord,
-    DiagnosticFormat, IdentityRecord, InputRecord, RequestSummary, ServiceInfo, StatusReport,
+    BuildKind, BuildRequest, BuildResult, CompileFailureRecord, CrashRecord,
+    DAEMON_PROTOCOL_VERSION, DestinationRecord, DiagnosticFormat, IdentityRecord, InputRecord,
+    InventoryEntryRecord, RequestSummary, ServiceInfo, StatusReport, TestImageRecord,
+    UnimportedFileRecord, UnimportedRecord,
 };
 pub use service::{BuildExecutor, BuildOutput, MAX_QUEUED_REQUESTS, ServeExit};
 

--- a/crates/rue/src/daemon/protocol.rs
+++ b/crates/rue/src/daemon/protocol.rs
@@ -229,13 +229,30 @@ pub enum RequestBody {
     /// End the service. It answers [`ResponseBody::Stopping`] and then exits;
     /// the caller observes completion by the socket disappearing.
     Stop,
-    /// Compile an executable through the service's retained host (ADR-0085
-    /// §3, §5). The service answers [`ResponseBody::Accepted`] or
+    /// Compile through the service's retained host (ADR-0085 §3, §5): an
+    /// executable, a test image, or a test inventory, as `kind` says. The
+    /// service answers [`ResponseBody::Accepted`] or
     /// [`ResponseBody::Rejected`] before any work begins; an accepted request
     /// is followed on the same connection by one [`BuildReply`] frame and,
     /// when it carries linked bytes, by those bytes in raw chunks. The
     /// connection then carries nothing else.
     Build(Box<BuildRequest>),
+}
+
+/// Which artifact a build request asks for. All three run over the same
+/// retained host; the root selection they imply is request data, never a
+/// host or service namespace (ADR-0085 §3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildKind {
+    /// An executable published at the request's output path.
+    Executable,
+    /// A test image staged at the request's output path, with the inventory
+    /// and per-test compile-failure attribution the client runner needs
+    /// (ADR-0083 §3).
+    TestImage,
+    /// The test inventory alone: no codegen, no link, no bytes.
+    TestListing,
 }
 
 /// How the client wants diagnostics rendered. The service renders once with
@@ -254,6 +271,10 @@ pub enum DiagnosticFormat {
 /// client's own process would have, without ever changing its own cwd.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BuildRequest {
+    /// Named `artifact` rather than `kind` because the request travels
+    /// flattened into the internally tagged [`RequestBody`], whose tag is
+    /// `kind`.
+    pub artifact: BuildKind,
     /// The client's invocation directory.
     pub working_directory: String,
     /// The root source as written.
@@ -262,6 +283,11 @@ pub struct BuildRequest {
     pub output_path: String,
     /// `--source-manifest` as written.
     pub source_manifest_path: Option<String>,
+    /// `--test-candidates` as written, already validated by the client. Every
+    /// kind acquires it under the host's read policy, as the direct path does
+    /// even for an ordinary build (ADR-0083 §1); a test image also reports
+    /// against it.
+    pub test_candidates_path: Option<String>,
     /// `RUE_STD_PATH` as captured; `None` when unset, `Some("")` when empty,
     /// each keeping its direct-mode meaning.
     pub std_root: Option<String>,
@@ -328,15 +354,23 @@ pub struct BuildReply {
 pub enum BuildResult {
     /// The program was rejected or the destination refused; nothing to publish.
     Rejected { stderr: String },
-    /// The executable is linked. `bytes` raw chunk bytes follow this frame;
-    /// the client publishes them at `destination` after revalidating
-    /// `inputs`, exactly as a watch cycle does.
+    /// The executable or test image is linked. `bytes` raw chunk bytes
+    /// follow this frame; the client publishes them at `destination` after
+    /// revalidating `inputs`, exactly as a watch cycle does. A test image
+    /// also carries what its runner needs.
     Ready {
         stderr: String,
         target: String,
         destination: DestinationRecord,
         inputs: Vec<InputRecord>,
         bytes: u64,
+        test_image: Option<Box<TestImageRecord>>,
+    },
+    /// The test inventory. `entries` is `None` when the listing itself was
+    /// refused; `stderr` then carries why, rendered.
+    Listing {
+        stderr: String,
+        entries: Option<Vec<InventoryEntryRecord>>,
     },
     /// The request's cancellation was observed; nothing was produced.
     Canceled,
@@ -365,6 +399,67 @@ pub struct InputRecord {
     pub symlink_boundary: Option<String>,
     /// `(volume, file)` identities along the expected symlink route.
     pub symlink_route: Vec<(u64, u64)>,
+}
+
+/// One test of an inventory, as the compiler's inventory entry spells it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InventoryEntryRecord {
+    pub id: String,
+    pub module: String,
+    pub name: String,
+    pub file: String,
+    pub line: u32,
+    pub column: u32,
+    pub ordinal: u32,
+    /// `(issue, platform)`: `@known_bug` markers, `platform` `None` when
+    /// unscoped.
+    pub expected_failures: Vec<(String, Option<String>)>,
+}
+
+/// What a test image carries beside its bytes (ADR-0083 §3), projected once
+/// by the canonical renderer so the runner never renders a diagnostic itself.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestImageRecord {
+    /// Whether the closure spans more than one user module.
+    pub multi_module_closure: bool,
+    pub entries: Vec<InventoryEntryRecord>,
+    pub compile_failures: Vec<CompileFailureRecord>,
+    pub unimported: UnimportedRecord,
+}
+
+/// The `compile_error` verdict the compiler decided for one test.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompileFailureRecord {
+    pub ordinal: u32,
+    pub xfail_eligible: bool,
+    pub payload: String,
+    pub message: String,
+    /// `(file, line, column)` of the first diagnostic's primary span.
+    pub location: Option<(String, u32, u32)>,
+    pub diagnostics: Vec<serde_json::Value>,
+}
+
+/// The unimported-test-file report (ADR-0083 §1), rendered.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UnimportedRecord {
+    /// No `--test-candidates` was declared.
+    NotDeclared,
+    /// The declared files outside the closure, with the warnings the direct
+    /// path prints for them already rendered (empty when there are none).
+    Files {
+        stderr: String,
+        files: Vec<UnimportedFileRecord>,
+    },
+    /// The report itself failed; `stderr` carries the diagnostics rendered.
+    Failed { stderr: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnimportedFileRecord {
+    pub path: String,
+    pub tests: u32,
+    pub parse_failed: bool,
 }
 
 /// A request the service is executing or holding, as status reports it.
@@ -472,6 +567,42 @@ mod tests {
         let mut reader = wire.as_slice();
         let error = read_frame::<Hello>(&mut reader, MAX_CONTROL_FRAME_BYTES).unwrap_err();
         assert!(matches!(error, FrameError::Truncated), "{error}");
+    }
+
+    #[test]
+    fn a_build_request_round_trips_inside_the_tagged_request_body() {
+        let request = Request {
+            id: 3,
+            body: RequestBody::Build(Box::new(BuildRequest {
+                artifact: BuildKind::TestImage,
+                working_directory: "/w".into(),
+                root_source: "main.rue".into(),
+                output_path: "/w/.run/image".into(),
+                source_manifest_path: None,
+                test_candidates_path: Some("tests.txt".into()),
+                std_root: Some(String::new()),
+                workers: 0,
+                target: "x86-64-linux".into(),
+                opt_level: "O2".into(),
+                preview_features: vec!["test_infra".into()],
+                link_archives: Vec::new(),
+                error_format: DiagnosticFormat::Json,
+                color: true,
+            })),
+        };
+        let mut wire = Vec::new();
+        write_frame(&mut wire, &request).unwrap();
+        let mut reader = wire.as_slice();
+        let decoded: Request = read_frame(&mut reader, MAX_CONTROL_FRAME_BYTES)
+            .unwrap()
+            .unwrap();
+        let RequestBody::Build(decoded) = decoded.body else {
+            panic!("a build request decodes as a build");
+        };
+        let RequestBody::Build(original) = request.body else {
+            unreachable!()
+        };
+        assert_eq!(decoded, original);
     }
 
     #[test]

--- a/crates/rue/src/daemon/tests.rs
+++ b/crates/rue/src/daemon/tests.rs
@@ -82,6 +82,7 @@ impl BuildExecutor for StubExecutor {
                 },
                 inputs: Vec::new(),
                 bytes: bytes.len() as u64,
+                test_image: None,
             },
             bytes,
         }
@@ -94,10 +95,12 @@ impl BuildExecutor for StubExecutor {
 
 fn build_request(root_source: &str) -> BuildRequest {
     BuildRequest {
+        artifact: BuildKind::Executable,
         working_directory: "/w".into(),
         root_source: root_source.into(),
         output_path: "out".into(),
         source_manifest_path: None,
+        test_candidates_path: None,
         std_root: None,
         workers: 1,
         target: "x86_64-linux".into(),

--- a/crates/rue/src/daemon_client.rs
+++ b/crates/rue/src/daemon_client.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 
 use rue_compiler::{CompileOptions, LinkerMode};
 use rue_driver::daemon::{
-    self, BuildRequest, BuildResult, DaemonScope, DiagnosticFormat, EndpointRoot, InputRecord,
-    ProcessLauncher, StartOptions, Submission, SubmitError,
+    self, BuildKind, BuildRequest, BuildResult, DaemonScope, DiagnosticFormat, EndpointRoot,
+    InputRecord, ProcessLauncher, StartOptions, Submission, SubmitError,
 };
 use rue_driver::{HostPathContext, WatchInput, WatchInputParts};
 use rue_error::ErrorCode;
@@ -19,6 +19,7 @@ use crate::output::{PublicationDestination, PublishRequest, publish_watch_execut
 use crate::{
     DiagnosticOutput, DriverMode, ErrorFormat, Options, VERSION, compile_pool_jobs,
     driver_failure_exit_code, ice_diagnostic, render_driver_error, render_internal_error,
+    test_mode, test_mode_jobs, test_repro_env, test_repro_flags,
 };
 
 /// `--daemon=<mode>`.
@@ -60,9 +61,6 @@ impl std::str::FromStr for DaemonMode {
 /// the support table of ADR-0085 §2: each of these keeps its existing direct
 /// stream and lifecycle contract until its own slice moves it.
 pub(crate) fn unsupported_reason(options: &Options) -> Option<&'static str> {
-    if options.mode == DriverMode::Test {
-        return Some("`rue test` runs directly until its service slice lands");
-    }
     if options.watch {
         return Some("--watch runs directly");
     }
@@ -96,6 +94,14 @@ pub(crate) enum Outcome {
     Direct,
 }
 
+/// What a test run needs beyond the compile: decided before submission so
+/// the request names the image's staging path.
+struct TestPlan {
+    seed: u64,
+    run_root: PathBuf,
+    image_path: PathBuf,
+}
+
 /// Compile `options` through the service, or report why not.
 pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome {
     let format = options.error_format;
@@ -119,7 +125,41 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
         ));
     }
 
-    let request = capture(options, path_context);
+    let kind = match (&options.mode, options.test.list) {
+        (DriverMode::Compile, _) => BuildKind::Executable,
+        (DriverMode::Test, true) => BuildKind::TestListing,
+        (DriverMode::Test, false) => BuildKind::TestImage,
+    };
+    // A test image is staged in the run's own private directory, never at a
+    // path the user named (ADR-0083 §2); it exists before submission so the
+    // service's destination preflight sees it.
+    let test_plan = match kind {
+        BuildKind::TestImage => {
+            let seed = options.test.seed.unwrap_or_else(test_mode::fresh_seed);
+            match test_mode::service_run_root(seed) {
+                Ok((run_root, image_path)) => Some(TestPlan {
+                    seed,
+                    run_root,
+                    image_path,
+                }),
+                Err(message) => {
+                    eprintln!("error: {message}");
+                    return Outcome::Exit(failure_exit);
+                }
+            }
+        }
+        BuildKind::Executable | BuildKind::TestListing => None,
+    };
+    let output_path = match &test_plan {
+        Some(plan) => plan.image_path.display().to_string(),
+        None => options.output_path.clone(),
+    };
+    let discard_plan = |plan: &TestPlan| {
+        let _ = std::fs::remove_file(&plan.image_path);
+        let _ = std::fs::remove_dir(&plan.run_root);
+    };
+
+    let request = capture(options, path_context, kind, output_path);
     let scope_dir = match &options.daemon_scope {
         Some(scope) => path_context.anchor(Path::new(scope)),
         None => {
@@ -129,38 +169,33 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
                 .unwrap_or_else(|| path_context.working_directory().to_path_buf())
         }
     };
-    let scope = match DaemonScope::new(&scope_dir, options.daemon_isolation.as_deref()) {
-        Ok(scope) => scope,
-        Err(error) => return fallback(format!("no service scope: {error}")),
-    };
-    let root = match EndpointRoot::resolve() {
-        Ok(root) => root,
-        Err(error) => return fallback(format!("no service endpoint: {error}")),
-    };
-    let launcher = match ProcessLauncher::current_executable() {
-        Ok(launcher) => launcher,
-        Err(error) => return fallback(format!("no service launcher: {error}")),
-    };
-    let mut started =
-        match daemon::start_connection(scope, &root, &StartOptions::default(), &launcher) {
-            Ok(started) => started,
-            Err(error) => return fallback(format!("the service is unavailable: {error}")),
+    let submitted = (|| -> Result<(BuildResult, Vec<u8>), Outcome> {
+        let scope = DaemonScope::new(&scope_dir, options.daemon_isolation.as_deref())
+            .map_err(|error| fallback(format!("no service scope: {error}")))?;
+        let root = EndpointRoot::resolve()
+            .map_err(|error| fallback(format!("no service endpoint: {error}")))?;
+        let launcher = ProcessLauncher::current_executable()
+            .map_err(|error| fallback(format!("no service launcher: {error}")))?;
+        let mut started =
+            daemon::start_connection(scope, &root, &StartOptions::default(), &launcher)
+                .map_err(|error| fallback(format!("the service is unavailable: {error}")))?;
+        let ticket = match started.connection.submit_build(request) {
+            Ok(Submission::Accepted { ticket, .. }) => ticket,
+            Ok(Submission::Rejected { reason }) => {
+                return Err(fallback(format!(
+                    "the service refused the request: {reason}"
+                )));
+            }
+            Err(SubmitError::BeforeSubmission(error)) => {
+                return Err(fallback(format!(
+                    "the request could not be submitted: {error}"
+                )));
+            }
+            // The service may have started the request: not a fallback,
+            // however the invocation was configured (ADR-0085 §6).
+            Err(error @ SubmitError::Ambiguous(_)) => return Err(fail(error.to_string())),
         };
-    let ticket = match started.connection.submit_build(request) {
-        Ok(Submission::Accepted { ticket, .. }) => ticket,
-        Ok(Submission::Rejected { reason }) => {
-            return fallback(format!("the service refused the request: {reason}"));
-        }
-        Err(SubmitError::BeforeSubmission(error)) => {
-            return fallback(format!("the request could not be submitted: {error}"));
-        }
-        // The service may have started the request: not a fallback, however
-        // the invocation was configured (ADR-0085 §6).
-        Err(error @ SubmitError::Ambiguous(_)) => return fail(error.to_string()),
-    };
-    let (result, bytes) = match started.connection.await_build(ticket) {
-        Ok(answer) => answer,
-        Err(error) => {
+        started.connection.await_build(ticket).map_err(|error| {
             // A compiler panic aborts the service; it leaves a record naming
             // the request it ended, which is the client's only account of
             // the defect.
@@ -175,20 +210,39 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
                 );
                 return Outcome::Exit(failure_exit);
             }
-            return fail(format!(
+            fail(format!(
                 "the compiler service ended the request without an answer: {error}"
-            ));
+            ))
+        })
+    })();
+    let (result, bytes) = match submitted {
+        Ok(answer) => answer,
+        Err(outcome) => {
+            if let Some(plan) = &test_plan {
+                discard_plan(plan);
+            }
+            return outcome;
         }
     };
-    drop(started);
 
     match result {
         BuildResult::Rejected { stderr } => {
             eprint!("{stderr}");
-            Outcome::Exit(1)
+            if let Some(plan) = &test_plan {
+                discard_plan(plan);
+            }
+            // A rejected program: compile mode's ordinary status, or the test
+            // runner's "the run did not happen" (ADR-0083 §2).
+            Outcome::Exit(failure_exit)
+        }
+        BuildResult::Listing { stderr, entries } => {
+            Outcome::Exit(test_mode::run_service_listing(stderr, entries, &options.test).code())
         }
         BuildResult::Canceled => fail("the compiler service canceled the request".into()),
         BuildResult::Failed { message, internal } => {
+            if let Some(plan) = &test_plan {
+                discard_plan(plan);
+            }
             if internal {
                 eprintln!("{}", render_internal_error(format, message));
                 Outcome::Exit(failure_exit)
@@ -201,6 +255,7 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
             target,
             destination,
             inputs,
+            test_image,
             ..
         } => {
             eprint!("{stderr}");
@@ -229,8 +284,19 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
                     &inputs,
                 )
             };
-            match publication {
-                Ok(()) => {
+            // `InputsChanged` included: a source that changed between the
+            // compile and the rename is refused, not installed, and the last
+            // successfully published file stays (ADR-0085 §5).
+            if let Err(error) = publication {
+                let diagnostics = DiagnosticOutput::new(format, Vec::new());
+                eprintln!("{}", diagnostics.render_error(&error.into_compile_error()));
+                if let Some(plan) = &test_plan {
+                    discard_plan(plan);
+                }
+                return Outcome::Exit(failure_exit);
+            }
+            match test_plan {
+                None => {
                     announce(
                         Announcement::Completed,
                         &options.source_path,
@@ -243,13 +309,34 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
                     );
                     Outcome::Exit(0)
                 }
-                // `InputsChanged` included: a source that changed between
-                // the compile and the rename is refused, not installed, and
-                // the last successfully published file stays (ADR-0085 §5).
-                Err(error) => {
-                    let diagnostics = DiagnosticOutput::new(format, Vec::new());
-                    eprintln!("{}", diagnostics.render_error(&error.into_compile_error()));
-                    Outcome::Exit(1)
+                Some(plan) => {
+                    let Some(record) = test_image else {
+                        discard_plan(&plan);
+                        return fail(
+                            "the compiler service answered a test request without its inventory"
+                                .into(),
+                        );
+                    };
+                    let std_root = std::env::var_os("RUE_STD_PATH").map(PathBuf::from);
+                    let exit = test_mode::run_service_image(test_mode::ServiceRun {
+                        record: *record,
+                        image_path: &plan.image_path,
+                        run_root: &plan.run_root,
+                        options: &options.test,
+                        root: &options.source_path,
+                        repro_root: &test_mode::absolute_spelling_at(
+                            Path::new(&options.source_path),
+                            path_context.working_directory(),
+                        ),
+                        repro_flags: &test_repro_flags(options, path_context),
+                        repro_env: &test_repro_env(std_root.as_deref()),
+                        jobs: test_mode_jobs(options.jobs),
+                        target: options.target,
+                        opt_level: options.opt_level,
+                        candidates_declared: options.test_candidates_path.is_some(),
+                        seed: plan.seed,
+                    });
+                    Outcome::Exit(exit.code())
                 }
             }
         }
@@ -269,7 +356,12 @@ fn render_daemon_error(format: ErrorFormat, message: String) -> String {
 /// Capture this invocation as the service will see it (ADR-0085 §3): every
 /// path as written together with the directory it was written in, and the
 /// terminal policy of this process's stderr.
-fn capture(options: &Options, path_context: &HostPathContext) -> BuildRequest {
+fn capture(
+    options: &Options,
+    path_context: &HostPathContext,
+    kind: BuildKind,
+    output_path: String,
+) -> BuildRequest {
     let mut preview_features: Vec<String> = options
         .preview_features
         .iter()
@@ -277,10 +369,12 @@ fn capture(options: &Options, path_context: &HostPathContext) -> BuildRequest {
         .collect();
     preview_features.sort();
     BuildRequest {
+        artifact: kind,
         working_directory: path_context.working_directory().display().to_string(),
         root_source: options.source_path.clone(),
-        output_path: options.output_path.clone(),
+        output_path,
         source_manifest_path: options.source_manifest_path.clone(),
+        test_candidates_path: options.test_candidates_path.clone(),
         std_root: std::env::var_os("RUE_STD_PATH")
             .map(|value| value.to_string_lossy().into_owned()),
         workers: compile_pool_jobs(&options.mode, options.jobs),

--- a/crates/rue/src/daemon_service.rs
+++ b/crates/rue/src/daemon_service.rs
@@ -10,16 +10,22 @@
 use std::path::{Path, PathBuf};
 
 use rue_compiler::PreviewFeature;
-use rue_compiler::unstable::{ColorChoice, CompilationCancellation};
+use rue_compiler::unstable::{
+    ColorChoice, CompilationCancellation, SourceInfo, TestCandidateInventory,
+};
 use rue_compiler::{CompileOptions, CompilerSessionConfig, LinkerMode, RootSelection};
 use rue_driver::daemon::{
-    BuildExecutor, BuildOutput, BuildRequest, BuildResult, DestinationRecord, DiagnosticFormat,
-    InputRecord,
+    BuildExecutor, BuildKind, BuildOutput, BuildRequest, BuildResult, DestinationRecord,
+    DiagnosticFormat, InputRecord, TestImageRecord,
 };
-use rue_driver::{FilesystemCompilerHost, HostOpenRequest, HostPathContext, SourceLoadError};
+use rue_driver::{
+    FilesystemCompilerHost, HostOpenRequest, HostPathContext, SourceLoadError,
+    load_declared_candidates_with_context,
+};
 
-use crate::compile::{CycleTransport, TransportOutcome, produce_transport};
-use crate::{ErrorFormat, render_source_load_error_with_color};
+use crate::compile::{CycleTransport, TransportOutcome, produce_test_transport, produce_transport};
+use crate::test_mode::{inventory_entry_record, prepare_image, produce_listing_transport};
+use crate::{DiagnosticOutput, ErrorFormat, render_source_load_error_with_color};
 
 /// What selects a retained host (ADR-0085 §3): the requested root and its
 /// resolution context, the manifest selection, the configured standard
@@ -89,7 +95,13 @@ fn parse(request: &BuildRequest) -> Result<Parsed, String> {
             opt_level,
             preview_features,
             link_archives: request.link_archives.iter().map(PathBuf::from).collect(),
-            root_selection: RootSelection::Executable,
+            // A test request roots every test item in the closure; an
+            // executable request roots none of them (ADR-0083 §1). Root
+            // selection is request data over the one shared host.
+            root_selection: match request.artifact {
+                BuildKind::Executable => RootSelection::Executable,
+                BuildKind::TestImage | BuildKind::TestListing => RootSelection::Tests,
+            },
         },
         format: match request.error_format {
             DiagnosticFormat::Text => ErrorFormat::Text,
@@ -179,47 +191,70 @@ impl BuildExecutor for Executor {
             }
             Err(error) => return rejected(error),
         }
-        let CycleTransport { stderr, outcome } = produce_transport(
-            host,
-            &parsed.options,
-            parsed.format,
-            parsed.color,
-            &request.root_source,
-            Path::new(&request.output_path),
-            cancellation.clone(),
-        );
-        match outcome {
-            TransportOutcome::Rejected => BuildOutput {
-                result: BuildResult::Rejected { stderr },
-                bytes: Vec::new(),
-            },
-            TransportOutcome::Canceled => BuildOutput {
-                result: BuildResult::Canceled,
-                bytes: Vec::new(),
-            },
-            TransportOutcome::Ready {
-                target,
-                bytes,
-                destination,
-                inputs,
-            } => {
-                let (path, display_path, source_paths) = destination.into_parts();
-                BuildOutput {
-                    result: BuildResult::Ready {
-                        stderr,
-                        target: target.to_string(),
-                        destination: DestinationRecord {
-                            path: path.display().to_string(),
-                            display_path: display_path.display().to_string(),
-                            source_paths: source_paths
-                                .into_iter()
-                                .map(|path| path.display().to_string())
-                                .collect(),
-                        },
-                        inputs: inputs.into_iter().map(input_record).collect(),
-                        bytes: bytes.len() as u64,
+        // The declared candidate inventory is acquired under the host's read
+        // policy in every mode, as the direct path does, so a build rule that
+        // writes a broken list fails the build it broke (ADR-0083 §1).
+        let candidates = match acquire_candidates(host, request, &parsed) {
+            Ok(candidates) => candidates,
+            Err(stderr) => {
+                return BuildOutput {
+                    result: BuildResult::Rejected { stderr },
+                    bytes: Vec::new(),
+                };
+            }
+        };
+        match request.artifact {
+            BuildKind::Executable => {
+                let transport = produce_transport(
+                    host,
+                    &parsed.options,
+                    parsed.format,
+                    parsed.color,
+                    &request.root_source,
+                    Path::new(&request.output_path),
+                    cancellation.clone(),
+                );
+                ready_output(transport, |_| None)
+            }
+            BuildKind::TestImage => {
+                let transport = produce_test_transport(
+                    host,
+                    &parsed.options,
+                    parsed.format,
+                    parsed.color,
+                    candidates.as_ref(),
+                    Path::new(&request.output_path),
+                    cancellation.clone(),
+                );
+                let multi_module_closure = host.published_user_module_count() > 1;
+                let color = parsed.color;
+                ready_output(transport, move |published| {
+                    Some(Box::new(
+                        prepare_image(published, multi_module_closure, color).into_record(),
+                    ))
+                })
+            }
+            BuildKind::TestListing => {
+                match produce_listing_transport(
+                    host,
+                    &parsed.options,
+                    parsed.format,
+                    parsed.color,
+                    cancellation,
+                ) {
+                    None => BuildOutput {
+                        result: BuildResult::Canceled,
+                        bytes: Vec::new(),
                     },
-                    bytes,
+                    Some(listing) => BuildOutput {
+                        result: BuildResult::Listing {
+                            stderr: listing.stderr,
+                            entries: listing.entries.map(|entries| {
+                                entries.into_iter().map(inventory_entry_record).collect()
+                            }),
+                        },
+                        bytes: Vec::new(),
+                    },
                 }
             }
         }
@@ -227,6 +262,77 @@ impl BuildExecutor for Executor {
 
     fn retained_hosts(&self) -> u32 {
         u32::from(self.retained.is_some())
+    }
+}
+
+/// Load and acquire the request's declared test candidates, rendering a
+/// failure as the direct path would print it.
+fn acquire_candidates(
+    host: &mut FilesystemCompilerHost,
+    request: &BuildRequest,
+    parsed: &Parsed,
+) -> Result<Option<TestCandidateInventory>, String> {
+    let Some(path) = request.test_candidates_path.as_deref() else {
+        return Ok(None);
+    };
+    let declared = load_declared_candidates_with_context(path, &parsed.path_context)
+        .map_err(|message| format!("{message}\n"))?;
+    host.acquire_test_candidates(&declared)
+        .map(Some)
+        .map_err(|errors| {
+            let snapshot = host.source_snapshot();
+            let sources = snapshot
+                .files()
+                .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+                .collect();
+            let diagnostics = DiagnosticOutput::with_color(parsed.format, sources, parsed.color);
+            format!("{}\n", diagnostics.render_errors(&errors))
+        })
+}
+
+/// The wire form of a cycle transport; `companion` projects what rides
+/// beside a test image's bytes.
+fn ready_output<Published>(
+    transport: CycleTransport<Published>,
+    companion: impl FnOnce(Published) -> Option<Box<TestImageRecord>>,
+) -> BuildOutput {
+    let CycleTransport { stderr, outcome } = transport;
+    match outcome {
+        TransportOutcome::Rejected => BuildOutput {
+            result: BuildResult::Rejected { stderr },
+            bytes: Vec::new(),
+        },
+        TransportOutcome::Canceled => BuildOutput {
+            result: BuildResult::Canceled,
+            bytes: Vec::new(),
+        },
+        TransportOutcome::Ready {
+            target,
+            bytes,
+            destination,
+            inputs,
+            published,
+        } => {
+            let (path, display_path, source_paths) = destination.into_parts();
+            BuildOutput {
+                result: BuildResult::Ready {
+                    stderr,
+                    target: target.to_string(),
+                    destination: DestinationRecord {
+                        path: path.display().to_string(),
+                        display_path: display_path.display().to_string(),
+                        source_paths: source_paths
+                            .into_iter()
+                            .map(|path| path.display().to_string())
+                            .collect(),
+                    },
+                    inputs: inputs.into_iter().map(input_record).collect(),
+                    bytes: bytes.len() as u64,
+                    test_image: companion(published),
+                },
+                bytes,
+            }
+        }
     }
 }
 
@@ -266,10 +372,12 @@ mod tests {
 
         fn request(&self, output: &str) -> BuildRequest {
             BuildRequest {
+                artifact: BuildKind::Executable,
                 working_directory: self.directory.path().display().to_string(),
                 root_source: "main.rue".into(),
                 output_path: output.into(),
                 source_manifest_path: None,
+                test_candidates_path: None,
                 std_root: None,
                 workers: 1,
                 target: rue_target::Target::host().unwrap().to_string(),
@@ -419,5 +527,209 @@ mod tests {
         assert!(stderr.contains("absent.rue"), "{stderr}");
         assert!(stderr.ends_with('\n'));
         assert_eq!(executor.retained_hosts(), 0);
+    }
+}
+
+#[cfg(test)]
+mod test_request_tests {
+    use std::fs;
+
+    use rue_driver::daemon::UnimportedRecord;
+
+    use super::*;
+
+    const SUITE: &str = "fn add(a: i32, b: i32) -> i32 { a + b }\n\
+                         test \"adds\" { @assert(add(1, 2) == 3); }\n\
+                         test \"broken\" { let x: i32 = \"nope\"; @assert(x == 1); }\n\
+                         fn main() -> i32 { 0 }\n";
+
+    struct Suite {
+        directory: tempfile::TempDir,
+    }
+
+    impl Suite {
+        fn new() -> Self {
+            let directory = tempfile::tempdir().unwrap();
+            fs::write(directory.path().join("main.rue"), SUITE).unwrap();
+            fs::write(
+                directory.path().join("extra_tests.rue"),
+                "test \"never imported\" { }\n",
+            )
+            .unwrap();
+            fs::write(
+                directory.path().join("candidates.txt"),
+                "main.rue\nextra_tests.rue\n",
+            )
+            .unwrap();
+            Self { directory }
+        }
+
+        fn request(&self, artifact: BuildKind, output: &str) -> BuildRequest {
+            BuildRequest {
+                artifact,
+                working_directory: self.directory.path().display().to_string(),
+                root_source: "main.rue".into(),
+                output_path: output.into(),
+                source_manifest_path: None,
+                test_candidates_path: None,
+                std_root: None,
+                workers: 1,
+                target: rue_target::Target::host().unwrap().to_string(),
+                opt_level: "O0".into(),
+                preview_features: Vec::new(),
+                link_archives: Vec::new(),
+                error_format: DiagnosticFormat::Text,
+                color: false,
+            }
+        }
+    }
+
+    #[test]
+    fn a_test_image_carries_the_runner_companion_and_shares_the_host() {
+        let suite = Suite::new();
+        let mut executor = Executor::new();
+        let cancellation = CompilationCancellation::new();
+
+        let mut request = suite.request(BuildKind::TestImage, "image");
+        request.test_candidates_path = Some("candidates.txt".into());
+        let answer = executor.build(&request, &cancellation);
+        let BuildResult::Ready {
+            stderr,
+            test_image: Some(record),
+            bytes: announced,
+            ..
+        } = &answer.result
+        else {
+            panic!(
+                "a test image is ready with its companion: {:?}",
+                answer.result
+            );
+        };
+        assert_eq!(*announced, answer.bytes.len() as u64);
+        assert!(
+            stderr.contains("E0206"),
+            "the closure's analysis failures are on stderr: {stderr}"
+        );
+        let ids: Vec<&str> = record
+            .entries
+            .iter()
+            .map(|entry| entry.id.as_str())
+            .collect();
+        assert_eq!(ids, ["main.rue::adds", "main.rue::broken"]);
+        assert_eq!(record.compile_failures.len(), 1);
+        let failure = &record.compile_failures[0];
+        assert_eq!(
+            failure.ordinal, record.entries[1].ordinal,
+            "the failure is attributed to the broken test"
+        );
+        assert!(failure.xfail_eligible);
+        assert!(failure.payload.starts_with("E0206: "));
+        assert_eq!(failure.diagnostics[0]["code"], "E0206");
+        assert_eq!(
+            failure
+                .location
+                .as_ref()
+                .map(|(file, line, _)| (file.as_str(), *line)),
+            Some(("main.rue", 3))
+        );
+        assert!(!record.multi_module_closure);
+        let UnimportedRecord::Files { stderr, files } = &record.unimported else {
+            panic!(
+                "declared candidates produce a report: {:?}",
+                record.unimported
+            );
+        };
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "extra_tests.rue");
+        assert_eq!(files[0].tests, 1);
+        assert!(stderr.contains("extra_tests.rue"), "{stderr}");
+        assert_eq!(executor.retained_hosts(), 1);
+
+        // The executable request over the same host neither sees the test
+        // closure's failure nor links its tests (ADR-0083 §1).
+        let executable =
+            executor.build(&suite.request(BuildKind::Executable, "app"), &cancellation);
+        let BuildResult::Ready {
+            stderr,
+            test_image: None,
+            ..
+        } = &executable.result
+        else {
+            panic!("{:?}", executable.result);
+        };
+        assert_eq!(
+            stderr, "",
+            "a test-only failure never poisons an executable"
+        );
+        assert_eq!(executor.retained_hosts(), 1);
+
+        // And the listing, over the same host again, lists both and repeats
+        // the analysis diagnostics.
+        let listing = executor.build(
+            &suite.request(BuildKind::TestListing, "unused"),
+            &cancellation,
+        );
+        let BuildResult::Listing {
+            stderr,
+            entries: Some(entries),
+        } = &listing.result
+        else {
+            panic!("{:?}", listing.result);
+        };
+        assert!(stderr.contains("E0206"), "{stderr}");
+        assert_eq!(entries.len(), 2);
+        assert!(listing.bytes.is_empty(), "a listing links nothing");
+        assert_eq!(executor.retained_hosts(), 1);
+
+        // A fresh executor renders the same image companion.
+        let fresh = Executor::new().build(&request, &cancellation);
+        let BuildResult::Ready {
+            stderr: fresh_stderr,
+            test_image: Some(fresh_record),
+            ..
+        } = fresh.result
+        else {
+            panic!("{:?}", fresh.result);
+        };
+        assert_eq!(&fresh_stderr, stderr_of(&answer.result));
+        assert_eq!(*fresh_record, **record);
+    }
+
+    fn stderr_of(result: &BuildResult) -> &String {
+        match result {
+            BuildResult::Ready { stderr, .. }
+            | BuildResult::Rejected { stderr }
+            | BuildResult::Listing { stderr, .. } => stderr,
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_broken_candidate_list_is_the_direct_failure_and_a_listing_can_be_canceled() {
+        let suite = Suite::new();
+        let mut executor = Executor::new();
+        let mut request = suite.request(BuildKind::TestImage, "image");
+        request.test_candidates_path = Some("missing.txt".into());
+        let answer = executor.build(&request, &CompilationCancellation::new());
+        let BuildResult::Rejected { stderr } = &answer.result else {
+            panic!("{:?}", answer.result);
+        };
+        assert!(stderr.contains("missing.txt"), "{stderr}");
+
+        let canceled = CompilationCancellation::new();
+        canceled.cancel();
+        let listing = executor.build(&suite.request(BuildKind::TestListing, "unused"), &canceled);
+        assert!(matches!(listing.result, BuildResult::Canceled));
+        let live = executor.build(
+            &suite.request(BuildKind::TestListing, "unused"),
+            &CompilationCancellation::new(),
+        );
+        assert!(matches!(
+            live.result,
+            BuildResult::Listing {
+                entries: Some(_),
+                ..
+            }
+        ));
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -287,8 +287,9 @@ Usage: rue [options] <root.rue> [output]
 
 The compiler takes exactly one root source file and discovers every other
 file through its @import graph; pass build-system inputs with --source-manifest.
-An ordinary internal-linker build can run through the local compiler service
-with --daemon=auto or --daemon=required (ADR-0085); the default is off.
+An ordinary internal-linker build or `rue test` can run through the local
+compiler service with --daemon=auto or --daemon=required (ADR-0085); the
+default is off.
 
 Commands:
   explain <E####>      Show the compiler-owned explanation for an error code
@@ -371,10 +372,11 @@ Options:
   --daemon <mode>      off (default): compile in this process; auto: use or
                        start the compiler service for supported requests and
                        compile directly otherwise; required: the service must
-                       run it. Supported: ordinary internal-linker builds.
-                       --watch, --emit, --linker, --time-passes,
-                       --benchmark-json, rue test, and compiler tracing run
-                       directly under auto and are refused under required.
+                       run it. Supported: ordinary internal-linker builds,
+                       rue test, and rue test --list. --watch, --emit,
+                       --linker, --time-passes, --benchmark-json, and
+                       compiler tracing run directly under auto and are
+                       refused under required.
   --daemon-scope <dir> The service scope directory (default: the root source's
                        directory); --daemon-isolation <name> selects a
                        separate service within it. Both match `rue daemon`.
@@ -1154,7 +1156,7 @@ fn validate_mode_combinations(options: &Options) -> Result<(), String> {
 /// shared query budget's own auto-detection", while a test run has to name a
 /// concrete number of concurrent processes. ADR-0083 §3's default is every
 /// test in parallel, so zero resolves to available parallelism.
-fn test_mode_jobs(jobs: usize) -> usize {
+pub(crate) fn test_mode_jobs(jobs: usize) -> usize {
     if jobs > 0 {
         return jobs;
     }
@@ -1186,7 +1188,7 @@ pub(crate) fn compile_pool_jobs(mode: &DriverMode, jobs: usize) -> usize {
 /// is run later, possibly elsewhere, and "whatever the host was" is not a
 /// reproduction. `--filter`, `--exact`, and `--seed` are added by the runner,
 /// which owns the identity being reproduced.
-fn test_repro_flags(options: &Options, path_context: &HostPathContext) -> Vec<String> {
+pub(crate) fn test_repro_flags(options: &Options, path_context: &HostPathContext) -> Vec<String> {
     let mut flags = vec![
         "--target".to_string(),
         options.target.to_string(),
@@ -1231,7 +1233,7 @@ fn test_repro_flags(options: &Options, path_context: &HostPathContext) -> Vec<St
 /// The CLI's empty spelling means "no toolchain std is configured" and is
 /// carried verbatim — absolutizing it would silently turn that into the
 /// current directory, which is a different run.
-fn test_repro_env(std_root: Option<&Path>) -> Vec<(String, String)> {
+pub(crate) fn test_repro_env(std_root: Option<&Path>) -> Vec<(String, String)> {
     let Some(std_root) = std_root else {
         return Vec::new();
     };
@@ -1464,7 +1466,7 @@ impl<'a> DiagnosticOutput<'a> {
         }
     }
 
-    fn render_errors(&self, errors: &CompileErrors) -> String {
+    pub(crate) fn render_errors(&self, errors: &CompileErrors) -> String {
         let errors = with_import_migration_helps(errors);
         self.render_prepared_errors(&errors)
     }

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -30,8 +30,14 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use rue_compiler::unstable::{SourceInfo, TestCandidateInventory, TestInventoryEntry};
+use rue_compiler::unstable::{
+    ColorChoice, SourceInfo, TestCandidateInventory, TestExpectedFailure, TestInventoryEntry,
+};
 use rue_compiler::{AcceptedReadManifest, CompileErrors, CompileOptions, OptLevel, SourceSnapshot};
+use rue_driver::daemon::{
+    CompileFailureRecord, InventoryEntryRecord, TestImageRecord, UnimportedFileRecord,
+    UnimportedRecord,
+};
 use rue_driver::{AttemptedRead, FilesystemCompilerHost, WatchInput};
 use rue_target::Target;
 
@@ -283,6 +289,108 @@ pub(crate) fn run(request: TestRequest<'_, '_>) -> TestExitCode {
     }
 }
 
+/// A run whose image the compiler service linked (ADR-0085 §5): the runner
+/// half of [`run`], over the projection the service sent.
+pub(crate) struct ServiceRun<'a> {
+    pub(crate) record: TestImageRecord,
+    pub(crate) image_path: &'a Path,
+    pub(crate) run_root: &'a Path,
+    pub(crate) options: &'a TestOptions,
+    pub(crate) root: &'a str,
+    pub(crate) repro_root: &'a str,
+    pub(crate) repro_flags: &'a [String],
+    pub(crate) repro_env: &'a [(String, String)],
+    pub(crate) jobs: usize,
+    pub(crate) target: Target,
+    pub(crate) opt_level: OptLevel,
+    pub(crate) candidates_declared: bool,
+    pub(crate) seed: u64,
+}
+
+/// The private directory and image path a service-linked run stages its
+/// image in, created before the request is submitted so the service's
+/// destination preflight sees it.
+pub(crate) fn service_run_root(
+    seed: u64,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
+    let run_root = exec::run_root(seed, None);
+    std::fs::create_dir_all(&run_root)
+        .map_err(|error| format!("could not create the test run directory: {error}"))?;
+    let image_path = run_root.join("rue-test-image");
+    Ok((run_root, image_path))
+}
+
+/// Run a service-linked image. The process-level setup [`run`] performs
+/// happens here too: nothing may spawn before the channel descriptor is
+/// pinned and the signal forwarding installed.
+pub(crate) fn run_service_image(request: ServiceRun<'_>) -> TestExitCode {
+    exec::reserve_channel_descriptor();
+    exec::install_signal_forwarding();
+    let ServiceRun {
+        record,
+        image_path,
+        run_root,
+        options,
+        root,
+        repro_root,
+        repro_flags,
+        repro_env,
+        jobs,
+        target,
+        opt_level,
+        candidates_declared,
+        seed,
+    } = request;
+    let outcome = run_prepared(PreparedRun {
+        prepared: PreparedImage::from_record(record),
+        image_path,
+        run_root,
+        options,
+        root,
+        repro_root,
+        repro_flags,
+        repro_env,
+        jobs,
+        target,
+        opt_level,
+        candidates: if candidates_declared {
+            CandidateSource::Declared
+        } else {
+            CandidateSource::None
+        },
+        seed,
+        cycle: None,
+        cancellation: None,
+    });
+    match outcome {
+        CycleOutcome::Finished(exit) => exit,
+        CycleOutcome::Canceled | CycleOutcome::Superseded(_) => TestExitCode::RunnerError,
+    }
+}
+
+/// List a service-produced inventory: what the service rendered goes to
+/// stderr, then the selection is emitted exactly as a direct listing is.
+pub(crate) fn run_service_listing(
+    stderr: String,
+    entries: Option<Vec<InventoryEntryRecord>>,
+    options: &TestOptions,
+) -> TestExitCode {
+    let reporter = Reporter::new(options.format, render::Context::default());
+    finish_listing(
+        ListingTransport {
+            stderr,
+            entries: entries.map(|entries| {
+                entries
+                    .into_iter()
+                    .map(inventory_entry_from_record)
+                    .collect()
+            }),
+        },
+        options,
+        &reporter,
+    )
+}
+
 /// Everything one test cycle needs.
 ///
 /// One-shot mode drives exactly one of these; `rue test --watch` drives one per
@@ -391,21 +499,262 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
             return CycleOutcome::Superseded(boundary);
         }
     };
-    // Built here rather than above because the closure is only published once
-    // the image is: nothing before this point could answer how many modules the
-    // program has.
+    let prepared = prepare_image(image, multi_module_closure, ColorChoice::Auto);
+    run_prepared(PreparedRun {
+        prepared,
+        image_path: &image_path,
+        run_root: &run_root,
+        options,
+        root,
+        repro_root,
+        repro_flags,
+        repro_env,
+        jobs,
+        target,
+        opt_level,
+        candidates: candidate_source(candidates),
+        seed,
+        cycle,
+        cancellation,
+    })
+}
+
+/// What a test image carries beside its bytes, projected once into the owned,
+/// render-complete form the runner consumes (ADR-0083 §3): the inventory, the
+/// `compile_error` verdicts with their rendered payloads and JSON copies, and
+/// the unimported-test-file report with its warnings rendered.
+///
+/// Both ways of obtaining an image end here. A direct run projects its own
+/// published image; a run through the compiler service receives the same
+/// projection over the wire (ADR-0085 §5). The runner therefore cannot tell
+/// them apart, which is what keeps the two streams identical by construction
+/// rather than by care.
+pub(crate) struct PreparedImage {
+    multi_module_closure: bool,
+    entries: Vec<TestInventoryEntry>,
+    compile_errors: CompileErrorVerdicts,
+    unimported: UnimportedReport,
+}
+
+/// The unimported-test-file report (ADR-0083 §1), with whatever the direct
+/// path prints for it already rendered.
+enum UnimportedReport {
+    NotDeclared,
+    Files {
+        stderr: String,
+        files: Vec<UnimportedFile>,
+    },
+    Failed {
+        stderr: String,
+    },
+}
+
+/// Project a published image for the runner, rendering under `color`.
+pub(crate) fn prepare_image(
+    image: crate::compile::PublishedTestImage,
+    multi_module_closure: bool,
+    color: ColorChoice,
+) -> PreparedImage {
+    let diagnostics = diagnostics_for_snapshot(image.error_format, &image.source_snapshot, color);
+    let compile_errors = CompileErrorVerdicts::new(&image.compile_failures, &diagnostics);
+    let unimported = match image.unimported_test_files {
+        None => UnimportedReport::NotDeclared,
+        Some(Err(errors)) => UnimportedReport::Failed {
+            stderr: format!("{}\n", diagnostics.render_prepared_errors(&errors)),
+        },
+        Some(Ok(files)) => {
+            let warnings: Vec<rue_compiler::CompileWarning> = files
+                .iter()
+                .map(|file| {
+                    let kind = if file.parse_failed {
+                        rue_error::WarningKind::UnimportedTestFileUnparsable {
+                            path: file.path.clone(),
+                        }
+                    } else {
+                        rue_error::WarningKind::UnimportedTestFile {
+                            path: file.path.clone(),
+                            tests: file.tests,
+                        }
+                    };
+                    rue_compiler::CompileWarning::without_span(kind)
+                })
+                .collect();
+            UnimportedReport::Files {
+                stderr: if warnings.is_empty() {
+                    String::new()
+                } else {
+                    format!("{}\n", diagnostics.render_warnings(&warnings))
+                },
+                files: files
+                    .iter()
+                    .map(|file| UnimportedFile {
+                        path: file.path.clone(),
+                        tests: file.tests,
+                        parse_failed: file.parse_failed,
+                    })
+                    .collect(),
+            }
+        }
+    };
+    PreparedImage {
+        multi_module_closure,
+        entries: image.inventory.entries,
+        compile_errors,
+        unimported,
+    }
+}
+
+impl PreparedImage {
+    /// The wire form (ADR-0085 §5).
+    pub(crate) fn into_record(self) -> TestImageRecord {
+        TestImageRecord {
+            multi_module_closure: self.multi_module_closure,
+            entries: self
+                .entries
+                .into_iter()
+                .map(inventory_entry_record)
+                .collect(),
+            compile_failures: self.compile_errors.into_records(),
+            unimported: match self.unimported {
+                UnimportedReport::NotDeclared => UnimportedRecord::NotDeclared,
+                UnimportedReport::Files { stderr, files } => UnimportedRecord::Files {
+                    stderr,
+                    files: files
+                        .into_iter()
+                        .map(|file| UnimportedFileRecord {
+                            path: file.path,
+                            tests: file.tests,
+                            parse_failed: file.parse_failed,
+                        })
+                        .collect(),
+                },
+                UnimportedReport::Failed { stderr } => UnimportedRecord::Failed { stderr },
+            },
+        }
+    }
+
+    pub(crate) fn from_record(record: TestImageRecord) -> Self {
+        Self {
+            multi_module_closure: record.multi_module_closure,
+            entries: record
+                .entries
+                .into_iter()
+                .map(inventory_entry_from_record)
+                .collect(),
+            compile_errors: CompileErrorVerdicts::from_records(record.compile_failures),
+            unimported: match record.unimported {
+                UnimportedRecord::NotDeclared => UnimportedReport::NotDeclared,
+                UnimportedRecord::Files { stderr, files } => UnimportedReport::Files {
+                    stderr,
+                    files: files
+                        .into_iter()
+                        .map(|file| UnimportedFile {
+                            path: file.path,
+                            tests: file.tests,
+                            parse_failed: file.parse_failed,
+                        })
+                        .collect(),
+                },
+                UnimportedRecord::Failed { stderr } => UnimportedReport::Failed { stderr },
+            },
+        }
+    }
+}
+
+pub(crate) fn inventory_entry_record(entry: TestInventoryEntry) -> InventoryEntryRecord {
+    InventoryEntryRecord {
+        id: entry.id,
+        module: entry.module,
+        name: entry.name,
+        file: entry.file,
+        line: entry.line,
+        column: entry.column,
+        ordinal: entry.ordinal,
+        expected_failures: entry
+            .expected_failures
+            .into_iter()
+            .map(|marker| (marker.issue, marker.platform))
+            .collect(),
+    }
+}
+
+pub(crate) fn inventory_entry_from_record(record: InventoryEntryRecord) -> TestInventoryEntry {
+    TestInventoryEntry {
+        id: record.id,
+        module: record.module,
+        name: record.name,
+        file: record.file,
+        line: record.line,
+        column: record.column,
+        ordinal: record.ordinal,
+        expected_failures: record
+            .expected_failures
+            .into_iter()
+            .map(|(issue, platform)| TestExpectedFailure { issue, platform })
+            .collect(),
+    }
+}
+
+/// Everything the run of an already prepared image needs.
+pub(crate) struct PreparedRun<'a> {
+    pub(crate) prepared: PreparedImage,
+    /// Where the image's bytes already are.
+    pub(crate) image_path: &'a Path,
+    pub(crate) run_root: &'a Path,
+    pub(crate) options: &'a TestOptions,
+    pub(crate) root: &'a str,
+    pub(crate) repro_root: &'a str,
+    pub(crate) repro_flags: &'a [String],
+    pub(crate) repro_env: &'a [(String, String)],
+    pub(crate) jobs: usize,
+    pub(crate) target: Target,
+    pub(crate) opt_level: OptLevel,
+    pub(crate) candidates: CandidateSource,
+    pub(crate) seed: u64,
+    pub(crate) cycle: Option<u64>,
+    pub(crate) cancellation: Option<&'a exec::RunCancellation>,
+}
+
+/// Run the plan over a prepared image: the half of a cycle after the image
+/// exists, shared by direct runs, watch cycles, and runs through the compiler
+/// service.
+pub(crate) fn run_prepared(request: PreparedRun<'_>) -> CycleOutcome {
+    let PreparedRun {
+        prepared,
+        image_path,
+        run_root,
+        options,
+        root,
+        repro_root,
+        repro_flags,
+        repro_env,
+        jobs,
+        target,
+        opt_level,
+        candidates,
+        seed,
+        cycle,
+        cancellation,
+    } = request;
+    let PreparedImage {
+        multi_module_closure,
+        entries,
+        compile_errors,
+        unimported,
+    } = prepared;
+    // Built here rather than earlier because the closure is only published
+    // once the image is: nothing before this point could answer how many
+    // modules the program has.
     let reporter = Reporter::new(
         options.format,
         render::Context {
             multi_module_closure,
         },
     );
-    let diagnostics = diagnostics_for_snapshot(image.error_format, &image.source_snapshot);
-    let compile_errors = CompileErrorVerdicts::new(&image.compile_failures, &diagnostics);
 
-    let total = image.inventory.entries.len();
+    let total = entries.len();
     let plan = selection::plan(
-        &image.inventory.entries,
+        &entries,
         &options.filters,
         options.exact,
         options.shard,
@@ -427,11 +776,10 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
     watch_milestone("run-started");
 
     if plan.is_empty() {
-        discard_run_root(&image_path, &run_root);
-        let unimported = match report_unimported(image.unimported_test_files.as_ref(), &diagnostics)
-        {
+        discard_run_root(image_path, run_root);
+        let unimported = match report_unimported(&unimported) {
             Ok(unimported) => unimported,
-            Err(_) => return CycleOutcome::Finished(TestExitCode::RunnerError),
+            Err(()) => return CycleOutcome::Finished(TestExitCode::RunnerError),
         };
         // Said before the terminal event, so a reader of an interleaved
         // terminal sees the reason ahead of the vacuous "0 passed" summary.
@@ -446,7 +794,7 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
             xpass: 0,
             wall_ms: elapsed_ms(started),
             unimported_test_files: unimported,
-            test_candidates: candidate_source(candidates),
+            test_candidates: candidates,
         });
         watch_milestone("run-finished");
         return CycleOutcome::Finished(TestExitCode::EmptySelection);
@@ -460,8 +808,8 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
         plan: &plan,
         compile_errors: &compile_errors,
         target,
-        image: &image_path,
-        run_root: &run_root,
+        image: image_path,
+        run_root,
         seed,
         timeout: Duration::from_millis(options.timeout_ms),
         jobs,
@@ -475,7 +823,7 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
     // The image is the runner's own artifact and is never retained; the run
     // root goes with it unless a failing test left a scratch directory behind,
     // in which case the non-recursive removal fails and the evidence survives.
-    discard_run_root(&image_path, &run_root);
+    discard_run_root(image_path, run_root);
 
     // An edit that landed mid-run killed the tests that were still going, so
     // the counts describe neither the whole plan nor the verdicts that would
@@ -499,9 +847,9 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
         return CycleOutcome::Finished(TestExitCode::RunnerError);
     }
 
-    let unimported = match report_unimported(image.unimported_test_files.as_ref(), &diagnostics) {
+    let unimported = match report_unimported(&unimported) {
         Ok(unimported) => unimported,
-        Err(_) => return CycleOutcome::Finished(TestExitCode::RunnerError),
+        Err(()) => return CycleOutcome::Finished(TestExitCode::RunnerError),
     };
     reporter.emit(&Event::RunFinished {
         passed: outcome.passed,
@@ -513,7 +861,7 @@ pub(crate) fn run_cycle(request: CycleRequest<'_, '_>) -> CycleOutcome {
         xpass: outcome.xpass,
         wall_ms: elapsed_ms(started),
         unimported_test_files: unimported,
-        test_candidates: candidate_source(candidates),
+        test_candidates: candidates,
     });
     watch_milestone("run-finished");
 
@@ -612,6 +960,46 @@ impl CompileErrorVerdicts {
 
     fn get(&self, ordinal: u32) -> Option<&CompileErrorVerdict> {
         self.by_ordinal.get(&ordinal)
+    }
+
+    fn into_records(self) -> Vec<CompileFailureRecord> {
+        self.by_ordinal
+            .into_iter()
+            .map(|(ordinal, verdict)| CompileFailureRecord {
+                ordinal,
+                xfail_eligible: verdict.xfail_eligible,
+                payload: verdict.payload,
+                message: verdict.message,
+                location: verdict
+                    .location
+                    .map(|location| (location.file, location.line, location.column)),
+                diagnostics: verdict.diagnostics,
+            })
+            .collect()
+    }
+
+    fn from_records(records: Vec<CompileFailureRecord>) -> Self {
+        Self {
+            by_ordinal: records
+                .into_iter()
+                .map(|record| {
+                    (
+                        record.ordinal,
+                        CompileErrorVerdict {
+                            xfail_eligible: record.xfail_eligible,
+                            payload: record.payload,
+                            message: record.message,
+                            location: record.location.map(|(file, line, column)| Location {
+                                file,
+                                line,
+                                column,
+                            }),
+                            diagnostics: record.diagnostics,
+                        },
+                    )
+                })
+                .collect(),
+        }
     }
 }
 
@@ -750,49 +1138,120 @@ fn produce_listing(
     }
 }
 
+/// A listing rendered for its consumer: what goes to stderr, and the
+/// inventory when the listing succeeded. Direct and service listings both
+/// end in [`finish_listing`] over this (ADR-0085 §5).
+pub(crate) struct ListingTransport {
+    pub(crate) stderr: String,
+    /// `None` when the listing itself was refused; `stderr` says why.
+    pub(crate) entries: Option<Vec<TestInventoryEntry>>,
+}
+
+impl OwnedListingResponse {
+    fn into_transport(self, color: ColorChoice) -> ListingTransport {
+        let OwnedListingResponse {
+            source_snapshot,
+            accepted_reads,
+            attempted_reads,
+            watch_inputs,
+            error_format,
+            result,
+        } = self;
+        drop((accepted_reads, attempted_reads, watch_inputs));
+        let diagnostics = diagnostics_for_snapshot(error_format, &source_snapshot, color);
+        let listing = match result {
+            Ok(listing) => listing,
+            Err(errors) => {
+                return ListingTransport {
+                    stderr: format!("{}\n", diagnostics.render_prepared_errors(&errors)),
+                    entries: None,
+                };
+            }
+        };
+        let rue_compiler::unstable::TestListing {
+            inventory,
+            failure_diagnostics,
+        } = listing;
+        // A listing still lists every declaration and still succeeds, but it
+        // says what the run would say about the bodies that did not analyze:
+        // on stderr, in the run's own `--error-format`, through the same
+        // renderer. A listing that swallowed them would be the papercut the
+        // run path refuses to be — a reader inspecting a suite would see
+        // nothing wrong with tests the run will report as `compile_error`.
+        let stderr = if failure_diagnostics.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "{}\n",
+                diagnostics.render_prepared_errors(&failure_diagnostics)
+            )
+        };
+        ListingTransport {
+            stderr,
+            entries: Some(inventory.entries),
+        }
+    }
+}
+
+/// Produce a listing for the compiler service, rendered under `color`.
+pub(crate) fn produce_listing_transport(
+    host: &mut FilesystemCompilerHost,
+    compile_options: &CompileOptions,
+    error_format: crate::ErrorFormat,
+    color: ColorChoice,
+    cancellation: &rue_compiler::unstable::CompilationCancellation,
+) -> Option<ListingTransport> {
+    let source_snapshot = host.source_snapshot().clone();
+    let result = match host.cancellable_test_inventory(compile_options, cancellation.clone()) {
+        rue_compiler::unstable::CancellableTestListingOutcome::Completed(mut listing) => {
+            listing.failure_diagnostics =
+                rue_driver::with_import_migration_helps(&listing.failure_diagnostics);
+            Ok(listing)
+        }
+        rue_compiler::unstable::CancellableTestListingOutcome::Errors(errors) => {
+            Err(rue_driver::with_import_migration_helps(&errors))
+        }
+        rue_compiler::unstable::CancellableTestListingOutcome::Canceled => return None,
+    };
+    Some(
+        OwnedListingResponse {
+            source_snapshot,
+            accepted_reads: host.accepted_reads().clone(),
+            attempted_reads: host.attempted_reads().to_vec(),
+            watch_inputs: host.watch_inputs(),
+            error_format,
+            result,
+        }
+        .into_transport(color),
+    )
+}
+
 fn complete_listing(
     response: OwnedListingResponse,
     options: &TestOptions,
     reporter: &Reporter,
 ) -> TestExitCode {
-    let OwnedListingResponse {
-        source_snapshot,
-        accepted_reads,
-        attempted_reads,
-        watch_inputs,
-        error_format,
-        result,
-    } = response;
-    drop((accepted_reads, attempted_reads, watch_inputs));
-    let diagnostics = diagnostics_for_snapshot(error_format, &source_snapshot);
-    let listing = match result {
-        Ok(listing) => listing,
-        Err(errors) => {
-            diagnostics.print_prepared_errors(&errors);
-            return TestExitCode::RunnerError;
-        }
+    finish_listing(
+        response.into_transport(ColorChoice::Auto),
+        options,
+        reporter,
+    )
+}
+
+/// Print what the listing rendered, then list the selection.
+fn finish_listing(
+    transport: ListingTransport,
+    options: &TestOptions,
+    reporter: &Reporter,
+) -> TestExitCode {
+    let ListingTransport { stderr, entries } = transport;
+    eprint!("{stderr}");
+    let Some(entries) = entries else {
+        return TestExitCode::RunnerError;
     };
-    let rue_compiler::unstable::TestListing {
-        inventory,
-        failure_diagnostics,
-    } = listing;
-    // A listing still lists every declaration and still succeeds, but it says
-    // what the run would say about the bodies that did not analyze: on stderr,
-    // in the run's own `--error-format`, through the same renderer. A listing
-    // that swallowed them would be the papercut the run path refuses to be —
-    // a reader inspecting a suite would see nothing wrong with tests the run
-    // will report as `compile_error`.
-    if !failure_diagnostics.is_empty() {
-        diagnostics.print_prepared_errors(&failure_diagnostics);
-    }
-    let selected = selection::select(
-        &inventory.entries,
-        &options.filters,
-        options.exact,
-        options.shard,
-    );
+    let selected = selection::select(&entries, &options.filters, options.exact, options.shard);
     if selected.is_empty() {
-        eprintln!("{}", empty_selection_reason(inventory.entries.len()));
+        eprintln!("{}", empty_selection_reason(entries.len()));
         return TestExitCode::EmptySelection;
     }
     for entry in selected {
@@ -1434,62 +1893,32 @@ pub(crate) fn std_root_spelling(path: &Path) -> String {
 ///
 /// Returns `Err(())` when the report itself failed; its diagnostics have
 /// already been presented.
-fn report_unimported(
-    report: Option<
-        &Result<Vec<rue_compiler::unstable::UnimportedTestFile>, rue_compiler::CompileErrors>,
-    >,
-    diagnostics: &crate::DiagnosticOutput<'_>,
-) -> Result<Option<Vec<UnimportedFile>>, ()> {
-    let Some(report) = report else {
-        return Ok(None);
-    };
-    let files = match report {
-        Ok(files) => files,
-        Err(errors) => {
-            diagnostics.print_prepared_errors(errors);
-            return Err(());
+/// Say what the prepared report says, where the direct path always said it:
+/// after the run, before `run_finished`.
+fn report_unimported(report: &UnimportedReport) -> Result<Option<Vec<UnimportedFile>>, ()> {
+    match report {
+        UnimportedReport::NotDeclared => Ok(None),
+        UnimportedReport::Failed { stderr } => {
+            eprint!("{stderr}");
+            Err(())
         }
-    };
-    let warnings: Vec<rue_compiler::CompileWarning> = files
-        .iter()
-        .map(|file| {
-            let kind = if file.parse_failed {
-                rue_error::WarningKind::UnimportedTestFileUnparsable {
-                    path: file.path.clone(),
-                }
-            } else {
-                rue_error::WarningKind::UnimportedTestFile {
-                    path: file.path.clone(),
-                    tests: file.tests,
-                }
-            };
-            rue_compiler::CompileWarning::without_span(kind)
-        })
-        .collect();
-    if !warnings.is_empty() {
-        diagnostics.print_warnings(&warnings);
+        UnimportedReport::Files { stderr, files } => {
+            eprint!("{stderr}");
+            Ok(Some(files.clone()))
+        }
     }
-    Ok(Some(
-        files
-            .iter()
-            .map(|file| UnimportedFile {
-                path: file.path.clone(),
-                tests: file.tests,
-                parse_failed: file.parse_failed,
-            })
-            .collect(),
-    ))
 }
 
 fn diagnostics_for_snapshot(
     format: crate::ErrorFormat,
     snapshot: &rue_compiler::SourceSnapshot,
+    color: ColorChoice,
 ) -> crate::DiagnosticOutput<'_> {
     let sources = snapshot
         .files()
         .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
         .collect();
-    crate::DiagnosticOutput::new(format, sources)
+    crate::DiagnosticOutput::with_color(format, sources, color)
 }
 
 #[cfg(test)]

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -796,8 +796,7 @@ pub(crate) fn run_prepared(request: PreparedRun<'_>) -> CycleOutcome {
             unimported_test_files: unimported,
             test_candidates: candidates,
         });
-        watch_milestone("run-finished");
-        return CycleOutcome::Finished(TestExitCode::EmptySelection);
+        return finish_run(TestExitCode::EmptySelection, cycle);
     }
 
     // A repro is pasted into some other shell, from some other directory, so it
@@ -863,12 +862,11 @@ pub(crate) fn run_prepared(request: PreparedRun<'_>) -> CycleOutcome {
         unimported_test_files: unimported,
         test_candidates: candidates,
     });
-    watch_milestone("run-finished");
 
     // A `compile_error` test is a failed test, not a failed run: exit 1 with
     // the other tests' verdicts, never the 2 that says nothing ran
     // (ADR-0083 §3).
-    CycleOutcome::Finished(
+    finish_run(
         if outcome.failed + outcome.timeout + outcome.crash + outcome.compile_error + outcome.xpass
             > 0
         {
@@ -876,7 +874,24 @@ pub(crate) fn run_prepared(request: PreparedRun<'_>) -> CycleOutcome {
         } else {
             TestExitCode::AllPassed
         },
+        cycle,
     )
+}
+
+/// End a cycle that published `run_finished`.
+///
+/// A watch cycle publishes its exit status before the `run-finished`
+/// milestone, not after: the milestone is what a driver waits for before it
+/// stops the watcher, and the interrupt handler answers with the last status
+/// published, so a status published after the milestone could lose the race
+/// and report the previous cycle's. The watch loop stores the same status
+/// again when the outcome reaches it, which is harmless.
+fn finish_run(exit: TestExitCode, cycle: Option<u64>) -> CycleOutcome {
+    if cycle.is_some() {
+        exec::set_watch_exit_status(exit);
+    }
+    watch_milestone("run-finished");
+    CycleOutcome::Finished(exit)
 }
 
 /// Remove the cycle's image and, if nothing retained a scratch directory

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,7 +84,7 @@ any failure is the invocation's failure and nothing is retried.
 | Request | `auto` | `required` |
 | --- | --- | --- |
 | Ordinary internal-linker build | service | service |
-| `rue test`, `rue test --list` | direct (its own slice of RUE-2128) | refused |
+| `rue test`, `rue test --list` (the image or inventory; the runner stays in the client) | service | service |
 | `--watch`, any `--emit`, `--linker <cmd>` | direct | refused |
 | `--time-passes`, `--benchmark-json` | direct | refused |
 | Tracing via `--log-level` or `RUST_LOG` | direct | refused |


### PR DESCRIPTION
The second request-execution slice of RUE-2128 (ADR-0085 §2, §3, §5), stacked on #3110 (RUE-2179) and retargeted to `trunk` once that lands: test-image and test-inventory requests over the same service, protocol and executor, sharing the retained host with executable builds of the same root.

**Requests.** A build request names its artifact: an executable, a test image, or a test listing. Root selection follows the artifact over the one retained host, so a test-only analysis failure never poisons an executable request and executable-only roots never reach an inventory. Every request carries `--test-candidates` as written; the service acquires the declared inventory under the host's read policy in every mode, as the direct path does even for an ordinary build (ADR-0083 §1), and a test image reports against it.

**One preparation boundary.** A published image's companion (the inventory, the per-test compile-failure attribution with its rendered payload, message, location, JSON diagnostics and xfail eligibility, the unimported-test-file report with its warnings rendered, the module count) is projected once, by the canonical renderer under the client's format and color, into the owned form the runner consumes (`PreparedImage`). The run after that point is one function shared by direct runs, watch cycles and service runs; the listing has the same shape (what goes to stderr, then the entries, then one emission path). Direct mode runs through the same projection in-process, so the service cannot drift from it, and the runner, its process groups, stdin/stdout, event stream, verdicts, seeds and exit statuses are untouched and stay in the client (ADR-0083 §2, §3).

**Client.** `rue test` and `rue test --list` under `--daemon=auto|required` submit a test-image or listing request; `rue test --watch` stays direct. The client creates the run's private directory before submission so the image is staged there through the existing publication path (with input revalidation), then runs the plan; a listing prints what the service rendered and emits the selection. A rejected program is the runner's "the run did not happen" status, as directly. The support table, `--help` text and `docs/development.md` move `rue test` to supported.

**Protocol.** `BuildKind` on the request; `BuildResult::Ready` gains the optional `TestImageRecord`; `BuildResult::Listing` carries the rendered stderr and the entries. A round-trip test pins the request inside the internally tagged request body (the artifact field is deliberately not named `kind`, which is that body's tag).

**Coverage.** Executor tests: a test image carries the companion (attribution to the broken test, xfail eligibility, JSON diagnostics, location, the unimported report from declared candidates), the executable request over the same host sees no test-only failure, the listing over the same host lists both tests and repeats the analysis diagnostics, a fresh executor renders the identical companion; a broken candidate list is the direct failure; a canceled listing recovers. CLI cases under `--daemon=required`: a human-format run with pass, fail and `compile_error` verdicts and the diagnostics on stderr, JSON runs with filters and the `compile_error` payload and location, `--list` in stable-ID order with the analysis diagnostics, an empty selection, `--test-candidates` reporting an unimported file, a missing candidate list, and the root's executable build over the same retained host afterwards. Locally, a run's human and JSON streams through the service matched direct mode's apart from timings and the order concurrent `test_started` events happen to be published in.

Verified locally: both driver unit suites, `scripts/rue cli daemon`, `scripts/rue cli rue_test`, `scripts/rue cli test_candidates`, `scripts/rue cli test_declarations`, `scripts/rue cli watch`, the test-runner unit tests, `//crates/rue-oracle-diff:oracle-diff-test`, and the clippy/fmt gates for `rue` and `rue-cli-tests`.

Fixes RUE-2181