### PR TITLE
RUE-2185: answer analysis-only --emit air through the compiler service

### DIFF
--- a/crates/rue-cli-tests/cases/daemon.toml
+++ b/crates/rue-cli-tests/cases/daemon.toml
@@ -122,8 +122,8 @@ name = "the_support_table_decides_between_service_and_direct"
 description = "Requests outside the support table run directly under auto and are refused before any work under required; a refused request starts no service."
 files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
 daemon = { steps = [
-  { args = ["--daemon=required", "--emit", "air", "main.rue"], exit_code = 1, stderr_contains = ["Error: --daemon=required: --emit runs directly"] },
-  { args = ["--daemon=required", "--error-format", "json", "--emit", "air", "main.rue"], exit_code = 1, stderr_contains = ["\"code\":\"E1503\"", "--emit runs directly"] },
+  { args = ["--daemon=required", "--emit", "cfg", "main.rue"], exit_code = 1, stderr_contains = ["Error: --daemon=required: --emit stages other than a sole `air` run directly"] },
+  { args = ["--daemon=required", "--error-format", "json", "--emit", "air", "--emit", "cfg", "main.rue"], exit_code = 1, stderr_contains = ["\"code\":\"E1503\"", "--emit stages other than a sole `air` run directly"] },
   { args = ["--daemon=required", "--watch", "main.rue"], exit_code = 1, stderr_contains = ["Error: --daemon=required: --watch runs directly"] },
   { args = ["--daemon=required", "--linker", "cc", "main.rue"], exit_code = 1, stderr_contains = ["a system linker runs directly"] },
   { args = ["--daemon=required", "--time-passes", "main.rue"], exit_code = 1, stderr_contains = ["--time-passes runs directly"] },
@@ -179,5 +179,35 @@ daemon = { steps = [
   { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["  retained hosts: 1", "  active request: none"] },
   { args = ["--daemon=required", "main.rue", "-o", "app"], exit_code = 0, stdout_contains = ["Compiled main.rue -> app"], run_output = "app", run_output_stdout_contains = ["42\n"] },
   { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["  retained hosts: 1"] },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+] }
+
+[[case]]
+name = "analysis_only_emit_air_goes_through_the_service"
+description = "--emit air under --daemon=required is answered by the service without linking: the AIR text, its warnings, a rejected program's diagnostics and the exit statuses are direct mode's, over the same retained host as the root's executable build."
+files = [{ path = "main.rue", source = """
+fn add(a: i32, b: i32) -> i32 { a + b }
+fn main() -> i32 { let unused: i32 = 7; add(1, 2) - 3 }
+""" }]
+daemon = { steps = [
+  { args = ["--emit", "air", "main.rue"], exit_code = 0, stdout_contains = ["=== AIR ===", "function main:"], stderr_contains = ["warning", "unused"] },
+  { args = ["--daemon=required", "--emit", "air", "main.rue"], exit_code = 0, stdout_contains = ["=== AIR ===", "function main:"], stderr_contains = ["warning", "unused"] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["  retained hosts: 1"] },
+  { args = ["--daemon=required", "main.rue", "-o", "app"], exit_code = 0, stdout_contains = ["Compiled main.rue -> app"], run_output = "app" },
+  { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["stopped service pid"] },
+] }
+
+[[case]]
+name = "a_rejected_analysis_is_reported_as_directly"
+description = "A program the analysis rejects is reported through the service exactly as direct mode reports it, with nothing on stdout."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = "nope";
+    x
+}
+""" }]
+daemon = { steps = [
+  { args = ["--daemon=required", "--emit", "air", "main.rue"], exit_code = 1, stdout_not_contains = ["=== AIR ==="], stderr_contains = ["error: [E0206]: type mismatch: expected string type, found i32", " --> main.rue:2:5"] },
+  { args = ["--daemon=required", "--error-format", "json", "--emit", "air", "main.rue"], exit_code = 1, stderr_contains = ["\"code\":\"E0206\""] },
   { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["stopped service pid"] },
 ] }

--- a/crates/rue/src/daemon/mod.rs
+++ b/crates/rue/src/daemon/mod.rs
@@ -34,8 +34,8 @@ pub use client::{ConnectError, Connection, Submission, SubmitError};
 pub use protocol::{
     BuildKind, BuildRequest, BuildResult, CompileFailureRecord, CrashRecord,
     DAEMON_PROTOCOL_VERSION, DestinationRecord, DiagnosticFormat, IdentityRecord, InputRecord,
-    InventoryEntryRecord, RequestSummary, ServiceInfo, StatusReport, TestImageRecord,
-    UnimportedFileRecord, UnimportedRecord,
+    InventoryEntryRecord, OutputStream, RequestSummary, ServiceInfo, StatusReport, StreamWrite,
+    TestImageRecord, UnimportedFileRecord, UnimportedRecord,
 };
 pub use service::{BuildExecutor, BuildOutput, MAX_QUEUED_REQUESTS, ServeExit};
 

--- a/crates/rue/src/daemon/protocol.rs
+++ b/crates/rue/src/daemon/protocol.rs
@@ -253,6 +253,9 @@ pub enum BuildKind {
     TestImage,
     /// The test inventory alone: no codegen, no link, no bytes.
     TestListing,
+    /// The analysis-only presentation `--emit air`: semantic analysis of the
+    /// executable root set, rendered; no codegen, no link, no bytes.
+    Analysis,
 }
 
 /// How the client wants diagnostics rendered. The service renders once with
@@ -372,6 +375,10 @@ pub enum BuildResult {
         stderr: String,
         entries: Option<Vec<InventoryEntryRecord>>,
     },
+    /// A presentation: everything the direct `--emit` would have written, in
+    /// the order it would have written it, to whichever stream. `ok` is
+    /// whether the direct invocation would have succeeded.
+    Presentation { ok: bool, writes: Vec<StreamWrite> },
     /// The request's cancellation was observed; nothing was produced.
     Canceled,
     /// The service could not run the request. `internal` marks a compiler
@@ -399,6 +406,21 @@ pub struct InputRecord {
     pub symlink_boundary: Option<String>,
     /// `(volume, file)` identities along the expected symlink route.
     pub symlink_route: Vec<(u64, u64)>,
+}
+
+/// Which standard stream a write belongs to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+/// One write the direct path would have made, verbatim.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamWrite {
+    pub stream: OutputStream,
+    pub text: String,
 }
 
 /// One test of an inventory, as the compiler's inventory entry spells it.

--- a/crates/rue/src/daemon_client.rs
+++ b/crates/rue/src/daemon_client.rs
@@ -15,6 +15,7 @@ use rue_driver::{HostPathContext, WatchInput, WatchInputParts};
 use rue_error::ErrorCode;
 
 use crate::compile::{Announcement, announce};
+use crate::emit::{self, EmitStage};
 use crate::output::{PublicationDestination, PublishRequest, publish_watch_executable};
 use crate::{
     DiagnosticOutput, DriverMode, ErrorFormat, Options, VERSION, compile_pool_jobs,
@@ -64,8 +65,8 @@ pub(crate) fn unsupported_reason(options: &Options) -> Option<&'static str> {
     if options.watch {
         return Some("--watch runs directly");
     }
-    if !options.emit_stages.is_empty() {
-        return Some("--emit runs directly");
+    if !options.emit_stages.is_empty() && options.emit_stages != [EmitStage::Air] {
+        return Some("--emit stages other than a sole `air` run directly");
     }
     if !matches!(options.linker, LinkerMode::Internal) {
         return Some("a system linker runs directly");
@@ -126,6 +127,7 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
     }
 
     let kind = match (&options.mode, options.test.list) {
+        (DriverMode::Compile, _) if !options.emit_stages.is_empty() => BuildKind::Analysis,
         (DriverMode::Compile, _) => BuildKind::Executable,
         (DriverMode::Test, true) => BuildKind::TestListing,
         (DriverMode::Test, false) => BuildKind::TestImage,
@@ -148,7 +150,7 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
                 }
             }
         }
-        BuildKind::Executable | BuildKind::TestListing => None,
+        BuildKind::Executable | BuildKind::TestListing | BuildKind::Analysis => None,
     };
     let output_path = match &test_plan {
         Some(plan) => plan.image_path.display().to_string(),
@@ -237,6 +239,12 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
         }
         BuildResult::Listing { stderr, entries } => {
             Outcome::Exit(test_mode::run_service_listing(stderr, entries, &options.test).code())
+        }
+        BuildResult::Presentation { ok, writes } => {
+            match emit::replay(emit::EmitTransport { ok, writes }) {
+                Ok(()) => Outcome::Exit(0),
+                Err(()) => Outcome::Exit(1),
+            }
         }
         BuildResult::Canceled => fail("the compiler service canceled the request".into()),
         BuildResult::Failed { message, internal } => {

--- a/crates/rue/src/daemon_service.rs
+++ b/crates/rue/src/daemon_service.rs
@@ -99,7 +99,7 @@ fn parse(request: &BuildRequest) -> Result<Parsed, String> {
             // executable request roots none of them (ADR-0083 §1). Root
             // selection is request data over the one shared host.
             root_selection: match request.artifact {
-                BuildKind::Executable => RootSelection::Executable,
+                BuildKind::Executable | BuildKind::Analysis => RootSelection::Executable,
                 BuildKind::TestImage | BuildKind::TestListing => RootSelection::Tests,
             },
         },
@@ -233,6 +233,28 @@ impl BuildExecutor for Executor {
                         prepare_image(published, multi_module_closure, color).into_record(),
                     ))
                 })
+            }
+            BuildKind::Analysis => {
+                match crate::emit::produce_transport(
+                    host,
+                    &[crate::emit::EmitStage::Air],
+                    parsed.options.clone(),
+                    parsed.format,
+                    parsed.color,
+                    cancellation,
+                ) {
+                    None => BuildOutput {
+                        result: BuildResult::Canceled,
+                        bytes: Vec::new(),
+                    },
+                    Some(presentation) => BuildOutput {
+                        result: BuildResult::Presentation {
+                            ok: presentation.ok,
+                            writes: presentation.writes,
+                        },
+                        bytes: Vec::new(),
+                    },
+                }
             }
             BuildKind::TestListing => {
                 match produce_listing_transport(
@@ -390,8 +412,8 @@ mod tests {
         }
     }
 
-    const GOOD: &str = "fn main() -> i32 { 0 }\n";
-    const BROKEN: &str = "fn main() -> i32 {\n    let x: i32 = \"nope\";\n    x\n}\n";
+    pub(super) const GOOD: &str = "fn main() -> i32 { 0 }\n";
+    pub(super) const BROKEN: &str = "fn main() -> i32 {\n    let x: i32 = \"nope\";\n    x\n}\n";
 
     #[test]
     fn a_retained_host_serves_edit_fix_and_revert_with_fresh_parity() {
@@ -702,6 +724,75 @@ mod test_request_tests {
             | BuildResult::Listing { stderr, .. } => stderr,
             other => panic!("{other:?}"),
         }
+    }
+
+    #[test]
+    fn an_analysis_request_renders_the_presentation_over_the_shared_host() {
+        let suite = Suite::new();
+        let mut executor = Executor::new();
+        let cancellation = CompilationCancellation::new();
+        let answer = executor.build(&suite.request(BuildKind::Analysis, "unused"), &cancellation);
+        let BuildResult::Presentation { ok, writes } = &answer.result else {
+            panic!("{:?}", answer.result);
+        };
+        assert!(ok);
+        assert!(answer.bytes.is_empty(), "an analysis links nothing");
+        let stdout: String = writes
+            .iter()
+            .filter(|write| write.stream == rue_driver::daemon::OutputStream::Stdout)
+            .map(|write| write.text.as_str())
+            .collect();
+        assert!(stdout.starts_with("=== AIR ===\n"), "{stdout}");
+        assert!(stdout.contains("function main:"), "{stdout}");
+        // The executable root set: the test bodies' failure is not this
+        // request's to report.
+        assert!(
+            writes
+                .iter()
+                .all(|write| write.stream == rue_driver::daemon::OutputStream::Stdout),
+            "{writes:?}"
+        );
+        assert_eq!(executor.retained_hosts(), 1);
+
+        // A fresh executor writes the same sequence.
+        let fresh =
+            Executor::new().build(&suite.request(BuildKind::Analysis, "unused"), &cancellation);
+        let BuildResult::Presentation {
+            writes: fresh_writes,
+            ..
+        } = fresh.result
+        else {
+            panic!("{:?}", fresh.result);
+        };
+        assert_eq!(&fresh_writes, writes);
+
+        // A rejected program: its diagnostics on stderr, nothing on stdout,
+        // not ok; then a canceled request, then recovery over the same host.
+        fs::write(
+            suite.directory.path().join("main.rue"),
+            super::tests::BROKEN,
+        )
+        .unwrap();
+        let rejected = executor.build(&suite.request(BuildKind::Analysis, "unused"), &cancellation);
+        let BuildResult::Presentation { ok, writes } = &rejected.result else {
+            panic!("{:?}", rejected.result);
+        };
+        assert!(!ok);
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].stream, rue_driver::daemon::OutputStream::Stderr);
+        assert!(writes[0].text.contains("E0206"), "{}", writes[0].text);
+        let canceled = CompilationCancellation::new();
+        canceled.cancel();
+        let answer = executor.build(&suite.request(BuildKind::Analysis, "unused"), &canceled);
+        assert!(matches!(answer.result, BuildResult::Canceled));
+        fs::write(suite.directory.path().join("main.rue"), SUITE).unwrap();
+        let recovered =
+            executor.build(&suite.request(BuildKind::Analysis, "unused"), &cancellation);
+        assert!(matches!(
+            recovered.result,
+            BuildResult::Presentation { ok: true, .. }
+        ));
+        assert_eq!(executor.retained_hosts(), 1);
     }
 
     #[test]

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -3,17 +3,21 @@ use rue_compiler::unstable::MetricsSnapshot;
 use rue_compiler::unstable::PresentationOutput;
 #[cfg(test)]
 use rue_compiler::unstable::update_for_presentation;
+use rue_compiler::unstable::{
+    CancellablePresentationOutcome, ColorChoice, CompilationCancellation, PresentationBatchRequest,
+    PresentationRequest, PresentationStage,
+};
 #[cfg(test)]
 use rue_compiler::unstable::{
     CanonicalRirPresentationMetrics, ParseMetrics, SemanticMetrics, rooted_cfg,
 };
-use rue_compiler::unstable::{PresentationBatchRequest, PresentationRequest, PresentationStage};
 use rue_compiler::{
     AcceptedReadManifest, CompileErrors, CompileOptions, DependencyEnvelope,
     DependencyEnvelopeStatus, ImportDiscoveryStatus, SourceSnapshot,
 };
 #[cfg(test)]
 use rue_compiler::{CompilerSession, RirView};
+use rue_driver::daemon::{OutputStream, StreamWrite};
 use rue_driver::{AttemptedRead, FilesystemCompilerHost, WatchInput};
 #[cfg(test)]
 use rue_error::{CompileError, ErrorKind};
@@ -267,6 +271,9 @@ struct OwnedEmitStage {
     output: PresentationOutput,
 }
 
+/// The presentation was abandoned at the request's cancellation.
+struct Canceled;
+
 fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
     let EmitRequest {
         host,
@@ -274,11 +281,23 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
         compile_options,
         diagnostics,
     } = request;
+    match produce_with_cancellation(host, stages, compile_options, diagnostics.format(), None) {
+        Ok(response) => response,
+        Err(Canceled) => unreachable!("a presentation without a cancellation is never canceled"),
+    }
+}
+
+fn produce_with_cancellation(
+    host: &mut FilesystemCompilerHost,
+    stages: &[EmitStage],
+    compile_options: CompileOptions,
+    error_format: crate::ErrorFormat,
+    cancellation: Option<&CompilationCancellation>,
+) -> Result<OwnedEmitResponse, Canceled> {
     let source_snapshot = host.source_snapshot().clone();
     let accepted_reads = host.accepted_reads().clone();
     let attempted_reads = host.attempted_reads().to_vec();
     let watch_inputs = host.watch_inputs();
-    let error_format = diagnostics.format();
     let target = compile_options.target;
     let discovery_revision = host.discovery_revision().clone();
 
@@ -288,7 +307,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
             match DependencyEnvelope::from_closed_revision(&discovery_revision) {
                 Some(envelope) => envelope,
                 None => {
-                    return OwnedEmitResponse {
+                    return Ok(OwnedEmitResponse {
                         source_snapshot,
                         accepted_reads,
                         attempted_reads,
@@ -298,7 +317,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
                         result: OwnedEmitResult::Failed(rue_driver::with_import_migration_helps(
                             discovery_revision.diagnostics(),
                         )),
-                    };
+                    });
                 }
             };
         let incomplete = dependency_envelope.status == DependencyEnvelopeStatus::Incomplete;
@@ -313,7 +332,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
                 "Error emitting dependency envelope: {error}"
             )),
         };
-        return OwnedEmitResponse {
+        return Ok(OwnedEmitResponse {
             source_snapshot,
             accepted_reads,
             attempted_reads,
@@ -321,11 +340,11 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
             error_format,
             target,
             result,
-        };
+        });
     }
 
     if discovery_revision.status() != ImportDiscoveryStatus::ClosedValid {
-        return OwnedEmitResponse {
+        return Ok(OwnedEmitResponse {
             source_snapshot,
             accepted_reads,
             attempted_reads,
@@ -335,7 +354,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
             result: OwnedEmitResult::Failed(rue_driver::with_import_migration_helps(
                 discovery_revision.diagnostics(),
             )),
-        };
+        });
     }
 
     match emit_frontend_route(stages) {
@@ -344,7 +363,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
         | EmitFrontendRoute::None => {}
         EmitFrontendRoute::RirOnly => {
             if let Err(errors) = host.rir() {
-                return OwnedEmitResponse {
+                return Ok(OwnedEmitResponse {
                     source_snapshot,
                     accepted_reads,
                     attempted_reads,
@@ -354,7 +373,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
                     result: OwnedEmitResult::Failed(rue_driver::with_import_migration_helps(
                         &errors,
                     )),
-                };
+                });
             }
         }
     }
@@ -382,14 +401,23 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
     let whole_program_outputs = if whole_program_stages.is_empty() {
         Vec::new()
     } else {
-        match host.present_many(PresentationBatchRequest {
+        let batch = PresentationBatchRequest {
             stages: &whole_program_stages,
             options: &compile_options,
             file_order: &file_order,
-        }) {
-            Ok(outputs) => outputs,
-            Err(errors) => {
-                return OwnedEmitResponse {
+        };
+        let outcome = match cancellation {
+            Some(cancellation) => host.cancellable_present_many(batch, cancellation.clone()),
+            None => match host.present_many(batch) {
+                Ok(outputs) => CancellablePresentationOutcome::Completed(outputs),
+                Err(errors) => CancellablePresentationOutcome::Errors(errors),
+            },
+        };
+        match outcome {
+            CancellablePresentationOutcome::Completed(outputs) => outputs,
+            CancellablePresentationOutcome::Canceled => return Err(Canceled),
+            CancellablePresentationOutcome::Errors(errors) => {
+                return Ok(OwnedEmitResponse {
                     source_snapshot,
                     accepted_reads,
                     attempted_reads,
@@ -399,7 +427,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
                     result: OwnedEmitResult::Failed(rue_driver::with_import_migration_helps(
                         &errors,
                     )),
-                };
+                });
             }
         }
     };
@@ -425,7 +453,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
                 }) {
                     Ok(output) => output,
                     Err(errors) => {
-                        return OwnedEmitResponse {
+                        return Ok(OwnedEmitResponse {
                             source_snapshot,
                             accepted_reads,
                             attempted_reads,
@@ -435,7 +463,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
                             result: OwnedEmitResult::Failed(
                                 rue_driver::with_import_migration_helps(&errors),
                             ),
-                        };
+                        });
                     }
                 };
                 outputs.push(OwnedEmitStage {
@@ -460,7 +488,7 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
             output,
         });
     }
-    OwnedEmitResponse {
+    Ok(OwnedEmitResponse {
         source_snapshot,
         accepted_reads,
         attempted_reads,
@@ -468,10 +496,86 @@ fn produce(request: EmitRequest<'_, '_>) -> OwnedEmitResponse {
         error_format,
         target,
         result: OwnedEmitResult::Stages(outputs),
+    })
+}
+
+/// Everything one `--emit` writes, in order, to whichever stream, and whether
+/// the invocation succeeded. Direct mode replays it as it is produced; the
+/// compiler service sends it and its client replays it (ADR-0085 §5), so the
+/// streams and their interleaving are the same by construction.
+pub(crate) struct EmitTransport {
+    pub(crate) ok: bool,
+    pub(crate) writes: Vec<StreamWrite>,
+}
+
+impl EmitTransport {
+    fn out(&mut self, text: impl Into<String>) {
+        self.writes.push(StreamWrite {
+            stream: OutputStream::Stdout,
+            text: text.into(),
+        });
+    }
+
+    fn outln(&mut self, text: impl std::fmt::Display) {
+        self.out(format!("{text}\n"));
+    }
+
+    fn errln(&mut self, text: impl std::fmt::Display) {
+        self.writes.push(StreamWrite {
+            stream: OutputStream::Stderr,
+            text: format!("{text}\n"),
+        });
+    }
+}
+
+/// Replay a transport onto this process's streams.
+pub(crate) fn replay(transport: EmitTransport) -> Result<(), ()> {
+    use std::io::Write as _;
+    for write in transport.writes {
+        match write.stream {
+            OutputStream::Stdout => {
+                let mut stdout = std::io::stdout().lock();
+                let _ = stdout.write_all(write.text.as_bytes());
+                let _ = stdout.flush();
+            }
+            OutputStream::Stderr => {
+                let mut stderr = std::io::stderr().lock();
+                let _ = stderr.write_all(write.text.as_bytes());
+                let _ = stderr.flush();
+            }
+        }
+    }
+    if transport.ok { Ok(()) } else { Err(()) }
+}
+
+/// Produce a presentation for the compiler service: the same production as
+/// direct mode under the request's cancellation, rendered under `color`.
+/// `None` when the request was canceled.
+pub(crate) fn produce_transport(
+    host: &mut FilesystemCompilerHost,
+    stages: &[EmitStage],
+    compile_options: CompileOptions,
+    error_format: crate::ErrorFormat,
+    color: ColorChoice,
+    cancellation: &CompilationCancellation,
+) -> Option<EmitTransport> {
+    match produce_with_cancellation(
+        host,
+        stages,
+        compile_options,
+        error_format,
+        Some(cancellation),
+    ) {
+        Ok(response) => Some(render(response, color)),
+        Err(Canceled) => None,
     }
 }
 
 fn complete(response: OwnedEmitResponse) -> Result<(), ()> {
+    replay(render(response, ColorChoice::Auto))
+}
+
+fn render(response: OwnedEmitResponse, color: ColorChoice) -> EmitTransport {
     let OwnedEmitResponse {
         source_snapshot,
         accepted_reads,
@@ -491,23 +595,23 @@ fn complete(response: OwnedEmitResponse) -> Result<(), ()> {
             )
         })
         .collect();
-    let diagnostics = DiagnosticOutput::new(error_format, sources);
+    let diagnostics = DiagnosticOutput::with_color(error_format, sources, color);
+    let mut transport = EmitTransport {
+        ok: false,
+        writes: Vec::new(),
+    };
     match result {
         OwnedEmitResult::InternalFailure(message) => {
-            eprintln!("{message}");
-            Err(())
+            transport.errln(message);
         }
         OwnedEmitResult::Failed(errors) => {
-            diagnostics.print_prepared_errors(&errors);
-            Err(())
+            transport.errln(diagnostics.render_prepared_errors(&errors));
         }
         OwnedEmitResult::Dependencies { json, errors } => {
-            println!("{json}");
-            if let Some(errors) = errors {
-                diagnostics.print_prepared_errors(&errors);
-                Err(())
-            } else {
-                Ok(())
+            transport.outln(json);
+            match errors {
+                Some(errors) => transport.errln(diagnostics.render_prepared_errors(&errors)),
+                None => transport.ok = true,
             }
         }
         OwnedEmitResult::Stages(outputs) => {
@@ -516,62 +620,65 @@ fn complete(response: OwnedEmitResponse) -> Result<(), ()> {
                 let output = owned.output;
                 if let Some(file) = owned.file {
                     match owned.stage {
-                        EmitStage::Tokens => println!("=== Tokens ({file}) ==="),
-                        EmitStage::Ast => println!("=== AST ({file}) ==="),
+                        EmitStage::Tokens => transport.outln(format!("=== Tokens ({file}) ===")),
+                        EmitStage::Ast => transport.outln(format!("=== AST ({file}) ===")),
                         _ => unreachable!(),
                     }
-                    print!("{}", output.as_str());
-                    println!();
+                    transport.out(output.as_str());
+                    transport.outln("");
                     continue;
                 }
                 if !warnings_printed && emit_requires_semantic(&[owned.stage]) {
-                    diagnostics.print_warnings(output.warnings());
+                    if !output.warnings().is_empty() {
+                        transport.errln(diagnostics.render_warnings(output.warnings()));
+                    }
                     warnings_printed = true;
                 }
                 match owned.stage {
                     EmitStage::Rir => {
-                        println!("=== RIR ===");
-                        println!("{}", output.as_str());
-                        println!();
+                        transport.outln("=== RIR ===");
+                        transport.outln(output.as_str());
+                        transport.outln("");
                     }
                     EmitStage::Air => {
-                        println!("=== AIR ===");
-                        print!("{}", output.as_str());
-                        println!();
+                        transport.outln("=== AIR ===");
+                        transport.out(output.as_str());
+                        transport.outln("");
                     }
                     EmitStage::Cfg => {
-                        println!("=== CFG ===");
-                        print!("{}", output.as_str());
-                        println!();
+                        transport.outln("=== CFG ===");
+                        transport.out(output.as_str());
+                        transport.outln("");
                     }
-                    EmitStage::Lowering => println!("{}", output.as_str()),
+                    EmitStage::Lowering => transport.outln(output.as_str()),
                     EmitStage::Mir => {
-                        println!("=== MIR ({target}) ===");
-                        println!("{}", output.as_str());
+                        transport.outln(format!("=== MIR ({target}) ==="));
+                        transport.outln(output.as_str());
                     }
                     EmitStage::Liveness => {
-                        println!("=== Liveness Analysis ({target}) ===");
-                        println!("{}", output.as_str());
+                        transport.outln(format!("=== Liveness Analysis ({target}) ==="));
+                        transport.outln(output.as_str());
                     }
                     EmitStage::RegAlloc => {
-                        println!("=== Register Allocation ({target}) ===");
-                        println!("{}", output.as_str());
+                        transport.outln(format!("=== Register Allocation ({target}) ==="));
+                        transport.outln(output.as_str());
                     }
                     EmitStage::Asm => {
-                        println!("=== Assembly ({target}) ===");
-                        println!("{}", output.as_str());
+                        transport.outln(format!("=== Assembly ({target}) ==="));
+                        transport.outln(output.as_str());
                     }
-                    EmitStage::StackFrame => print!("{}", output.as_str()),
+                    EmitStage::StackFrame => transport.out(output.as_str()),
                     EmitStage::Abi => {
-                        println!("=== ABI ({target}) ===");
-                        print!("{}", output.as_str());
+                        transport.outln(format!("=== ABI ({target}) ==="));
+                        transport.out(output.as_str());
                     }
                     EmitStage::Tokens | EmitStage::Ast | EmitStage::Deps => unreachable!(),
                 }
             }
-            Ok(())
+            transport.ok = true;
         }
     }
+    transport
 }
 
 fn consume_emit_observations(

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -287,9 +287,9 @@ Usage: rue [options] <root.rue> [output]
 
 The compiler takes exactly one root source file and discovers every other
 file through its @import graph; pass build-system inputs with --source-manifest.
-An ordinary internal-linker build or `rue test` can run through the local
-compiler service with --daemon=auto or --daemon=required (ADR-0085); the
-default is off.
+An ordinary internal-linker build, `rue test`, or `--emit air` can run through
+the local compiler service with --daemon=auto or --daemon=required
+(ADR-0085); the default is off.
 
 Commands:
   explain <E####>      Show the compiler-owned explanation for an error code
@@ -373,10 +373,10 @@ Options:
                        start the compiler service for supported requests and
                        compile directly otherwise; required: the service must
                        run it. Supported: ordinary internal-linker builds,
-                       rue test, and rue test --list. --watch, --emit,
-                       --linker, --time-passes, --benchmark-json, and
-                       compiler tracing run directly under auto and are
-                       refused under required.
+                       rue test, rue test --list, and --emit air alone.
+                       --watch, other --emit stages, --linker, --time-passes,
+                       --benchmark-json, and compiler tracing run directly
+                       under auto and are refused under required.
   --daemon-scope <dir> The service scope directory (default: the root source's
                        directory); --daemon-isolation <name> selects a
                        separate service within it. Both match `rue daemon`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -85,7 +85,8 @@ any failure is the invocation's failure and nothing is retried.
 | --- | --- | --- |
 | Ordinary internal-linker build | service | service |
 | `rue test`, `rue test --list` (the image or inventory; the runner stays in the client) | service | service |
-| `--watch`, any `--emit`, `--linker <cmd>` | direct | refused |
+| `--emit air` alone (analysis only; nothing is linked) | service | service |
+| `--watch`, any other `--emit`, `--linker <cmd>` | direct | refused |
 | `--time-passes`, `--benchmark-json` | direct | refused |
 | Tracing via `--log-level` or `RUST_LOG` | direct | refused |
 | `--help`, `--version`, `explain`, `rue daemon` | local | local |


### PR DESCRIPTION
The third request-execution slice of RUE-2128 (ADR-0085 §2, §5), stacked on #3112 (RUE-2181) and retargeted as the stack lands: the check-style workflow the ADR names beside build and test, over the same service, protocol and executor, sharing the retained host with the root's executable and test requests.

**Request.** `--emit air` alone, in compile mode without `--watch`, under `--daemon=auto|required` submits an `Analysis` request over the executable root set; the service runs the existing presentation batch through `cancellable_present_many` under the request's cancellation and links nothing. Every other emit stage, alone or combined, stays direct under `auto` and is refused under `required` (the support-table case and `docs/development.md` say so).

**One rendering.** The emit completion is now an ordered sequence of stream writes (`EmitTransport`) produced once by the canonical renderer under the client's format and color: the stdout banners and text, the stderr warnings or diagnostics, and whether the invocation succeeded. Direct mode replays that sequence in-process exactly as it always printed it; the service sends it as `BuildResult::Presentation` and the client replays it, so the two streams and their interleaving are identical by construction.

**Coverage.** An executor test: the analysis of a suite renders the AIR of the executable root set with nothing on stderr (the test bodies' failure is not this request's), a fresh executor writes the same sequence, a rejected program is one stderr write and not ok, a canceled request produces nothing and the same host recovers. CLI cases under `--daemon=required`: `--emit air` with a warning matching direct mode's stdout and stderr and sharing the retained host with the root's executable build, a rejected program in text and JSON with nothing on stdout, and `--emit cfg` and `--emit air --emit cfg` refused. Locally, `--emit air` through the service and directly produced byte-identical stdout and stderr.

Verified locally: both driver unit suites, `scripts/rue cli daemon`, `scripts/rue cli emit_pipeline`, `scripts/rue cli emit`, `scripts/rue cli deps`, and the clippy/fmt gates for `rue` and `rue-cli-tests`.

Fixes RUE-2185