### PR TITLE
RUE-2175: struct patterns in match arms

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -4342,6 +4342,17 @@ impl<'a> ConstraintGenerator<'a> {
         pattern: &rue_rir::RirPatternView<'_>,
         ctx: &mut ConstraintContext,
     ) {
+        // A struct pattern arm (4.7:42, RUE-2175) binds the scrutinee to its
+        // hidden local, typed by the pattern head; the arm body's leading
+        // lets read the fields out of that local.
+        if let rue_rir::RirPatternView::Struct {
+            local, ty, span, ..
+        } = pattern
+        {
+            let head = self.infer_type_hint(self.rir.type_syntax(), *ty, None, None, span.file_id);
+            self.register_struct_pattern_local(*local, head, *span, ctx);
+            return;
+        }
         let rue_rir::RirPatternView::Path {
             module,
             ctor_head,
@@ -4370,6 +4381,27 @@ impl<'a> ConstraintGenerator<'a> {
             return;
         };
         self.register_payload_bindings(enum_ty, *variant, *elements, *pat_span, ctx);
+    }
+
+    /// Register the hidden local a struct pattern binds the matched value to
+    /// (RUE-2175). Its type is the head's when the head resolves, and a fresh
+    /// variable otherwise; sema reports an unresolvable head itself.
+    fn register_struct_pattern_local(
+        &mut self,
+        local: lasso::Spur,
+        ty: Option<InferType>,
+        span: rue_span::Span,
+        ctx: &mut ConstraintContext,
+    ) {
+        let ty = ty.unwrap_or_else(|| InferType::Var(self.fresh_var()));
+        ctx.insert_local(
+            local,
+            LocalVarInfo {
+                ty,
+                is_mut: false,
+                span,
+            },
+        );
     }
 
     /// Register the locals one variant pattern's payload positions introduce,
@@ -4424,6 +4456,21 @@ impl<'a> ConstraintGenerator<'a> {
                             nested_variant,
                             nested_elements,
                             span,
+                            ctx,
+                        );
+                    }
+                    // A struct pattern over the position (RUE-2175) binds the
+                    // payload field itself to its hidden local.
+                    if let rue_rir::RirPatternView::Struct {
+                        local,
+                        span: nested_span,
+                        ..
+                    } = nested
+                    {
+                        self.register_struct_pattern_local(
+                            local,
+                            Some(InferType::Concrete(ty)),
+                            nested_span,
                             ctx,
                         );
                     }
@@ -4492,6 +4539,11 @@ impl<'a> ConstraintGenerator<'a> {
                     InferType::Concrete(Type::ERROR)
                 }
             }
+            // A struct pattern (RUE-2175) contributes its head type; a head
+            // that does not resolve here is sema's to report.
+            rue_rir::RirPatternView::Struct { ty, span, .. } => self
+                .infer_type_hint(self.rir.type_syntax(), *ty, None, None, span.file_id)
+                .unwrap_or_else(|| InferType::Var(self.fresh_var())),
         }
     }
 

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -945,10 +945,36 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .with_help("the pattern head must name the initializer's own struct type"));
         }
 
-        let struct_name = self.format_type_name(head);
+        let fields: Vec<Spur> = self
+            .body_rir_ref()
+            .pattern_fields(fields)
+            .values()
+            .collect();
+        self.check_struct_pattern_fields(struct_id, fields.into_iter(), span)?;
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::UnitConst,
+            ty: Type::UNIT,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// Check a struct pattern's field list against the struct's declared
+    /// fields (spec 5.1:20, and 4.7:42 for a match arm): every name is a
+    /// field (E0401), no field is named twice (E0402), and no declared field
+    /// is left out (E0400). A pattern has no rest form, which is what makes a
+    /// field added to the struct an error at every pattern over it.
+    pub(crate) fn check_struct_pattern_fields(
+        &self,
+        struct_id: crate::types::StructId,
+        fields: impl Iterator<Item = Spur>,
+        span: Span,
+    ) -> CompileResult<()> {
+        let struct_name = self.format_type_name(Type::new_struct(struct_id));
         let struct_def = self.body_type_pool().struct_def(struct_id);
         let mut named = vec![false; struct_def.fields.len()];
-        for field in self.body_rir_ref().pattern_fields(fields) {
+        for field in fields {
             let field_name = self.body_interner().resolve(&field);
             let Some((index, _)) = struct_def.find_field(field_name) else {
                 return Err(CompileError::new(
@@ -990,13 +1016,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                  `field: _`",
             ));
         }
-
-        let air_ref = air.add_inst(AirInst {
-            data: AirInstData::UnitConst,
-            ty: Type::UNIT,
-            span,
-        });
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+        Ok(())
     }
 
     pub(crate) fn analyze_struct_ops(

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -113,7 +113,7 @@ pub(crate) fn prunable_match_body(
                 }
             }
             ComptimeMatchPattern::Integer(_) => {}
-            ComptimeMatchPattern::Path { .. } => return None,
+            ComptimeMatchPattern::Path { .. } | ComptimeMatchPattern::Struct => return None,
         }
     }
     (has_wildcard || (bool_true_covered && bool_false_covered)).then_some(selected)

--- a/crates/rue-air/src/sema/comptime/frames.rs
+++ b/crates/rue-air/src/sema/comptime/frames.rs
@@ -114,6 +114,9 @@ pub enum ComptimeMatchPattern<N> {
         variant: N,
         binding_count: usize,
     },
+    /// A struct pattern (RUE-2175). Its scrutinee is a struct value, which no
+    /// comptime scalar is, so a match containing one is never selected here.
+    Struct,
 }
 
 /// A semantic reason why the canonical engine cannot reduce an expression.
@@ -208,6 +211,7 @@ pub fn decode_comptime_match_pattern<N>(
             variant: name_from_symbol((*variant).into()),
             binding_count: elements.len(),
         },
+        rue_rir::RirPatternView::Struct { .. } => ComptimeMatchPattern::Struct,
     }
 }
 

--- a/crates/rue-air/src/sema/comptime/value_policy.rs
+++ b/crates/rue-air/src/sema/comptime/value_policy.rs
@@ -65,6 +65,8 @@ pub fn comptime_scalar_pattern_decision<N, V: ComptimeValue>(
                 ComptimePatternDecision::Decided(actual == *expected)
             }),
         ComptimeMatchPattern::Path { .. } => ComptimePatternDecision::HostPath,
+        // A struct value is never a comptime scalar (RUE-2175).
+        ComptimeMatchPattern::Struct => ComptimePatternDecision::Undecidable,
     }
 }
 

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -127,18 +127,61 @@ enum RootArm {
     Group(usize),
 }
 
-/// One level of a placed arm: a variant test and the payload it binds.
-struct ArmLevel<'p> {
-    pattern: &'p RirPattern,
-    /// The value this level's pattern is matched against: the match's
-    /// scrutinee at the outermost level, and the payload field the parent
-    /// level decomposes below that.
-    scrutinee: AirRef,
-    enum_id: crate::types::EnumId,
-    variant_index: u32,
-    /// The payload positions a nested pattern occupies. A level of its own
-    /// follows for each, so this level binds nothing there.
-    nested: Vec<u32>,
+/// One level of a placed arm: a pattern and the value it is matched against.
+enum ArmLevel<'p> {
+    /// A variant test and the payload it binds.
+    Variant {
+        pattern: &'p RirPattern,
+        /// The value this level's pattern is matched against: the match's
+        /// scrutinee at the outermost level, and the payload field the parent
+        /// level decomposes below that.
+        scrutinee: AirRef,
+        enum_id: crate::types::EnumId,
+        variant_index: u32,
+        /// The payload positions a nested pattern occupies. A level of its own
+        /// follows for each, so this level binds nothing there.
+        nested: Vec<u32>,
+    },
+    /// A struct pattern (spec 4.7:42, RUE-2175). It is irrefutable, so it
+    /// tests nothing: it binds the value it is matched against — the match's
+    /// scrutinee, or the payload field the parent level decomposes — to the
+    /// pattern's hidden local, and the arm body's leading `let`s read the
+    /// fields out of that local (5.1:21).
+    Struct {
+        pattern: &'p RirPattern,
+        scrutinee: AirRef,
+        /// The struct type the head names, which is also the value's type.
+        ty: Type,
+    },
+}
+
+impl ArmLevel<'_> {
+    /// The value this level is matched against.
+    fn scrutinee(&self) -> AirRef {
+        match self {
+            ArmLevel::Variant { scrutinee, .. } | ArmLevel::Struct { scrutinee, .. } => *scrutinee,
+        }
+    }
+
+    /// Whether a level of its own follows for some position of this level.
+    fn decomposes(&self) -> bool {
+        match self {
+            ArmLevel::Variant { nested, .. } => !nested.is_empty(),
+            ArmLevel::Struct { .. } => false,
+        }
+    }
+
+    /// The variant this level tests, when it is a variant level.
+    fn variant(&self) -> Option<(crate::types::EnumId, u32)> {
+        match self {
+            ArmLevel::Variant {
+                enum_id,
+                variant_index,
+                ..
+            } => Some((*enum_id, *variant_index)),
+            ArmLevel::Struct { .. } => None,
+        }
+    }
 }
 
 /// Where one arm lands in the match's dispatch, and what it must bind to get
@@ -186,11 +229,19 @@ fn decomposed_variants(patterns: &[&RirPattern]) -> AHashSet<Spur> {
     patterns
         .iter()
         .filter_map(|pattern| match pattern {
+            // A struct pattern in a payload position (RUE-2175) is
+            // irrefutable, so it discriminates nothing: only a nested
+            // *variant* pattern opens a group.
             RirPattern::Path {
                 variant, elements, ..
             } => elements
                 .iter()
-                .any(|element| matches!(element, rue_rir::RirPatternElement::Nested(_)))
+                .any(|element| {
+                    matches!(
+                        element,
+                        rue_rir::RirPatternElement::Nested(RirPattern::Path { .. })
+                    )
+                })
                 .then_some(*variant),
             _ => None,
         })
@@ -1125,6 +1176,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         self.body_interner().resolve(&*type_name),
                         self.body_interner().resolve(&*variant)
                     ),
+                    // A struct pattern's match is never prunable (its
+                    // scrutinee is a struct), so this spelling is nominal.
+                    RirPatternView::Struct { fields, .. } => format!(
+                        "{{ {} }}",
+                        fields
+                            .values()
+                            .map(|field| self.body_interner().resolve(&field).to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
                 };
                 ctx.warnings.push(
                     CompileWarning::new(WarningKind::UnreachablePattern(pat_str), pattern_span)
@@ -1208,9 +1269,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         *first_span_opt = Some(pattern_span);
                     }
                 }
-                // Enum patterns can't appear in a prunable match (they set
-                // `prunable = false` in the caller), so there's nothing to do.
-                RirPatternView::Path { .. } => {}
+                // Enum and struct patterns can't appear in a prunable match
+                // (they set `prunable = false` in the caller), so there's
+                // nothing to do.
+                RirPatternView::Path { .. } | RirPatternView::Struct { .. } => {}
             }
         }
     }
@@ -1365,8 +1427,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let scrutinee_type = scrutinee_result.ty;
         let reachable_edges_after_scrutinee = ctx.ownership.loop_break_stack.clone();
 
-        // Validate that we can match on this type (integers, booleans, and enums)
-        if !scrutinee_type.is_integer() && scrutinee_type != Type::BOOL && !scrutinee_type.is_enum()
+        // Validate that we can match on this type: integers, booleans, enums,
+        // and — when some arm is a struct pattern (4.7:42, RUE-2175) — the
+        // struct that pattern destructures. A struct scrutinee with no struct
+        // pattern to bind it stays what it always was, an invalid match type.
+        let has_struct_pattern_arm = self
+            .body_rir_ref()
+            .match_arms(arms)
+            .iter()
+            .any(|(pattern, _)| matches!(pattern, RirPatternView::Struct { .. }));
+        if !scrutinee_type.is_integer()
+            && scrutinee_type != Type::BOOL
+            && !scrutinee_type.is_enum()
+            && !(scrutinee_type.is_struct() && has_struct_pattern_arm)
         {
             return Err(CompileError::new(
                 ErrorKind::InvalidMatchType(self.format_type_name(scrutinee_type)),
@@ -1414,6 +1487,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Track patterns for exhaustiveness checking and duplicate detection
         let mut wildcard_span: Option<Span> = None;
         let mut wildcard_arm_index: Option<usize> = None;
+        // A struct pattern arm (4.7:42) is irrefutable like `_`: every arm
+        // after it is unreachable, and it makes the match exhaustive. The
+        // first irrefutable arm of either kind is the one a later arm's
+        // warning points at, with the wording for its kind.
+        let mut first_irrefutable: Option<(Span, &'static str, &'static str)> = None;
         let mut wildcard_outer_uncovered = false;
         let mut bool_true_span: Option<Span> = None;
         let mut bool_false_span: Option<Span> = None;
@@ -1446,8 +1524,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         for (arm_index, (pattern, body)) in arms.iter().enumerate() {
             let pattern_span = pattern.span();
 
-            // If we've seen a wildcard, everything after is unreachable
-            if let Some(first_wildcard_span) = wildcard_span {
+            // If we've seen an irrefutable pattern — a wildcard, or a struct
+            // pattern (4.7:42) — everything after is unreachable (4.7:18).
+            if let Some((first_irrefutable_span, label, note)) = first_irrefutable {
                 let pat_str = match &pattern {
                     RirPattern::Wildcard(_) => "_".to_string(),
                     RirPattern::Int {
@@ -1469,16 +1548,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             self.body_interner().resolve(&*variant)
                         )
                     }
+                    RirPattern::Struct { ty, fields, .. } => {
+                        self.spell_struct_pattern(*ty, fields, pattern_span, ctx)
+                    }
                 };
                 ctx.warnings.push(
-                    CompileWarning::new(
-                        WarningKind::UnreachablePattern(pat_str),
-                        pattern_span,
-                    )
-                    .with_label("previous wildcard pattern here", first_wildcard_span)
-                    .with_note(
-                        "this pattern will never be matched because the wildcard pattern above matches everything",
-                    ),
+                    CompileWarning::new(WarningKind::UnreachablePattern(pat_str), pattern_span)
+                        .with_label(label, first_irrefutable_span)
+                        .with_note(note),
                 );
             }
 
@@ -1531,6 +1608,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         wildcard_span = Some(pattern_span);
                         wildcard_arm_index = Some(arm_index);
                     }
+                    first_irrefutable.get_or_insert((
+                        pattern_span,
+                        "previous wildcard pattern here",
+                        "this pattern will never be matched because the wildcard pattern above matches everything",
+                    ));
                 }
                 RirPattern::Int {
                     value, negative, ..
@@ -1610,6 +1692,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // A variant pattern's legality is checked level by level as it
                 // is placed, immediately below.
                 RirPattern::Path { .. } => {}
+                // A struct pattern's head and field list are checked when it
+                // is placed, immediately below. It is irrefutable (4.7:42).
+                RirPattern::Struct { .. } => {
+                    first_irrefutable.get_or_insert((
+                        pattern_span,
+                        "previous struct pattern here",
+                        "this pattern will never be matched because the struct pattern above matches every value",
+                    ));
+                }
             }
 
             // A variant pattern is placed in the match's dispatch: at the
@@ -1618,6 +1709,21 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // variant's group. The walk validates every level it passes
             // through.
             let placement = match &pattern {
+                RirPattern::Struct { .. } => {
+                    let mut levels = Vec::new();
+                    self.resolve_struct_pattern_level(
+                        pattern,
+                        scrutinee_result.air_ref,
+                        scrutinee_type,
+                        ctx,
+                        &mut levels,
+                    )?;
+                    Some(ArmPlacement {
+                        levels,
+                        group: None,
+                        fields: Vec::new(),
+                    })
+                }
                 RirPattern::Path { .. } => {
                     let placement = self.place_match_arm(
                         air,
@@ -1629,14 +1735,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         &mut air_arms,
                         ctx,
                     )?;
-                    pattern_enum_id = Some(placement.levels[0].enum_id);
+                    let (enum_id, root_variant) = placement.levels[0]
+                        .variant()
+                        .expect("a placed variant pattern's first level tests its variant");
+                    pattern_enum_id = Some(enum_id);
                     // The outermost variant is covered by this arm's group,
                     // whether or not the arm discriminates its payload further.
                     // A second arm naming a variant that no arm discriminates
                     // further is unreachable, exactly as a repeated integer or
                     // boolean pattern is; when the variant *is* discriminated,
                     // reachability is decided over the group's matrix instead.
-                    let root_variant = placement.levels[0].variant_index;
                     if let Some(first_span) = covered_variants.get(&root_variant)
                         && placement.group.is_none()
                         && wildcard_span.is_none()
@@ -1686,12 +1794,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if let Some(placement) = &placement {
                 for level in &placement.levels {
                     let level_stmts = self.materialize_match_bindings(air, level, ctx)?;
-                    if level_stmts.is_empty() && level.nested.is_empty() {
-                        undrained.push(level.scrutinee);
+                    if level_stmts.is_empty() && !level.decomposes() {
+                        undrained.push(level.scrutinee());
                     }
                     binding_stmts.extend(level_stmts);
                 }
-            } else if scrutinee_type.is_enum() {
+            } else if scrutinee_type.is_enum() || scrutinee_type.is_struct() {
+                // A `_` arm over a struct scrutinee (4.7:42) consumes the
+                // value exactly as one over an enum does.
                 undrained.push(scrutinee_result.air_ref);
             }
 
@@ -1832,10 +1942,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             AirPattern::Int(pattern_int_denoted(*value, *negative) as i64)
                         }
                         RirPattern::Bool(b, _) => AirPattern::Bool(*b),
+                        // Irrefutable: the arm's bindings do all the work.
+                        RirPattern::Struct { .. } => AirPattern::Wildcard,
                         RirPattern::Path { .. } => {
-                            let level = placement
+                            let (enum_id, variant_index) = placement
                                 .as_ref()
                                 .and_then(|placement| placement.levels.first())
+                                .and_then(ArmLevel::variant)
                                 .ok_or_else(|| {
                                     CompileError::new(
                                         ErrorKind::InternalError(
@@ -1845,8 +1958,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                                     )
                                 })?;
                             AirPattern::EnumVariant {
-                                enum_id: level.enum_id,
-                                variant_index: level.variant_index,
+                                enum_id,
+                                variant_index,
                             }
                         }
                     };
@@ -1875,8 +1988,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         ctx.ownership.merge_arm_moves(arm_move_states);
 
-        // Exhaustiveness checking
-        let has_wildcard = wildcard_span.is_some();
+        // Exhaustiveness checking. A struct pattern arm is irrefutable
+        // (4.7:42), so it covers the scrutinee as a wildcard does.
+        let has_wildcard = first_irrefutable.is_some();
         let bool_true_covered = bool_true_span.is_some();
         let bool_false_covered = bool_false_span.is_some();
         let is_exhaustive = if scrutinee_type == Type::BOOL {
@@ -2033,7 +2147,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
 
-        let air_ref = if groups.is_empty() {
+        let air_ref = if scrutinee_type.is_struct() {
+            // Every arm over a struct scrutinee is irrefutable (a struct
+            // pattern or `_`), so the first arm always runs: there is no
+            // discriminant to switch on, and the arm's block — its bindings
+            // followed by its body — is the match's value. Later arms were
+            // analyzed for their diagnostics and reported unreachable above.
+            arm_bodies[0]
+        } else if groups.is_empty() {
             let body_arms: Vec<(AirPattern, AirRef)> = air_arms
                 .iter()
                 .map(|arm| match arm {
@@ -2924,7 +3045,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 matches!(element, rue_rir::RirPatternElement::Nested(_)).then_some(index as u32)
             })
             .collect();
-        levels.push(ArmLevel {
+        levels.push(ArmLevel::Variant {
             pattern,
             scrutinee,
             enum_id,
@@ -2941,6 +3062,24 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 fields.push(MatrixPattern::Wildcard);
                 continue;
             };
+            // A struct pattern over the position (4.7:42, RUE-2175) binds the
+            // whole field and discriminates nothing: its level projects the
+            // field out and its row entry is a wildcard.
+            if let RirPattern::Struct { .. } = inner {
+                let value = air.add_inst(AirInst {
+                    data: AirInstData::EnumPayloadGet {
+                        base: scrutinee,
+                        enum_id,
+                        variant_index,
+                        field_index: index as u32,
+                    },
+                    ty: field_type,
+                    span: inner.span(),
+                });
+                self.resolve_struct_pattern_level(inner, value, field_type, ctx, levels)?;
+                fields.push(MatrixPattern::Wildcard);
+                continue;
+            }
             if field_type.as_enum().is_none() {
                 return Err(CompileError::new(
                     ErrorKind::InvalidMatchType(self.format_type_name(field_type)),
@@ -2964,6 +3103,81 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             variant_index,
             fields,
         })
+    }
+
+    /// Resolve one struct pattern (spec 4.7:42, RUE-2175) against the value
+    /// it is matched on and record its level. The checks are the ones a let
+    /// statement's struct pattern makes (5.1:19, 5.1:20): the preview gate,
+    /// a head that names a struct type (E0213) and names the value's own
+    /// type (E0206), and a field list naming every declared field exactly
+    /// once (E0400, E0401, E0402). The field reads themselves are the arm
+    /// body's leading `let`s, analyzed with the body.
+    fn resolve_struct_pattern_level<'p>(
+        &mut self,
+        pattern: &'p RirPattern,
+        scrutinee: AirRef,
+        scrutinee_type: Type,
+        ctx: &AnalysisContext,
+        levels: &mut Vec<ArmLevel<'p>>,
+    ) -> CompileResult<()> {
+        let RirPattern::Struct {
+            ty, fields, span, ..
+        } = pattern
+        else {
+            unreachable!("resolve_struct_pattern_level accepts only struct patterns")
+        };
+        let span = *span;
+        self.require_preview(
+            rue_error::PreviewFeature::StructPatterns,
+            "struct patterns",
+            span,
+        )?;
+        let head = self.resolve_rir_type_with_ctx(*ty, span, ctx)?;
+        let Some(struct_id) = head.as_struct() else {
+            return Err(CompileError::new(
+                ErrorKind::StructPatternNotStruct {
+                    type_name: self.format_type_name(head),
+                },
+                span,
+            )
+            .with_help("a struct pattern names the fields of a struct type"));
+        };
+        if !self.types_equivalent(scrutinee_type, head) {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: self.format_type_name(head),
+                    found: self.format_type_name(scrutinee_type),
+                },
+                span,
+            )
+            .with_help("the pattern head must name the matched value's own struct type"));
+        }
+        self.check_struct_pattern_fields(struct_id, fields.iter().copied(), span)?;
+        levels.push(ArmLevel::Struct {
+            pattern,
+            scrutinee,
+            ty: head,
+        });
+        Ok(())
+    }
+
+    /// Spell a struct pattern for a diagnostic: `Point { x, y }`.
+    fn spell_struct_pattern(
+        &mut self,
+        ty: rue_rir::RirTypeSyntaxRef,
+        fields: &[Spur],
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> String {
+        let head = match self.resolve_rir_type_with_ctx(ty, span, ctx) {
+            Ok(head) => self.format_type_name(head),
+            Err(_) => "_".to_string(),
+        };
+        let fields: Vec<&str> = fields
+            .iter()
+            .map(|field| self.body_interner().resolve(field))
+            .collect();
+        format!("{head} {{ {} }}", fields.join(", "))
     }
 
     /// Compile one variant group's pattern matrix into a decision tree
@@ -3294,18 +3508,56 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         level: &ArmLevel<'_>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Vec<u32>> {
+        let (pattern, enum_id, variant_index, nested_positions, scrutinee_ref) = match level {
+            ArmLevel::Variant {
+                pattern,
+                scrutinee,
+                enum_id,
+                variant_index,
+                nested,
+            } => (*pattern, *enum_id, *variant_index, nested, *scrutinee),
+            // A struct pattern (4.7:42) binds the matched value to its hidden
+            // local — the temporary a let statement's struct pattern binds
+            // (5.1:21) — and the arm body's leading `let`s move or copy each
+            // field out of it. Whatever the local still owns at the arm's end
+            // is dropped then, so the value is fully accounted for and the
+            // caller's whole-scrutinee drop must not run.
+            ArmLevel::Struct {
+                pattern,
+                scrutinee,
+                ty,
+            } => {
+                let RirPattern::Struct { local, span, .. } = pattern else {
+                    unreachable!("a struct level holds a struct pattern")
+                };
+                let (local, span) = (*local, *span);
+                let (slot, storage_live, alloc) =
+                    self.allocate_local_storage(air, *scrutinee, *ty, span, ctx)?;
+                ctx.insert_local(
+                    local,
+                    LocalVar {
+                        slot,
+                        ty: *ty,
+                        is_mut: false,
+                        span,
+                        // Nothing can name the local, and a pattern over a
+                        // field-less struct reads nothing from it.
+                        allow_unused: true,
+                    },
+                );
+                return Ok(vec![storage_live.as_u32(), alloc.as_u32()]);
+            }
+        };
         let RirPattern::Path {
             variant,
             elements,
             span,
             ..
-        } = level.pattern
+        } = pattern
         else {
             return Ok(Vec::new());
         };
         let pattern_span = *span;
-        let (enum_id, variant_index) = (level.enum_id, level.variant_index);
-        let scrutinee_ref = level.scrutinee;
         let def = self.body_type_pool().enum_def(enum_id);
         let variant_name = self.body_interner().resolve(&*variant).to_string();
         let enum_name = self.format_type_name(Type::new_enum(enum_id));
@@ -3384,7 +3636,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // A position a nested pattern occupies is accounted for by the
             // level that matches it (RUE-2053): that level binds the field's
             // own positions, so nothing is bound or dropped here.
-            if level.nested.contains(&(i as u32)) {
+            if nested_positions.contains(&(i as u32)) {
                 continue;
             }
             // The source name at this position, or `None` when the position

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1436,11 +1436,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .match_arms(arms)
             .iter()
             .any(|(pattern, _)| matches!(pattern, RirPatternView::Struct { .. }));
-        if !scrutinee_type.is_integer()
-            && scrutinee_type != Type::BOOL
-            && !scrutinee_type.is_enum()
-            && !(scrutinee_type.is_struct() && has_struct_pattern_arm)
-        {
+        let matchable = scrutinee_type.is_integer()
+            || scrutinee_type == Type::BOOL
+            || scrutinee_type.is_enum()
+            || (scrutinee_type.is_struct() && has_struct_pattern_arm);
+        if !matchable {
             return Err(CompileError::new(
                 ErrorKind::InvalidMatchType(self.format_type_name(scrutinee_type)),
                 span,

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -1599,6 +1599,7 @@ fn pattern_record(
             Vec::new(),
         ),
         rue_parser::Pattern::Path(path) => path_pattern_record(owner, path, span),
+        rue_parser::Pattern::Struct(pattern) => struct_pattern_record(owner, pattern),
     }
 }
 
@@ -1631,6 +1632,7 @@ fn path_pattern_record(
         rue_parser::PatternElement::Nested(nested) => {
             path_pattern_record(owner, nested, nested.span)
         }
+        rue_parser::PatternElement::Struct(pattern) => struct_pattern_record(owner, pattern),
     }));
     syntax_record(
         "path_pattern",

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -2064,6 +2064,22 @@ impl<'a> ParsedBodyProjectionCollector<'a> {
             match element {
                 rue_parser::PatternElement::Binding(binding) => self.bind_local(*binding)?,
                 rue_parser::PatternElement::Nested(nested) => self.visit_path_pattern(nested)?,
+                rue_parser::PatternElement::Struct(pattern) => {
+                    self.visit_struct_pattern(pattern)?
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a struct pattern's head as a type position and bind each of its
+    /// field bindings as an ordinary local (spec 5.1:18, 5.1:21; 4.7:42 in a
+    /// match arm).
+    fn visit_struct_pattern(&mut self, pattern: &rue_parser::StructPattern) -> CompileResult<()> {
+        self.visit_type(&pattern.ty)?;
+        for field in &pattern.fields {
+            if let rue_parser::StructPatternBinding::Ident { name, .. } = &field.binding {
+                self.bind_local(*name)?;
             }
         }
         Ok(())
@@ -2236,17 +2252,7 @@ impl<'a> ParsedBodyProjectionCollector<'a> {
                         }
                         self.visit_expr(&binding.init)?;
                         if let LetPattern::Struct(pattern) = &binding.pattern {
-                            // A struct pattern's head is a type position and
-                            // each field binding is an ordinary local
-                            // (spec 5.1:18, 5.1:21).
-                            self.visit_type(&pattern.ty)?;
-                            for field in &pattern.fields {
-                                if let rue_parser::StructPatternBinding::Ident { name, .. } =
-                                    &field.binding
-                                {
-                                    self.bind_local(*name)?;
-                                }
-                            }
+                            self.visit_struct_pattern(pattern)?;
                         }
                         if let LetPattern::Ident(ident) = binding.pattern {
                             let alias = (!binding.is_mut)

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -104,11 +104,17 @@ fn block_charge(block: &ast::BlockExpr) -> u64 {
 fn pattern_charge(pattern: &ast::Pattern) -> u64 {
     match pattern {
         ast::Pattern::Path(path) => path_pattern_charge(path),
+        ast::Pattern::Struct(pattern) => boxed_charge(pattern, struct_pattern_charge),
         ast::Pattern::Wildcard(_)
         | ast::Pattern::Int(_)
         | ast::Pattern::NegInt(_)
         | ast::Pattern::Bool(_) => 0,
     }
+}
+
+/// A struct pattern (RUE-2175) owns its head type and its field list.
+fn struct_pattern_charge(pattern: &ast::StructPattern) -> u64 {
+    type_charge(&pattern.ty).saturating_add(owned_slice_charge(&pattern.fields, |_| 0))
 }
 
 fn path_pattern_charge(path: &ast::PathPattern) -> u64 {
@@ -127,6 +133,9 @@ fn path_pattern_charge(path: &ast::PathPattern) -> u64 {
             |element| match element {
                 ast::PatternElement::Binding(_) => 0,
                 ast::PatternElement::Nested(nested) => path_pattern_charge(nested),
+                ast::PatternElement::Struct(pattern) => {
+                    boxed_charge(pattern, struct_pattern_charge)
+                }
             },
         ))
 }

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -787,12 +787,42 @@ impl Shapes<'_> {
                         rue_parser::PatternElement::Nested(nested) => {
                             self.pattern(&Pattern::Path(nested.clone()))
                         }
+                        rue_parser::PatternElement::Struct(pattern) => self.struct_pattern(pattern),
                     })),
                     "_".into(),
                     "_".into(),
                 )
             }
+            Pattern::Struct(pattern) => self.struct_pattern(pattern),
         }
+    }
+
+    /// A struct pattern in a match arm (RUE-2175): the head type and one
+    /// field entry per binding, in source order.
+    fn struct_pattern(&self, pattern: &rue_parser::StructPattern) -> String {
+        node(
+            "pattern",
+            " form=struct",
+            self.ty(&pattern.ty),
+            list(pattern.fields.iter().map(|field| {
+                node(
+                    "field-pattern",
+                    match &field.binding {
+                        rue_parser::StructPatternBinding::Ident { is_mut: true, .. } => " form=mut",
+                        rue_parser::StructPatternBinding::Ident { is_mut: false, .. } => {
+                            " form=bind"
+                        }
+                        rue_parser::StructPatternBinding::Wildcard(_) => " form=discard",
+                    },
+                    self.ident(),
+                    "_".into(),
+                    "_".into(),
+                    "_".into(),
+                )
+            })),
+            "_".into(),
+            "_".into(),
+        )
     }
 
     fn statement(&self, statement: &Statement) -> String {

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -1012,6 +1012,10 @@ pub enum Pattern {
     Bool(BoolLit),
     /// Path pattern (e.g., `Color::Red` for enum variant)
     Path(PathPattern),
+    /// Struct pattern `T { f: b, ... }` over a struct scrutinee (spec 4.7:42,
+    /// preview feature `struct_patterns`, RUE-2175). Irrefutable: it binds
+    /// every field of the value and matches any value of its type.
+    Struct(Box<StructPattern>),
 }
 
 /// A negative integer literal pattern.
@@ -1025,16 +1029,19 @@ pub struct NegIntLit {
 
 /// One payload position of a tuple-variant pattern.
 ///
-/// A position either binds the field to a fresh name (or discards it with `_`)
-/// or holds a nested variant pattern the field must itself match
-/// (`R.Err(E.A(b))`, RUE-2053). Nesting is recursive: a nested pattern's own
-/// payload positions are `PatternElement`s again.
+/// A position either binds the field to a fresh name (or discards it with `_`),
+/// holds a nested variant pattern the field must itself match
+/// (`R.Err(E.A(b))`, RUE-2053), or holds a struct pattern that destructures
+/// the field (`R.Ok(Point { x, y })`, RUE-2175). Nesting is recursive: a
+/// nested variant pattern's own payload positions are `PatternElement`s again.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PatternElement {
     /// A payload binding name, or the wildcard `_` that discards the field.
     Binding(Ident),
     /// A nested variant pattern this payload field must match.
     Nested(PathPattern),
+    /// A struct pattern binding the fields of this payload position.
+    Struct(Box<StructPattern>),
 }
 
 impl PatternElement {
@@ -1043,6 +1050,7 @@ impl PatternElement {
         match self {
             PatternElement::Binding(ident) => ident.span,
             PatternElement::Nested(path) => path.span,
+            PatternElement::Struct(pattern) => pattern.span,
         }
     }
 
@@ -1050,7 +1058,7 @@ impl PatternElement {
     pub fn binding(&self) -> Option<&Ident> {
         match self {
             PatternElement::Binding(ident) => Some(ident),
-            PatternElement::Nested(_) => None,
+            PatternElement::Nested(_) | PatternElement::Struct(_) => None,
         }
     }
 }
@@ -1092,6 +1100,7 @@ impl Pattern {
             Pattern::NegInt(lit) => lit.span,
             Pattern::Bool(lit) => lit.span,
             Pattern::Path(path) => path.span,
+            Pattern::Struct(pattern) => pattern.span,
         }
     }
 }
@@ -1294,7 +1303,8 @@ impl LetPattern {
     }
 }
 
-/// A struct destructuring pattern: `T { f: b, g, h: _ }` (spec 5.1:18).
+/// A struct destructuring pattern: `T { f: b, g, h: _ }` (spec 5.1:18 in a
+/// let statement, 4.7:42 in a match arm).
 ///
 /// The head is written with the type grammar (`Point`, `m.Point`,
 /// `Pair(i32)`), exactly as a `let` annotation would name the type. A pattern
@@ -1908,7 +1918,21 @@ fn rebind_pattern(pattern: &mut Pattern, file_id: FileId) {
         Pattern::NegInt(literal) => rebind_span(&mut literal.span, file_id),
         Pattern::Bool(literal) => rebind_span(&mut literal.span, file_id),
         Pattern::Path(path) => rebind_path_pattern(path, file_id),
+        Pattern::Struct(pattern) => rebind_struct_pattern(pattern, file_id),
     }
+}
+
+fn rebind_struct_pattern(pattern: &mut StructPattern, file_id: FileId) {
+    rebind_type(&mut pattern.ty, file_id);
+    for field in &mut pattern.fields {
+        rebind_ident(&mut field.name, file_id);
+        match &mut field.binding {
+            StructPatternBinding::Ident { name, .. } => rebind_ident(name, file_id),
+            StructPatternBinding::Wildcard(span) => rebind_span(span, file_id),
+        }
+        rebind_span(&mut field.span, file_id);
+    }
+    rebind_span(&mut pattern.span, file_id);
 }
 
 fn rebind_path_pattern(path: &mut PathPattern, file_id: FileId) {
@@ -1926,6 +1950,7 @@ fn rebind_path_pattern(path: &mut PathPattern, file_id: FileId) {
         match element {
             PatternElement::Binding(binding) => rebind_ident(binding, file_id),
             PatternElement::Nested(nested) => rebind_path_pattern(nested, file_id),
+            PatternElement::Struct(pattern) => rebind_struct_pattern(pattern, file_id),
         }
     }
     rebind_span(&mut path.span, file_id);
@@ -2101,18 +2126,7 @@ fn rebind_let_pattern(pattern: &mut LetPattern, file_id: FileId) {
     match pattern {
         LetPattern::Ident(ident) => rebind_ident(ident, file_id),
         LetPattern::Wildcard(span) => rebind_span(span, file_id),
-        LetPattern::Struct(pattern) => {
-            rebind_type(&mut pattern.ty, file_id);
-            for field in &mut pattern.fields {
-                rebind_ident(&mut field.name, file_id);
-                match &mut field.binding {
-                    StructPatternBinding::Ident { name, .. } => rebind_ident(name, file_id),
-                    StructPatternBinding::Wildcard(span) => rebind_span(span, file_id),
-                }
-                rebind_span(&mut field.span, file_id);
-            }
-            rebind_span(&mut pattern.span, file_id);
-        }
+        LetPattern::Struct(pattern) => rebind_struct_pattern(pattern, file_id),
     }
 }
 

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -27,6 +27,11 @@ pub struct Parser {
     /// record `contains_anonymous_type_literal` (RUE-1837); only the difference
     /// across a body matters, so it never needs resetting.
     anonymous_type_literals: usize,
+    /// For each `(` token, the index of its matching `)` (`u32::MAX` when it
+    /// has none). Built once over the whole token stream the first time a
+    /// head scan needs to look past a parenthesised group (A.2:2 item 6), so
+    /// nested groups cost one lookup each instead of one walk each.
+    paren_close: Option<Vec<u32>>,
 }
 struct PrimitiveTypeSpurs {
     i8: Spur,
@@ -162,6 +167,7 @@ impl Parser {
             errors: diagnostics::ParserDiagnostics::default(),
             interner_error,
             anonymous_type_literals: 0,
+            paren_close: None,
         }
     }
 
@@ -186,6 +192,7 @@ impl Parser {
             errors: diagnostics::ParserDiagnostics::default(),
             interner_error,
             anonymous_type_literals: 0,
+            paren_close: None,
         }
     }
 

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -318,25 +318,12 @@ impl Parser {
     /// type-constructor call on a path head (`Result(i32, i32).Ok`, the group
     /// precedes a dot) from a variant's payload bindings (`Ok(v)`, the group is
     /// terminal) during a single left-to-right pass (RUE-947).
-    fn ctor_group_precedes_dot(&self) -> bool {
+    fn ctor_group_precedes_dot(&mut self) -> bool {
         debug_assert!(self.at(TokenKind::LParen));
-        let mut cursor = self.cursor;
-        let mut depth = 0usize;
-        while let Some(token) = self.tokens.get(cursor) {
-            match token.kind {
-                TokenKind::LParen => depth += 1,
-                TokenKind::RParen => {
-                    depth -= 1;
-                    if depth == 0 {
-                        return self.tokens.get(cursor + 1).map(|t| t.kind) == Some(TokenKind::Dot);
-                    }
-                }
-                TokenKind::Eof => return false,
-                _ => {}
-            }
-            cursor += 1;
-        }
-        false
+        let Some(close) = self.matching_paren(self.cursor) else {
+            return false;
+        };
+        self.tokens.get(close + 1).map(|t| t.kind) == Some(TokenKind::Dot)
     }
 
     /// Reject a trailing-dot float literal (`5.`) before it is mistaken for a

--- a/crates/rue-parser/src/parser/shared.rs
+++ b/crates/rue-parser/src/parser/shared.rs
@@ -18,6 +18,34 @@ impl Parser {
     pub(super) fn at(&self, kind: TokenKind) -> bool {
         self.kind() == kind
     }
+    /// The index of the `)` matching the `(` at token index `open`, if it has
+    /// one. The table behind it is built once, over the whole token stream,
+    /// the first time a head scan needs to look past a group (A.2:2 item 6):
+    /// deciding a group by the token after its `)` then costs one lookup per
+    /// group, so nested groups stay linear in the input.
+    pub(super) fn matching_paren(&mut self, open: usize) -> Option<usize> {
+        if self.paren_close.is_none() {
+            let mut table = vec![u32::MAX; self.tokens.len()];
+            let mut stack: Vec<usize> = Vec::new();
+            for (index, token) in self.tokens.iter().enumerate() {
+                match token.kind {
+                    TokenKind::LParen => stack.push(index),
+                    TokenKind::RParen => {
+                        if let Some(open) = stack.pop() {
+                            table[open] = u32::try_from(index).unwrap_or(u32::MAX);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            self.paren_close = Some(table);
+        }
+        self.paren_close
+            .as_ref()
+            .and_then(|table| table.get(open).copied())
+            .filter(|close| *close != u32::MAX)
+            .map(|close| close as usize)
+    }
     pub(super) fn bump(&mut self) -> Token {
         let token = self.tokens.get(self.cursor).cloned().unwrap_or(Token {
             kind: TokenKind::Eof,

--- a/crates/rue-parser/src/parser/statements.rs
+++ b/crates/rue-parser/src/parser/statements.rs
@@ -195,11 +195,45 @@ impl Parser {
                 let span = self.bump().span;
                 Ok(Pattern::Bool(BoolLit { value, span }))
             }
+            // A struct pattern's head is a type followed by `{`; a variant
+            // pattern's head is a path followed by `=>` or a payload list. One
+            // scan over the head decides which grammar the name starts
+            // (spec 4.7:2).
+            TokenKind::Ident(_) if self.struct_pattern_ahead() => self
+                .struct_pattern()
+                .map(|pattern| Pattern::Struct(Box::new(pattern))),
             TokenKind::Ident(_) => self.path_pattern(start),
             _ => {
                 self.error("expected pattern");
                 Err(())
             }
+        }
+    }
+
+    /// With the cursor at an identifier, report whether the tokens ahead spell
+    /// a struct pattern head: a type path (`Point`, `m.Point`), optionally
+    /// applied to constructor arguments (`Pair(i32)`), followed by `{`. A
+    /// variant pattern's head ends in `=>`, `,`, `)` or a payload list
+    /// instead, so the scan never commits to the wrong grammar (RUE-2175).
+    fn struct_pattern_ahead(&mut self) -> bool {
+        debug_assert!(matches!(self.kind(), TokenKind::Ident(_)));
+        let mut cursor = self.cursor + 1;
+        loop {
+            if self.nth(cursor - self.cursor) == TokenKind::LParen {
+                let Some(close) = self.matching_paren(cursor) else {
+                    return false;
+                };
+                cursor = close + 1;
+            }
+            let kind = self.nth(cursor - self.cursor);
+            if kind != TokenKind::Dot {
+                return kind == TokenKind::LBrace;
+            }
+            cursor += 1;
+            if !matches!(self.nth(cursor - self.cursor), TokenKind::Ident(_)) {
+                return false;
+            }
+            cursor += 1;
         }
     }
 
@@ -242,7 +276,8 @@ impl Parser {
     }
 
     /// One payload position of a tuple-variant pattern: a binder, the `_`
-    /// discard, or a nested variant pattern (RUE-2053). A nested pattern is
+    /// discard, a nested variant pattern (RUE-2053), or a struct pattern over
+    /// the payload field (RUE-2175). A nested pattern is
     /// parsed by the same `path_pattern` this method is called from — the
     /// pattern grammar has exactly one path parser (RUE-1988), so a payload
     /// position accepts every head form a top-level pattern accepts
@@ -254,6 +289,11 @@ impl Parser {
                 name: self.syms.underscore,
                 span,
             }));
+        }
+        if matches!(self.kind(), TokenKind::Ident(_)) && self.struct_pattern_ahead() {
+            return self
+                .struct_pattern()
+                .map(|pattern| PatternElement::Struct(Box::new(pattern)));
         }
         // A binder is a lone identifier, so the position is a nested pattern
         // exactly when the identifier continues into a path (`E.A`) or a
@@ -304,8 +344,9 @@ impl Parser {
     }
 
     /// One struct pattern: `struct_pattern = type "{" [ field_patterns ] "}"`
-    /// (spec 5.1:18). The head is parsed by the canonical type parser, so a
-    /// pattern names its struct exactly as a `let` annotation would.
+    /// (spec 5.1:18, and 4.7:42 in a match arm). The head is parsed by the
+    /// canonical type parser, so a pattern names its struct exactly as a `let`
+    /// annotation would.
     fn struct_pattern(&mut self) -> PResult<StructPattern> {
         let start = self.start();
         let ty = self.ty()?;
@@ -847,5 +888,103 @@ mod tests {
             parse_errors("fn f(x: i32) -> i32 { match x { Color => 0 } }").first(),
             Some(&"expected '.', found '=>'".to_owned())
         );
+    }
+
+    /// The first arm's pattern of the match a function body ends in.
+    fn first_arm(source: &str) -> Pattern {
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, _) = Parser::new(tokens, interner).parse().unwrap();
+        let Item::Function(function) = &ast.items[0] else {
+            panic!("expected a function item");
+        };
+        let Expr::Block(body) = &function.body else {
+            panic!("expected a block body");
+        };
+        let Expr::Match(match_expr) = &*body.expr else {
+            panic!("expected a match expression, got {:?}", body.expr);
+        };
+        match_expr.arms[0].pattern.clone()
+    }
+
+    /// A struct pattern in arm position (RUE-2175) carries every field form
+    /// a let pattern does: shorthand, rename, `mut`, and `_`.
+    #[test]
+    fn match_arm_accepts_a_struct_pattern() {
+        let Pattern::Struct(pattern) =
+            first_arm("fn f(p: P) -> i32 { match p { Point { x, y: py, mut z, w: _ } => 1 } }")
+        else {
+            panic!("expected a struct pattern");
+        };
+        assert_eq!(pattern.fields.len(), 4);
+        assert!(matches!(
+            pattern.fields[1].binding,
+            StructPatternBinding::Ident { is_mut: false, .. }
+        ));
+        assert!(matches!(
+            pattern.fields[2].binding,
+            StructPatternBinding::Ident { is_mut: true, .. }
+        ));
+        assert!(matches!(
+            pattern.fields[3].binding,
+            StructPatternBinding::Wildcard(_)
+        ));
+    }
+
+    /// The head takes every form a type does; the scan that tells a struct
+    /// pattern from a variant pattern looks past the path and any constructor
+    /// arguments to the `{`.
+    #[test]
+    fn struct_pattern_heads_take_every_type_form() {
+        for source in [
+            "fn f(p: P) -> i32 { match p { m.Point { x } => 1 } }",
+            "fn f(p: P) -> i32 { match p { Pair(i32) { a, b } => 1 } }",
+            "fn f(p: P) -> i32 { match p { m.Pair(i32, E) { a, b } => 1 } }",
+            "fn f(p: P) -> i32 { match p { Empty {} => 1 } }",
+        ] {
+            assert!(matches!(first_arm(source), Pattern::Struct(_)), "{source}");
+        }
+    }
+
+    /// A variant pattern keeps its grammar whatever head form it takes: the
+    /// struct-pattern scan commits only on a `{`.
+    #[test]
+    fn variant_patterns_are_not_mistaken_for_struct_patterns() {
+        for source in [
+            "fn f(r: R) -> i32 { match r { Color.Red => 1 } }",
+            "fn f(r: R) -> i32 { match r { m.Color.Red => 1 } }",
+            "fn f(r: R) -> i32 { match r { Result(i32, E).Ok(v) => 1 } }",
+            "fn f(r: R) -> i32 { match r { m.Result(i32, E).Ok(v) => 1 } }",
+            "fn f(r: R) -> i32 { match r { R.Ok(v) => { 1 } } }",
+        ] {
+            assert!(matches!(first_arm(source), Pattern::Path(_)), "{source}");
+        }
+    }
+
+    /// A payload position holds a struct pattern (RUE-2175) alongside the
+    /// binder, discard and nested-variant forms.
+    #[test]
+    fn payload_positions_accept_struct_patterns() {
+        let Pattern::Path(pattern) = first_arm(
+            "fn f(r: R) -> i32 { match r { R.Ok(Point { x, y }, _, E.A(b), m.Pair(i32) { a, b }) => 1 } }",
+        ) else {
+            panic!("expected a path pattern");
+        };
+        assert_eq!(pattern.elements.len(), 4);
+        assert!(matches!(pattern.elements[0], PatternElement::Struct(_)));
+        assert!(matches!(pattern.elements[1], PatternElement::Binding(_)));
+        assert!(matches!(pattern.elements[2], PatternElement::Nested(_)));
+        assert!(matches!(pattern.elements[3], PatternElement::Struct(_)));
+    }
+
+    /// A struct pattern's fields are binders only: nesting a pattern inside a
+    /// field position is not part of the grammar.
+    #[test]
+    fn struct_pattern_fields_do_not_nest() {
+        assert!(!parses(
+            "fn f(p: P) -> i32 { match p { Line { a: Point { x, y }, b } => 1 } }"
+        ));
+        assert!(!parses(
+            "fn f(p: P) -> i32 { match p { Cell { c: Color.Red } => 1 } }"
+        ));
     }
 }

--- a/crates/rue-parser/src/parser/statements.rs
+++ b/crates/rue-parser/src/parser/statements.rs
@@ -216,7 +216,6 @@ impl Parser {
     /// variant pattern's head ends in `=>`, `,`, `)` or a payload list
     /// instead, so the scan never commits to the wrong grammar (RUE-2175).
     fn struct_pattern_ahead(&mut self) -> bool {
-        debug_assert!(matches!(self.kind(), TokenKind::Ident(_)));
         let mut cursor = self.cursor + 1;
         loop {
             if self.nth(cursor - self.cursor) == TokenKind::LParen {

--- a/crates/rue-rir/src/api_inventory.rs
+++ b/crates/rue-rir/src/api_inventory.rs
@@ -256,7 +256,7 @@ fn rir_span_storage_is_tied_to_the_canonical_slot_visitor() {
     let pattern = source_region(schema, "pub enum RirPattern {", "impl RirPattern");
     assert_eq!(
         pattern.matches("Span").count(),
-        6,
+        7,
         "pattern span schema changed"
     );
     for shape in [
@@ -264,6 +264,7 @@ fn rir_span_storage_is_tied_to_the_canonical_slot_visitor() {
         "span: Span",
         "Bool(bool, Span)",
         "span: Span",
+        "fields: Vec<Spur>,\n        /// Location of the pattern.\n        span: Span",
     ] {
         assert!(pattern.contains(shape));
     }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -77,9 +77,17 @@ pub struct AstGen<'a> {
     /// nested and sibling compound assignments never share a temporary.
     compound_counter: u32,
     /// Monotonic counter used to mint unique names for the hidden temporaries
-    /// of a struct-pattern `let` (spec 5.1:18, RUE-1884), so nested and
-    /// sibling patterns never share one.
+    /// of a struct-pattern `let` (spec 5.1:18, RUE-1884) and of a struct
+    /// pattern in a match arm (4.7:42, RUE-2175), so nested and sibling
+    /// patterns never share one.
     struct_pattern_count: u32,
+    /// The field bindings of the struct patterns in the match arm currently
+    /// being lowered, in pattern preorder (RUE-2175). A struct pattern in arm
+    /// position binds the matched value to a hidden local and reads each field
+    /// out of it with an ordinary `let`; those lets are emitted while the
+    /// pattern is lowered and collected here, and the arm's body is wrapped in
+    /// a block that runs them first.
+    pending_arm_bindings: Vec<u32>,
     /// Source bindings that may be changed while this producer runs. A place
     /// index referring to one of these must be captured before the compound
     /// assignment's right-hand side; immutable bindings and file constants
@@ -214,6 +222,7 @@ impl<'a> AstGen<'a> {
             for_counter: 0,
             compound_counter: 0,
             struct_pattern_count: 0,
+            pending_arm_bindings: Vec::new(),
             mutable_place_names: AHashSet::new(),
             mutable_place_names_added: Vec::new(),
             structural_path: None,
@@ -1393,14 +1402,33 @@ impl<'a> AstGen<'a> {
                         self.with_structural_segment(
                             crate::RirStructuralPathSegment::MatchArm(index as u32),
                             |this| {
+                                // A struct pattern in this arm (RUE-2175) emits
+                                // the lets that bind its fields while it is
+                                // lowered; they run before the body, in the
+                                // body's own scope.
+                                let outer_bindings = std::mem::take(&mut this.pending_arm_bindings);
                                 let pattern = this.with_structural_segment(
                                     crate::RirStructuralPathSegment::Operand(0),
                                     |this| this.gen_pattern(&arm.pattern),
+                                );
+                                let bindings = std::mem::replace(
+                                    &mut this.pending_arm_bindings,
+                                    outer_bindings,
                                 );
                                 let body = this.gen_expr_at(
                                     crate::RirStructuralPathSegment::Operand(1),
                                     &arm.body,
                                 );
+                                let body = if bindings.is_empty() {
+                                    body
+                                } else {
+                                    let mut refs: Vec<InstRef> =
+                                        bindings.into_iter().map(InstRef::from_raw).collect();
+                                    refs.push(body);
+                                    this.rir
+                                        .add_block(&refs, arm.body.span())
+                                        .record_failure(&mut this.payload_error)
+                                };
                                 (pattern, body)
                             },
                         )
@@ -1848,6 +1876,37 @@ impl<'a> AstGen<'a> {
             },
             Pattern::Bool(lit) => RirPattern::Bool(lit.value, lit.span),
             Pattern::Path(path) => self.gen_path_pattern(path),
+            Pattern::Struct(pattern) => self.gen_struct_match_pattern(pattern),
+        }
+    }
+
+    /// Lower one struct pattern in arm position (spec 4.7:42, RUE-2175) to
+    /// the form a let statement's struct pattern takes (5.1:21): the matched
+    /// value is bound to a hidden local, and each field pattern becomes a
+    /// `let` of a field read on that local, emitted here and collected for
+    /// the arm body's wrapper block. The pattern record itself carries the
+    /// hidden name, the head type and the field list so that semantic
+    /// analysis can check the head against the matched value and the list
+    /// against the struct's declared fields before the lets are analyzed.
+    fn gen_struct_match_pattern(&mut self, pattern: &StructPattern) -> RirPattern {
+        let index = self.struct_pattern_count;
+        self.struct_pattern_count += 1;
+        let local = self.intern(format!("_@rue:destructure:{index}"));
+        let head = self.intern_type_at(crate::RirStructuralPathSegment::Operand(0), &pattern.ty);
+        let field_names: Vec<Spur> = pattern
+            .fields
+            .iter()
+            .map(|field| self.symbol(field.name.name))
+            .collect();
+        for (position, field) in pattern.fields.iter().enumerate() {
+            let alloc = self.gen_struct_pattern_field_let(local, field, 1 + position as u32);
+            self.pending_arm_bindings.push(alloc.as_u32());
+        }
+        RirPattern::Struct {
+            local,
+            ty: head,
+            fields: field_names,
+            span: pattern.span,
         }
     }
 
@@ -1883,6 +1942,16 @@ impl<'a> AstGen<'a> {
                     RirPatternElement::Nested(
                         self.with_structural_segment(segment, |this| this.gen_path_pattern(nested)),
                     )
+                }
+                // A struct pattern over the payload field (RUE-2175) takes the
+                // slot a nested variant pattern would, and nests as one.
+                rue_parser::PatternElement::Struct(pattern) => {
+                    let segment = crate::RirStructuralPathSegment::Operand(
+                        (1 + ctor_arity + position) as u32,
+                    );
+                    RirPatternElement::Nested(self.with_structural_segment(segment, |this| {
+                        this.gen_struct_match_pattern(pattern)
+                    }))
                 }
             })
             .collect();
@@ -2331,41 +2400,51 @@ impl<'a> AstGen<'a> {
         out.push(check.as_u32());
 
         for (position, field) in pattern.fields.iter().enumerate() {
-            let field_name = self.symbol(field.name.name);
-            let (binding, is_mut) = match &field.binding {
-                StructPatternBinding::Ident { name, is_mut } => {
-                    (Some(self.symbol(name.name)), *is_mut)
-                }
-                StructPatternBinding::Wildcard(_) => (None, false),
-            };
-            let projection = self.with_structural_segment(
-                crate::RirStructuralPathSegment::Operand(2 + position as u32),
-                |this| {
-                    let base = this.rir.add_inst(Inst {
-                        data: InstData::VarRef {
-                            name: local,
-                            anchor: None,
-                        },
-                        span: field.span,
-                    });
-                    this.rir.add_inst(Inst {
-                        data: InstData::FieldGet {
-                            base,
-                            field: field_name,
-                        },
-                        span: field.span,
-                    })
-                },
-            );
-            if is_mut && let Some(name) = binding {
-                self.mark_mutable_name(name);
-            }
-            let alloc = self
-                .rir
-                .add_alloc(&[], binding, is_mut, None, projection, false, field.span)
-                .record_failure(&mut self.payload_error);
+            let alloc = self.gen_struct_pattern_field_let(local, field, 2 + position as u32);
             out.push(alloc.as_u32());
         }
+    }
+
+    /// Lower one field pattern of a struct pattern to the `let` it stands for
+    /// (5.1:21): `let b = <local>.f;`, `let mut b = <local>.f;`, or
+    /// `let _ = <local>.f;`. The projection takes the structural operand slot
+    /// `operand` of the enclosing pattern.
+    fn gen_struct_pattern_field_let(
+        &mut self,
+        local: Spur,
+        field: &rue_parser::StructPatternField,
+        operand: u32,
+    ) -> InstRef {
+        let field_name = self.symbol(field.name.name);
+        let (binding, is_mut) = match &field.binding {
+            StructPatternBinding::Ident { name, is_mut } => (Some(self.symbol(name.name)), *is_mut),
+            StructPatternBinding::Wildcard(_) => (None, false),
+        };
+        let projection = self.with_structural_segment(
+            crate::RirStructuralPathSegment::Operand(operand),
+            |this| {
+                let base = this.rir.add_inst(Inst {
+                    data: InstData::VarRef {
+                        name: local,
+                        anchor: None,
+                    },
+                    span: field.span,
+                });
+                this.rir.add_inst(Inst {
+                    data: InstData::FieldGet {
+                        base,
+                        field: field_name,
+                    },
+                    span: field.span,
+                })
+            },
+        );
+        if is_mut && let Some(name) = binding {
+            self.mark_mutable_name(name);
+        }
+        self.rir
+            .add_alloc(&[], binding, is_mut, None, projection, false, field.span)
+            .record_failure(&mut self.payload_error)
     }
 
     fn gen_statement(&mut self, stmt: &Statement) -> InstRef {
@@ -3193,6 +3272,9 @@ impl SiteWalker {
                     this.walk_path_pattern(nested)
                 });
             }
+            // A struct pattern in a payload position (RUE-2175) holds a type
+            // and binders only: nothing in it is an expression this walk
+            // numbers, exactly as a let statement's struct pattern (5.1:18).
         }
     }
 }

--- a/crates/rue-rir/src/inst/editor.rs
+++ b/crates/rue-rir/src/inst/editor.rs
@@ -812,6 +812,7 @@ impl RirEditor {
             take_span: &mut dyn FnMut(RirSpanField) -> Result<Span, RirSpanRemapError<E>>,
             symbol: &mut dyn FnMut(Spur) -> Spur,
             remap_ref: &dyn Fn(InstRef) -> InstRef,
+            remap_type: &dyn Fn(RirTypeSyntaxRef) -> RirTypeSyntaxRef,
         ) -> Result<RirPattern, RirSpanRemapError<E>> {
             let index = *nested;
             *nested += 1;
@@ -840,9 +841,11 @@ impl RirEditor {
                             RirPatternElementView::Binding(name) => {
                                 RirPatternElement::Binding(symbol(name))
                             }
-                            RirPatternElementView::Nested(inner) => RirPatternElement::Nested(
-                                remap_pattern(&inner, arm, nested, take_span, symbol, remap_ref)?,
-                            ),
+                            RirPatternElementView::Nested(inner) => {
+                                RirPatternElement::Nested(remap_pattern(
+                                    &inner, arm, nested, take_span, symbol, remap_ref, remap_type,
+                                )?)
+                            }
                         });
                     }
                     RirPattern::Path {
@@ -854,6 +857,14 @@ impl RirEditor {
                         span,
                     }
                 }
+                RirPatternView::Struct {
+                    local, ty, fields, ..
+                } => RirPattern::Struct {
+                    local: symbol(*local),
+                    ty: remap_type(*ty),
+                    fields: fields.values().map(&mut *symbol).collect(),
+                    span,
+                },
             })
         }
 
@@ -1111,6 +1122,7 @@ impl RirEditor {
                                     &mut take_span,
                                     &mut symbol,
                                     &remap_ref,
+                                    &remap_type,
                                 )?;
                                 Ok((pattern, remap_ref(body)))
                             })

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -1404,6 +1404,18 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
                     }
                 }
             }
+            RirPatternView::Struct {
+                local, ty, fields, ..
+            } => {
+                self.byte(4)?;
+                self.symbol(*local)?;
+                self.type_reference(*ty)?;
+                self.count(fields.len())?;
+                for field in fields.values() {
+                    self.check()?;
+                    self.symbol(field)?;
+                }
+            }
         }
         Ok(())
     }
@@ -2821,7 +2833,7 @@ impl<
                 family: "match pattern",
             })?;
         let span = self.span(basis, RirSpanField::MatchPattern { arm, nested: index })?;
-        Ok(match Self::byte_tag(reader, "match pattern", 3)? {
+        Ok(match Self::byte_tag(reader, "match pattern", 4)? {
             0 => RirPattern::Wildcard(span),
             1 => RirPattern::Int {
                 value: reader.u64()?,
@@ -2857,6 +2869,25 @@ impl<
                     type_name,
                     variant,
                     elements,
+                    span,
+                }
+            }
+            4 => {
+                let local = self.symbol(reader)?;
+                let ty = self.type_reference(reader)?;
+                let count = Self::count(reader, "struct pattern fields", 1)?;
+                let mut fields = Vec::new();
+                fields
+                    .try_reserve_exact(count)
+                    .map_err(|_| Self::capacity("struct pattern fields"))?;
+                for _ in 0..count {
+                    self.check()?;
+                    fields.push(self.symbol(reader)?);
+                }
+                RirPattern::Struct {
+                    local,
+                    ty,
+                    fields,
                     span,
                 }
             }

--- a/crates/rue-rir/src/inst/payload.rs
+++ b/crates/rue-rir/src/inst/payload.rs
@@ -298,13 +298,21 @@ pub enum RirPatternView<'a> {
         elements: RirPatternElements<'a>,
         span: Span,
     },
+    /// A struct pattern (RUE-2175): the hidden local the value is bound to,
+    /// the head type, and the field names in source order.
+    Struct {
+        local: Spur,
+        ty: RirTypeSyntaxRef,
+        fields: RirSymbols<'a>,
+        span: Span,
+    },
 }
 
 impl RirPatternView<'_> {
     pub fn span(&self) -> Span {
         match self {
             Self::Wildcard(span) | Self::Bool(_, span) => *span,
-            Self::Int { span, .. } | Self::Path { span, .. } => *span,
+            Self::Int { span, .. } | Self::Path { span, .. } | Self::Struct { span, .. } => *span,
         }
     }
 
@@ -335,6 +343,17 @@ impl RirPatternView<'_> {
                 type_name: *type_name,
                 variant: *variant,
                 elements: elements.to_vec(),
+                span: *span,
+            },
+            Self::Struct {
+                local,
+                ty,
+                fields,
+                span,
+            } => RirPattern::Struct {
+                local: *local,
+                ty: *ty,
+                fields: fields.to_vec(),
                 span: *span,
             },
         }
@@ -739,6 +758,9 @@ pub enum PatternKind {
     /// Path pattern: [kind, span_start, span_len, module, type_name, variant]
     /// module is u32::MAX for None, otherwise an InstRef
     Path = 3,
+    /// Struct pattern (RUE-2175): [kind, span_start, span_len, span_file,
+    /// local, type_syntax, n_fields, fields…]
+    Struct = 4,
 }
 
 /// Words each pattern kind occupies, *excluding* the arm-body word.
@@ -756,6 +778,14 @@ const PATTERN_WILDCARD_WORDS: usize = 4; // kind, span_start, span_len, span_fil
 const PATTERN_INT_WORDS: usize = 7; // + value_lo, value_hi, negative
 const PATTERN_BOOL_WORDS: usize = 5; // + value
 const PATTERN_PATH_HEADER_WORDS: usize = 10; // + module, ctor_head, type_name, variant, n_elements, element_words
+/// A struct pattern record (RUE-2175): kind, span×3, the hidden local, the
+/// head's type-syntax reference and the field count, then one symbol word per
+/// field. Fields never nest, so the record's extent is fixed by its count.
+const PATTERN_STRUCT_HEADER_WORDS: usize = 7;
+const MATCH_STRUCT_LOCAL: usize = 4;
+const MATCH_STRUCT_TYPE: usize = 5;
+const MATCH_STRUCT_FIELD_COUNT: usize = 6;
+const MATCH_STRUCT_FIELDS_START: usize = 7;
 /// A binder payload position: [element kind, symbol].
 const PATTERN_ELEMENT_BINDING_WORDS: usize = 2;
 /// Payload-position kinds inside a path record's element section.
@@ -822,6 +852,7 @@ fn encoded_pattern_record_words(pattern: &RirPattern) -> Option<usize> {
         RirPattern::Path { elements, .. } => {
             PATTERN_PATH_HEADER_WORDS.checked_add(encoded_pattern_element_words(elements)?)
         }
+        RirPattern::Struct { fields, .. } => PATTERN_STRUCT_HEADER_WORDS.checked_add(fields.len()),
     }
 }
 
@@ -873,6 +904,9 @@ fn decoded_pattern_record_words(words: &[u32], position: usize) -> Option<usize>
             .and_then(|element_words| {
                 PATTERN_PATH_HEADER_WORDS.checked_add(*element_words as usize)
             }),
+        x if x == PatternKind::Struct as u32 => words
+            .get(position + MATCH_STRUCT_FIELD_COUNT)
+            .and_then(|count| PATTERN_STRUCT_HEADER_WORDS.checked_add(*count as usize)),
         _ => None,
     }
 }
@@ -913,6 +947,19 @@ fn validate_pattern_record(
     if kind == PatternKind::Bool as u32 {
         if words[position + MATCH_VALUE_LO_OR_BOOL_OR_BODY] > 1 {
             return Err("invalid boolean scalar");
+        }
+        return Ok(());
+    }
+    if kind == PatternKind::Struct as u32 {
+        if decode_symbol_word(words[position + MATCH_STRUCT_LOCAL]).is_none() {
+            return Err("symbol word is not representable");
+        }
+        // The type-syntax reference is range-checked against the arena by the
+        // instruction-level validation walk, which owns that table.
+        for field in &words[position + MATCH_STRUCT_FIELDS_START..end] {
+            if decode_symbol_word(*field).is_none() {
+                return Err("symbol word is not representable");
+            }
         }
         return Ok(());
     }
@@ -1039,6 +1086,25 @@ fn decode_pattern_record(
                 return None;
             }
             Some((RirPatternView::Bool(value != 0, span), record_words))
+        }
+        x if x == PatternKind::Struct as u32 => {
+            let count = *words.get(position + MATCH_STRUCT_FIELD_COUNT)? as usize;
+            let section = position + MATCH_STRUCT_FIELDS_START;
+            Some((
+                RirPatternView::Struct {
+                    local: decode_symbol_word(words[position + MATCH_STRUCT_LOCAL])?,
+                    ty: RirTypeSyntaxRef::from_u32(words[position + MATCH_STRUCT_TYPE]),
+                    // The field words were checked by `validate_pattern_record`
+                    // before this record was decoded.
+                    fields: RirSlice::new_validated(
+                        &words[section..section + count],
+                        SYMBOL_SCHEMA.width,
+                        |record| validated_symbol_word(record[0]),
+                    ),
+                    span,
+                },
+                record_words,
+            ))
         }
         x if x == PatternKind::Path as u32 => {
             let count = *words.get(position + MATCH_PATH_ELEMENT_COUNT)? as usize;
@@ -1656,6 +1722,14 @@ impl Rir {
         let limit = || RirPayloadBuildError::ResourceLimitExceeded {
             family: RirMatchArmsRange::FAMILY,
         };
+        if let RirPattern::Struct { local, fields, .. } = pattern {
+            u32::try_from(fields.len()).map_err(|_| limit())?;
+            Self::symbol_word(RirMatchArmsRange::FAMILY, *local)?;
+            for field in fields {
+                Self::symbol_word(RirMatchArmsRange::FAMILY, *field)?;
+            }
+            return Ok(());
+        }
         let RirPattern::Path {
             type_name,
             variant,
@@ -1762,6 +1836,22 @@ impl Rir {
                             Self::encode_pattern_record(words, nested);
                         }
                     }
+                }
+            }
+            RirPattern::Struct {
+                local, ty, fields, ..
+            } => {
+                words.extend([
+                    PatternKind::Struct as u32,
+                    span.start(),
+                    span.len(),
+                    span.file_id.index(),
+                    u32::try_from(local.into_usize()).expect("prevalidated symbol"),
+                    ty.as_u32(),
+                    u32::try_from(fields.len()).expect("prevalidated length"),
+                ]);
+                for field in fields {
+                    words.push(u32::try_from(field.into_usize()).expect("prevalidated symbol"));
                 }
             }
         }

--- a/crates/rue-rir/src/inst/printer.rs
+++ b/crates/rue-rir/src/inst/printer.rs
@@ -191,6 +191,20 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     format!("{}({})", base, positions.join(", "))
                 }
             }
+            RirPatternView::Struct {
+                local, ty, fields, ..
+            } => {
+                let fields: Vec<&str> = fields
+                    .iter()
+                    .map(|field| self.interner.resolve(&field))
+                    .collect();
+                format!(
+                    "{} {{ {} }} @{}",
+                    self.format_type(*ty),
+                    fields.join(", "),
+                    self.interner.resolve(&*local)
+                )
+            }
         }
     }
 

--- a/crates/rue-rir/src/inst/schema.rs
+++ b/crates/rue-rir/src/inst/schema.rs
@@ -202,6 +202,22 @@ pub enum RirPattern {
         /// Span of the pattern
         span: Span,
     },
+    /// Struct pattern `T { f: b, ... }` (RUE-2175, spec 4.7:42). The pattern
+    /// is irrefutable: it binds the matched value to the hidden `local`, whose
+    /// type must be the struct `ty` names, and the arm body's leading
+    /// statements read each field out of that local (the same lowering a let
+    /// statement's struct pattern has, 5.1:21). `fields` lists every field the
+    /// pattern names, in source order, for the exhaustive field check.
+    Struct {
+        /// The hidden local the matched value is bound to.
+        local: Spur,
+        /// The struct type the pattern head names.
+        ty: RirTypeSyntaxRef,
+        /// Every field the pattern names, in source order.
+        fields: Vec<Spur>,
+        /// Location of the pattern.
+        span: Span,
+    },
 }
 
 impl RirPattern {
@@ -212,6 +228,7 @@ impl RirPattern {
             RirPattern::Int { span, .. } => *span,
             RirPattern::Bool(_, span) => *span,
             RirPattern::Path { span, .. } => *span,
+            RirPattern::Struct { span, .. } => *span,
         }
     }
 }

--- a/crates/rue-rir/src/inst/tests.rs
+++ b/crates/rue-rir/src/inst/tests.rs
@@ -1970,6 +1970,216 @@ mod typed_payload_tests {
         );
     }
 
+    /// A struct pattern record (RUE-2175) — at arm position and nested in a
+    /// payload position — decodes through the borrowing view, numbers its
+    /// span slot in the arm's preorder, survives the slot-aware editor remap,
+    /// and round-trips through the packed codec.
+    #[test]
+    fn struct_pattern_records_survive_views_remap_and_packing() {
+        let interner = ThreadedRodeo::new();
+        let point = interner.get_or_intern("Point");
+        let hidden = interner.get_or_intern("_@rue:destructure:0");
+        let x = interner.get_or_intern("x");
+        let y = interner.get_or_intern("y");
+        let file = FileId::new(7);
+        let at = |position| Span::with_file(file, position, position + 1);
+        let context = RirValidationContext {
+            symbol_count: interner.len(),
+            source_lengths: &[(file, 100)],
+        };
+
+        let mut editor = RirEditor::new();
+        let head = editor.add_named_type(point).unwrap();
+        let value = editor.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: at(0),
+        });
+        let arms = [
+            (
+                RirPattern::Struct {
+                    local: hidden,
+                    ty: head,
+                    fields: vec![x, y],
+                    span: at(1),
+                },
+                value,
+            ),
+            (
+                RirPattern::Path {
+                    module: None,
+                    ctor_head: None,
+                    type_name: point,
+                    variant: x,
+                    elements: vec![RirPatternElement::Nested(RirPattern::Struct {
+                        local: hidden,
+                        ty: head,
+                        fields: vec![y],
+                        span: at(3),
+                    })],
+                    span: at(2),
+                },
+                value,
+            ),
+        ];
+        let matched = editor.add_match(value, &arms, at(4)).unwrap();
+        let root = editor
+            .add_fn_decl(
+                &[],
+                false,
+                false,
+                false,
+                false,
+                x,
+                &[],
+                head,
+                matched,
+                false,
+                RirParamMode::Normal,
+                false,
+                false,
+                at(5),
+            )
+            .unwrap();
+        let rir = ValidatedRir::finish(editor, &context).unwrap();
+
+        let check = |rir: &ValidatedRir, matched: InstRef| {
+            let InstData::Match { arms, .. } = &rir.get(matched).data else {
+                panic!("expected the match instruction");
+            };
+            let arms = rir.match_arms(arms);
+            let (first, _) = arms.get(0).unwrap();
+            let RirPatternView::Struct {
+                ty, fields, span, ..
+            } = &first
+            else {
+                panic!("expected a struct pattern at arm position, got {first:?}");
+            };
+            assert_eq!(fields.len(), 2);
+            assert_eq!((span.start, span.end), (1, 2));
+            assert!(matches!(
+                first.to_owned(),
+                RirPattern::Struct { fields, .. } if fields.len() == 2
+            ));
+            let (second, _) = arms.get(1).unwrap();
+            let records = second.preorder();
+            assert_eq!(records.len(), 2);
+            let RirPatternView::Struct {
+                fields,
+                span,
+                ty: nested_ty,
+                ..
+            } = &records[1]
+            else {
+                panic!("expected a nested struct pattern, got {:?}", records[1]);
+            };
+            assert_eq!(fields.len(), 1);
+            assert_eq!((span.start, span.end), (3, 4));
+            assert_eq!(*nested_ty, *ty);
+            assert!(matches!(
+                second.to_owned(),
+                RirPattern::Path { elements, .. }
+                    if matches!(elements[0], RirPatternElement::Nested(RirPattern::Struct { .. }))
+            ));
+        };
+        check(&rir, matched);
+        assert_eq!(
+            span_entries(&rir)
+                .into_iter()
+                .filter(|(slot, _)| matches!(slot.field(), RirSpanField::MatchPattern { .. }))
+                .map(|(slot, span)| (slot.field(), span.start))
+                .collect::<Vec<_>>(),
+            vec![
+                (RirSpanField::MatchPattern { arm: 0, nested: 0 }, 1),
+                (RirSpanField::MatchPattern { arm: 1, nested: 0 }, 2),
+                (RirSpanField::MatchPattern { arm: 1, nested: 1 }, 3),
+            ]
+        );
+
+        let mut destination = RirEditor::new();
+        destination
+            .try_append_remapped_with_span_slots(
+                &rir,
+                std::convert::identity,
+                || Ok::<_, &'static str>(()),
+                |_slot, span| Ok(span),
+            )
+            .unwrap();
+        let destination = ValidatedRir::finish(destination, &context).unwrap();
+        check(&destination, matched);
+
+        let packed = rir
+            .try_pack_candidate(
+                &interner,
+                PackedRirMetadata {
+                    declaration: root,
+                    method_owner: None,
+                },
+                || Ok::<_, std::convert::Infallible>(()),
+                |_slot, span| Ok((span.start, span.end)),
+            )
+            .unwrap();
+        let (decoded, _) = packed
+            .try_decode_validated(
+                PackedRirProjection {
+                    symbol_count: packed.symbol_count(),
+                    file_id: file,
+                    declaration_start: 0,
+                    source_length: 100,
+                },
+                || Ok::<_, std::convert::Infallible>(()),
+            )
+            .unwrap();
+        let decoded_match = decoded
+            .iter()
+            .find_map(|(reference, instruction)| {
+                matches!(instruction.data, InstData::Match { .. }).then_some(reference)
+            })
+            .unwrap();
+        check(&decoded, decoded_match);
+    }
+
+    #[test]
+    fn finish_rejects_unrepresentable_struct_pattern_field_before_iteration() {
+        let symbol = Spur::try_from_usize(0).unwrap();
+        let mut editor = RirEditor::new();
+        let head = editor.add_named_type(symbol).unwrap();
+        let value = editor.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: span(),
+        });
+        editor
+            .add_match(
+                value,
+                &[(
+                    RirPattern::Struct {
+                        local: symbol,
+                        ty: head,
+                        fields: vec![symbol],
+                        span: span(),
+                    },
+                    value,
+                )],
+                span(),
+            )
+            .unwrap();
+        // The arm count occupies word 0, so the record starts at word 1 and its
+        // one field symbol sits at the start of the field section.
+        editor.rir.extra[1 + MATCH_STRUCT_FIELDS_START] = u32::MAX;
+
+        assert_eq!(
+            ValidatedRir::finish(editor, &context()).unwrap_err(),
+            rir_payload_error! {
+                family: RirMatchArmsRange::FAMILY,
+                start: 0,
+                extent: 10,
+                record: Some(0),
+                expected: 9,
+                actual: 9,
+                reason: "symbol word is not representable",
+            }
+        );
+    }
+
     #[test]
     fn finish_rejects_out_of_owner_match_refs_and_context_values() {
         let symbol = Spur::try_from_usize(0).unwrap();

--- a/crates/rue-rir/src/inst/validation.rs
+++ b/crates/rue-rir/src/inst/validation.rs
@@ -289,6 +289,10 @@ impl Rir {
                             MATCH_PATH_ELEMENT_WORDS + 1,
                             "path record header is truncated",
                         ),
+                        Some(kind) if kind == PatternKind::Struct as u32 => (
+                            MATCH_STRUCT_FIELD_COUNT + 1,
+                            "struct record header is truncated",
+                        ),
                         Some(kind)
                             if kind != PatternKind::Wildcard as u32
                                 && kind != PatternKind::Int as u32
@@ -569,10 +573,11 @@ impl Rir {
                         reason: "invalid boolean scalar",
                     });
                 }
-            } else if kind == PatternKind::Path as u32 {
+            } else if kind == PatternKind::Path as u32 || kind == PatternKind::Struct as u32 {
                 // Path records nest (RUE-2053), so their symbols, payload
                 // positions and nesting depth are checked by one recursive walk
-                // rather than a flat scan of a binding array.
+                // rather than a flat scan of a binding array. A struct record
+                // (RUE-2175) takes the same walk for its symbol words.
                 if let Err(reason) = validate_pattern_record(words, position, 0) {
                     return Err(rir_payload_error! {
                         family: RirMatchArmsRange::FAMILY,
@@ -755,6 +760,16 @@ impl Rir {
                                     if let RirPatternElementView::Binding(name) = element {
                                         symbols!(name);
                                     }
+                                }
+                            }
+                            if let RirPatternView::Struct {
+                                local, ty, fields, ..
+                            } = record
+                            {
+                                symbols!(local);
+                                types!(ty);
+                                for field in fields.values() {
+                                    symbols!(field);
                                 }
                             }
                         }

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -2071,3 +2071,275 @@ fn main() -> i32 {
 """
 expected_stdout = "5\n-1\n"
 exit_code = 4
+
+# =============================================================================
+# Struct Patterns in Match Arms (4.7:42-4.7:44, preview feature
+# `struct_patterns`, RUE-2175)
+# =============================================================================
+
+[[case]]
+name = "struct_pattern_arm_binds_every_field"
+spec = ["4.7:42", "4.7:44"]
+preview = "struct_patterns"
+preview_should_pass = true
+description = "An arm's struct pattern over a struct scrutinee binds shorthand, renamed, mutable, and discarded fields"
+source = """
+struct Point { x: i32, y: i32, z: i32, w: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2, z: 100, w: 7 };
+    match p {
+        Point { x, y: py, mut z, w: _ } => {
+            z = z / 100;
+            x + py + z - 1
+        }
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "struct_pattern_in_a_payload_position"
+spec = ["4.7:42", "4.7:44"]
+preview = "struct_patterns"
+preview_should_pass = true
+description = "A payload position holds a struct pattern that binds the fields of the payload value"
+source = """
+struct Point { x: i32, y: i32 }
+enum R { Ok(Point), Err(i32) }
+
+fn f(k: i32) -> R {
+    if k > 0 { R.Ok(Point { x: 40, y: 2 }) } else { R.Err(7) }
+}
+
+fn main() -> i32 {
+    let a = match f(1) { R.Ok(Point { x, y }) => x + y, R.Err(e) => e };
+    let b = match f(0) { R.Ok(Point { x, y }) => x + y, R.Err(e) => e };
+    a + b - 7
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "struct_pattern_head_takes_every_type_form"
+spec = ["4.7:42"]
+preview = "struct_patterns"
+preview_should_pass = true
+description = "The head is a type: a type-constructor call names an instantiated struct"
+source = """
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+
+fn main() -> i32 {
+    let p = Pair(i32) { a: 40, b: 2 };
+    match p { Pair(i32) { a, b } => a + b }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "struct_pattern_covers_its_payload_position_in_a_variant_group"
+spec = ["4.7:44", "4.7:40"]
+preview = "struct_patterns"
+preview_should_pass = true
+description = "Beside nested variant patterns, a struct pattern covers its position like a binding; the group stays exhaustive over the other columns"
+source = """
+struct Point { x: i32, y: i32 }
+enum Inner { A(i32), B }
+enum Outer { Pair(Inner, Point), Other }
+
+fn pick(o: Outer) -> i32 {
+    match o {
+        Outer.Pair(Inner.A(v), Point { x, y }) => v + x + y,
+        Outer.Pair(Inner.B, Point { x, y: _ }) => x,
+        Outer.Other => 100,
+    }
+}
+
+fn main() -> i32 {
+    let a = pick(Outer.Pair(Inner.A(10), Point { x: 30, y: 2 }));
+    let b = pick(Outer.Pair(Inner.B, Point { x: 1, y: 1 }));
+    a + b - pick(Outer.Other) + 99
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "struct_pattern_arm_is_irrefutable"
+spec = ["4.7:44", "4.7:18"]
+preview = "struct_patterns"
+preview_should_pass = true
+description = "One struct pattern arm is exhaustive over a struct scrutinee, and an arm after it is unreachable"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2 };
+    match p {
+        Point { x, y } => x + y,
+        _ => 0,
+    }
+}
+"""
+warning_contains = ["unreachable pattern '_'", "previous struct pattern here"]
+exit_code = 42
+
+[[case]]
+name = "struct_pattern_temporary_drops_at_the_end_of_the_arm"
+spec = ["4.7:44", "4.7:31"]
+preview = "struct_patterns"
+preview_should_pass = true
+description = "A discarded field drops at its own let, a moved field with the arm's bindings, and what the temporary still owns when the arm ends, all before the code after the match"
+source = """
+struct Tag { id: i32 }
+drop fn Tag(self) { @dbg(self.id); }
+struct Pair { a: Tag, b: Tag }
+enum Slot { Full(Pair), Empty }
+
+fn main() -> i32 {
+    let s = Slot.Full(Pair { a: Tag { id: 1 }, b: Tag { id: 2 } });
+    match s {
+        Slot.Full(Pair { a, b: _ }) => @dbg(a.id + 10),
+        Slot.Empty => @dbg(0),
+    }
+    @dbg(3);
+    0
+}
+"""
+expected_stdout = """
+2
+11
+1
+3
+"""
+exit_code = 0
+
+[[case]]
+name = "struct_pattern_arm_cannot_move_out_of_a_destructor_struct"
+spec = ["4.7:44"]
+preview = "struct_patterns"
+preview_should_pass = true
+source = """
+struct Handle { fd: i32 }
+drop fn Handle(self) { @dbg(self.fd); }
+struct Guard { handle: Handle, id: i32 }
+drop fn Guard(self) { @dbg(self.id); }
+fn main() -> i32 {
+    let g = Guard { handle: Handle { fd: 3 }, id: 7 };
+    match g { Guard { handle, id } => handle.fd + id }
+}
+"""
+compile_fail = true
+error_contains = "E0456"
+
+[[case]]
+name = "struct_pattern_arm_cannot_discard_a_linear_field"
+spec = ["4.7:44"]
+preview = "struct_patterns"
+preview_should_pass = true
+source = """
+linear struct Token { id: i32 }
+struct Holder { t: Token, n: i32 }
+fn main() -> i32 {
+    let h = Holder { t: Token { id: 1 }, n: 2 };
+    match h { Holder { t: _, n } => n }
+}
+"""
+compile_fail = true
+error_contains = "E0478"
+
+[[case]]
+name = "struct_pattern_arm_head_must_be_a_struct"
+spec = ["4.7:43"]
+preview = "struct_patterns"
+preview_should_pass = true
+source = """
+enum Color { Red, Blue }
+fn main() -> i32 { let c = Color.Red; match c { Color { x } => 1 } }
+"""
+compile_fail = true
+error_contains = "E0213"
+
+[[case]]
+name = "struct_pattern_arm_head_must_name_the_scrutinee_type"
+spec = ["4.7:43"]
+preview = "struct_patterns"
+preview_should_pass = true
+source = """
+struct Point { x: i32, y: i32 }
+struct Size { w: i32, h: i32 }
+fn main() -> i32 { let p = Point { x: 1, y: 2 }; match p { Size { w, h } => w + h } }
+"""
+compile_fail = true
+error_contains = ["E0206", "expected Size, found Point"]
+
+[[case]]
+name = "struct_pattern_in_a_payload_position_must_name_the_field_type"
+spec = ["4.7:43"]
+preview = "struct_patterns"
+preview_should_pass = true
+source = """
+struct Point { x: i32, y: i32 }
+enum R { Ok(i32), Err(i32) }
+fn main() -> i32 {
+    let r = R.Ok(1);
+    match r { R.Ok(Point { x, y }) => x + y, R.Err(e) => e }
+}
+"""
+compile_fail = true
+error_contains = ["E0206", "expected Point, found i32"]
+
+[[case]]
+name = "struct_pattern_arm_names_every_field_exactly_once"
+spec = ["4.7:43"]
+preview = "struct_patterns"
+preview_should_pass = true
+source = """
+struct Point { x: i32, y: i32, z: i32 }
+fn main() -> i32 { let p = Point { x: 1, y: 2, z: 3 }; match p { Point { x } => x } }
+"""
+compile_fail = true
+error_contains = ["E0400", "missing fields 'y', 'z' in struct 'Point'"]
+
+[[case]]
+name = "struct_scrutinee_needs_a_struct_pattern_arm"
+spec = ["4.7:43"]
+preview = "struct_patterns"
+preview_should_pass = true
+description = "A match over a struct value whose arms are all `_` is still an invalid match type"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 { let p = Point { x: 1, y: 2 }; match p { _ => 3 } }
+"""
+compile_fail = true
+error_contains = "E0602"
+
+[[case]]
+name = "struct_pattern_arm_requires_preview"
+spec = ["4.7:42", "8.4:1"]
+description = "A struct pattern in a match arm without --preview struct_patterns is the preview-gate error naming the feature"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2 };
+    match p { Point { x, y } => x + y }
+}
+"""
+compile_fail = true
+error_contains = ["E1100", "--preview struct_patterns"]
+
+[[case]]
+name = "struct_pattern_field_positions_do_not_nest"
+spec = ["4.7:42"]
+preview = "struct_patterns"
+preview_should_pass = true
+description = "A field pattern is a binding only: a nested pattern inside a field position is a syntax error"
+source = """
+struct Point { x: i32, y: i32 }
+struct Line { a: Point, b: Point }
+fn main() -> i32 {
+    let l = Line { a: Point { x: 1, y: 2 }, b: Point { x: 3, y: 4 } };
+    match l { Line { a: Point { x, y }, b } => x + y + b.x }
+}
+"""
+compile_fail = true
+error_contains = "E0100"

--- a/crates/rue-ui-tests/cases/diagnostics/struct_patterns.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/struct_patterns.toml
@@ -1,7 +1,7 @@
 [section]
 id = "diagnostics.struct_patterns"
 name = "Struct pattern diagnostics"
-description = "Pins the diagnostics of the struct_patterns preview (spec 5.1:18-5.1:21, RUE-1884): the preview gate, the head checks, and the exhaustive field list with its repairs."
+description = "Pins the diagnostics of the struct_patterns preview (spec 5.1:18-5.1:21, RUE-1884; 4.7:42-4.7:44 in match arms, RUE-2175): the preview gate, the head checks, the exhaustive field list with its repairs, and the irrefutable arm."
 
 [[case]]
 name = "struct_pattern_without_preview_names_the_flag"
@@ -106,3 +106,104 @@ fn main() -> i32 {
 exit_code = 1
 warning_contains = ["unused variable", "'y'"]
 expected_warning_count = 1
+
+[[case]]
+name = "match_arm_struct_pattern_without_preview_names_the_flag"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2 };
+    match p {
+        Point { x, y } => x + y,
+    }
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E1100]",
+    "struct patterns requires preview feature `struct_patterns`",
+    "use --preview struct_patterns to enable this feature (ADR-0091)",
+]
+
+[[case]]
+name = "arm_after_a_struct_pattern_is_unreachable"
+preview = "struct_patterns"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2 };
+    match p {
+        Point { x, y } => x + y,
+        _ => 0,
+    }
+}
+"""
+exit_code = 42
+warning_contains = [
+    "unreachable pattern '_'",
+    "previous struct pattern here",
+    "this pattern will never be matched because the struct pattern above matches every value",
+]
+
+[[case]]
+name = "struct_pattern_after_a_wildcard_is_spelled_in_the_warning"
+preview = "struct_patterns"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2 };
+    match p {
+        _ => 42,
+        Point { x, y } => x + y,
+    }
+}
+"""
+exit_code = 42
+warning_contains = [
+    "unreachable pattern 'Point { x, y }'",
+    "previous wildcard pattern here",
+]
+
+[[case]]
+name = "payload_struct_pattern_names_the_field_type_and_the_repair"
+preview = "struct_patterns"
+source = """
+struct Point { x: i32, y: i32 }
+enum R { Ok(i32), Err(i32) }
+
+fn main() -> i32 {
+    let r = R.Ok(1);
+    match r {
+        R.Ok(Point { x, y }) => x + y,
+        R.Err(e) => e,
+    }
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0206]",
+    "type mismatch: expected Point, found i32",
+    "the pattern head must name the matched value's own struct type",
+]
+
+[[case]]
+name = "struct_scrutinee_without_a_struct_pattern_is_not_matchable"
+preview = "struct_patterns"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    match p {
+        _ => 3,
+    }
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0602]",
+    "cannot match on type 'Point', expected integer, bool, or enum",
+]

--- a/docs/designs/0005-preview-features.md
+++ b/docs/designs/0005-preview-features.md
@@ -195,10 +195,10 @@ mechanism), so the `PreviewFeature` enum is not empty.
   module remain exhaustively checked against the variants known there. Adding
   variants can still change layout, ABI, or runtime behavior, so the promise
   does not provide a binary compatibility guarantee.
-- `struct_patterns` — struct destructuring patterns in `let` statements
-  (ADR-0091, RUE-1884): `let Point { x, y } = p;` binds every field by name
-  and has no rest form, so an added field is a compile error at every
-  pattern. Match-arm struct patterns are the feature's second phase.
+- `struct_patterns` — struct destructuring patterns in `let` statements and
+  match arms (ADR-0091, RUE-1884, RUE-2175): `let Point { x, y } = p;` and
+  `match r { R.Ok(Point { x, y }) => .. }` bind every field by name and have
+  no rest form, so an added field is a compile error at every pattern.
 
 ## Implementation Phases
 

--- a/docs/designs/0091-struct-patterns.md
+++ b/docs/designs/0091-struct-patterns.md
@@ -67,6 +67,17 @@ enum payload patterns (4.7:30), but no struct pattern in `let` or `match`.
    the initializer must have exactly that type (E0206).
 5. **Preview gate.** The feature ships behind `--preview struct_patterns`
    until its second phase lands.
+6. **Match arms (phase 2).** A struct pattern may be a match arm's own
+   pattern over a struct scrutinee, or occupy a payload position of a
+   variant pattern (`R.Ok(Point { x, y })`). It is irrefutable, so it makes
+   a match exhaustive by itself and every later arm unreachable, and in a
+   payload position it covers that position as a binding does. It binds
+   exactly as the `let` form does: the matched value — the scrutinee, or the
+   payload field moved out of its variant — is bound to the arm's unnameable
+   temporary and each field pattern is the corresponding `let` of a field
+   read, run before the arm body in the body's scope. A field position of a
+   struct pattern is a binder only; nesting inside it is not part of this
+   ADR.
 
 ### Implementation shape
 
@@ -78,18 +89,28 @@ instruction — preview gate, head resolution, type agreement, and the
 exhaustive field list — before the projections are analyzed, and emits no
 value for it. Nothing downstream of AIR changes.
 
+In a match arm the parser produces `Pattern::Struct` (or a
+`PatternElement::Struct` payload position) and RIR lowering emits a
+`RirPattern::Struct` record carrying the hidden local's name, the head type
+and the field names, plus the per-field `Alloc`s of `FieldGet`s, which wrap
+the arm body in a block. Semantic analysis treats the record as one level of
+the arm's placement: it performs the same head and field checks, allocates
+the matched value — the scrutinee, or the `EnumPayloadGet` projection of its
+payload position — into the hidden local, and leaves the field reads to the
+body's leading `let`s. A struct pattern contributes a wildcard column to a
+variant group's pattern matrix, so nested variant patterns beside it still
+decide exhaustiveness. A match over a struct scrutinee emits no AIR `Match`
+at all: its first arm always runs, so that arm's block is the match's value.
+
 ## Implementation Phases
 
 - [x] **Phase 1: `let` struct patterns** - RUE-1884 (this ADR's initial
   implementation).
-- [ ] **Phase 2: struct patterns in `match` arms** - RUE-2175: a top-level
+- [x] **Phase 2: struct patterns in `match` arms** - RUE-2175: a top-level
   struct pattern over a struct scrutinee and a struct pattern in an enum
-  payload position (`R.Ok(Point { x, y })`). This needs a `RirPattern`
-  variant and its packed-payload encoding, the pattern matrix treating the
-  irrefutable struct row as a binder that owns nested projections, and the
-  same exhaustive field check.
-- [ ] **Stabilization**: drop the preview gate once phase 2 lands and the
-  spec cases run without it.
+  payload position (`R.Ok(Point { x, y })`), spec 4.7:42 through 4.7:45.
+- [ ] **Stabilization**: drop the preview gate now that phase 2 has landed
+  and the spec cases run without it.
 
 ## Consequences
 
@@ -114,8 +135,9 @@ value for it. Nothing downstream of AIR changes.
 
 - Whether a rest form `..` is ever admitted (the ruling asked this to be
   recorded; the answer is deliberately deferred).
-- Nested struct patterns inside a field position (`Line { a: Point { x, y }, b }`)
-  are not part of phase 1.
+- Nested patterns inside a field position (`Line { a: Point { x, y }, b }`,
+  `Cell { c: Color.Red }`) are not part of either phase: a field pattern is a
+  binder only.
 
 ## References
 
@@ -123,4 +145,5 @@ value for it. Nothing downstream of AIR changes.
 - [ADR-0037: Exclusivity model: access-point based](0037-exclusivity-model-access-point-based.md)
 - [ADR-0038: Error handling: sum types, Result/Option, and must-check via linearity](0038-error-handling-sum-types-result-must-check.md)
 - [Let Statements, §5.1](../spec/src/05-statements/01-let-statements.md)
-- RUE-1884, RUE-613, RUE-246
+- [Match Expressions, §4.7](../spec/src/04-expressions/07-match-expressions.md)
+- RUE-1884, RUE-2175, RUE-613, RUE-246

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -12,6 +12,7 @@ A match expression provides multi-way branching based on pattern matching.
 
 {{ rule(id="4.7:2", cat="normative") }}
 
+<!-- grammar-sync(id="4.7:2", production="pattern", role="source") -->
 <!-- grammar-sync(id="4.7:2", production="path_pattern", role="source") -->
 <!-- grammar-sync(id="4.7:2", production="pattern_elements", role="source") -->
 <!-- grammar-sync(id="4.7:2", production="pattern_element", role="source") -->
@@ -23,11 +24,12 @@ match_arm = pattern "=>" expression ;
 pattern        = "_"
                | [ "-" ] INTEGER
                | BOOL
-               | path_pattern ;
+               | path_pattern
+               | struct_pattern ;
 path_pattern = pattern_head "." IDENT [ "(" pattern_elements ")" ] ;
 pattern_head   = qualified_ident [ "(" [ call_args ] ")" ] ;
 pattern_elements = pattern_element { "," pattern_element } [ "," ] ;
-pattern_element = IDENT | "_" | path_pattern ;
+pattern_element = IDENT | "_" | path_pattern | struct_pattern ;
 ```
 
 An enum variant is a `path_pattern`: its `pattern_head` may be a qualified
@@ -39,7 +41,11 @@ module binding (`module.Alias.Variant`, 10.4:21). A bare variant
 pattern omits the optional payload list and is the all-wildcard form. An
 explicit payload list contains one or more positions and may have a trailing
 comma; an empty list such as `Enum.Variant()` is not a pattern. Each position is
-a binding name, the `_` wildcard, or a nested variant pattern (4.7:37).
+a binding name, the `_` wildcard, a nested variant pattern (4.7:37), or a
+struct pattern (4.7:42). A `struct_pattern` is the production of 5.1:2; a
+struct pattern's head is a type, so a name that continues into `{` — directly,
+through a module path, or through a type-constructor call — begins a struct
+pattern and any other name begins a `path_pattern`.
 
 ## Patterns
 
@@ -425,6 +431,74 @@ fn main() -> i32 {
         R.Ok(_) => 0,
         R.Err(E.A(b)) => @intCast(b),   // -> 1
         R.Err(E.B) => 2,
+    }
+}
+```
+
+## Struct Patterns in Match Arms
+
+{{ preview_feature(feature="struct_patterns", adr="ADR-0091", doc="0091-struct-patterns.md") }}
+
+{{ rule(id="4.7:42", cat="normative") }}
+
+A match arm's pattern **MAY** be a struct pattern (5.1:18), `T { f: b, ... }`,
+and a payload position of a tuple-variant pattern (4.7:30) **MAY** hold one:
+`match p { Point { x, y } => ... }` binds the fields of a struct scrutinee, and
+`R.Ok(Point { x, y })` binds the fields of the payload value a variant carries.
+The head is written with the type grammar exactly as a let statement's struct
+pattern writes it — a struct name, a module-qualified name, or a
+type-constructor call — and each field pattern takes the forms of 5.1:18: the
+shorthand `f`, the rename `f: b`, the mutable binding `mut f` or `f: mut b`,
+and the discard `f: _`. A field pattern is a binding, never a nested pattern.
+Struct patterns are a preview feature: a match expression containing one
+**MUST** be compiled with `--preview struct_patterns` (8.4:1).
+
+{{ rule(id="4.7:43", cat="legality-rule") }}
+
+The head of a struct pattern **MUST** name a struct type (E0213), and that type
+**MUST** be the type of the value the pattern is matched against (E0206): the
+scrutinee's type for an arm's own pattern, and the payload field's type for a
+pattern in a payload position (as a nested variant pattern resolves against its
+field, 4.7:37). The field list is checked as 5.1:20 checks it: every declared
+field named exactly once, with a missing field E0400, an unknown name E0401,
+and a repeated field E0402. A scrutinee of struct type is legal only in a match
+some arm of which is a struct pattern; a match over a struct value whose arms
+are all `_` is E0602 as before.
+
+{{ rule(id="4.7:44", cat="normative") }}
+
+A struct pattern is irrefutable (4.7:3): it matches every value of its type. An
+arm whose pattern is a struct pattern therefore makes the match exhaustive by
+itself, and every arm after it is unreachable (4.7:18, 4.7:20); in a payload
+position it covers every value of that position, as a binding does (4.7:39).
+The arm binds as the let statements of 5.1:21 bind: the matched value — the
+scrutinee, or the payload position moved out of its enclosing payload
+(4.7:38) — is bound to an unnameable temporary of the arm, and each field
+pattern in source order is `let b = t.f;`, `let mut b = t.f;`, or
+`let _ = t.f;`, run before the arm body in the body's own scope. A Copy field is
+copied, a move field is moved out of the temporary, a field whose type carries
+a linear value cannot be discarded (E0478), and a move field of a struct that
+has a destructor cannot be moved out (E0456, 3.9). Whatever the temporary still
+owns at the end of the arm is dropped then, with the arm's other bindings, in
+reverse declaration order (4.7:31).
+
+{{ rule(id="4.7:45", cat="example") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+enum Shape { Dot(Point), Empty }
+
+fn origin_distance(s: Shape) -> i32 {
+    match s {
+        Shape.Dot(Point { x, y: py }) => x + py,   // binds x and py
+        Shape.Empty => 0,
+    }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2 };
+    match p {
+        Point { mut x, y: _ } => { x = x + 2; x }  // y is discarded -> 42
     }
 }
 ```

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -30,6 +30,7 @@ this appendix governs.
 <!-- grammar-sync(id="5.1:2", production="struct_pattern", role="appendix") -->
 <!-- grammar-sync(id="5.1:2", production="field_patterns", role="appendix") -->
 <!-- grammar-sync(id="5.1:2", production="field_pattern", role="appendix") -->
+<!-- grammar-sync(id="4.7:2", production="pattern", role="appendix") -->
 <!-- grammar-sync(id="4.7:2", production="path_pattern", role="appendix") -->
 <!-- grammar-sync(id="4.7:2", production="pattern_elements", role="appendix") -->
 <!-- grammar-sync(id="4.7:2", production="pattern_element", role="appendix") -->
@@ -237,11 +238,12 @@ match_arm      = pattern "=>" expression ;
 pattern        = "_"
                | [ "-" ] INTEGER
                | BOOL
-               | path_pattern ;
+               | path_pattern
+               | struct_pattern ;
 path_pattern = pattern_head "." IDENT [ "(" pattern_elements ")" ] ;
 pattern_head   = qualified_ident [ "(" [ call_args ] ")" ] ;
 pattern_elements = pattern_element { "," pattern_element } [ "," ] ;
-pattern_element = IDENT | "_" | path_pattern ;
+pattern_element = IDENT | "_" | path_pattern | struct_pattern ;
 while_expr     = "while" expression "{" block "}" ;
 loop_expr      = "loop" "{" block "}" ;
 for_expr       = "for" ( IDENT | "_" ) "in" expression "{" block "}" ;
@@ -338,6 +340,12 @@ Notes:
 - **Nested variant patterns**: a payload position may itself be a
   `path_pattern`, recursively — `R.Err(E.A(b))` — matching against that
   position's payload type (4.7:37).
+- **Struct patterns in arms**: a match arm, or a payload position, may be a
+  `struct_pattern` — `Point { x, y }`, `R.Ok(Point { x, y })` — binding the
+  fields of the struct value there (4.7:42). A name that continues into `{`
+  (directly, through a module path, or through a type-constructor call)
+  begins a struct pattern; any other name begins a `path_pattern`. A struct
+  pattern's field positions are binders and do not nest.
 - **A parameter takes at most one mode** (`comptime`, `inout`, or `borrow`);
   duplicate or conflicting modes are a parse error.
 - **Statement termination**: `let`, assignment, and ordinary expression


### PR DESCRIPTION
Phase 1 of ADR-0091 let a `let` statement take a struct apart with an exhaustive struct pattern; a match arm still could not, so a payload carrying a struct had to be bound whole and read field by field in the arm body. This is the match half of the RUE-1884 ruling, behind the same `--preview struct_patterns` gate:

```rue
match p { Point { x, y: py, mut z, w: _ } => ... }
match r { R.Ok(Point { x, y }) => ..., R.Err(e) => ... }
```

- **Language.** A struct pattern is irrefutable: one arm makes a match over a struct scrutinee exhaustive and every later arm unreachable, and in a payload position it covers that position as a binding does, so nested variant patterns beside it still decide exhaustiveness over the group's matrix. The head and field checks are the ones a let pattern makes (E0213, E0206, E0400, E0401, E0402), with E0206 naming the payload field's type in a payload position; a struct scrutinee with no struct-pattern arm stays E0602. Binding is the let form's: the matched value goes into an unnameable temporary of the arm and each field pattern is a `let` of a field read run before the body, so Copy, move, E0478 and E0456 follow from existing rules, and what the temporary still owns drops at the end of the arm. Spec 4.7:42 through 4.7:45; the grammar in 4.7:2 and the appendix gain the production (with a new grammar-sync marker for `pattern`).
- **Compiler.** The parser grows `Pattern::Struct` and a `PatternElement::Struct` payload position, telling a struct head from a variant head by whether the type path (through any constructor arguments) is followed by `{`. That scan and the existing constructor-group scan now share a matching-paren table built once per token stream, so nested groups cost a lookup instead of a walk. astgen lowers a struct pattern to a `RirPattern::Struct` record (hidden local, head type, field names) plus the per-field lets that wrap the arm body; the record has a packed encoding, span slot, validation, printer, editor remap and packed-codec support. Sema places the record as one level of the arm, allocating the matched value into the hidden local and leaving the field reads to the body's leading lets, and emits no AIR match for a struct scrutinee, whose first arm always runs.
- **Tests.** Fifteen spec cases in `expressions/match.toml`, five UI cases in `diagnostics/struct_patterns.toml`, parser tests for the head disambiguation, and RIR tests for the record's views, span slots, remap, packed round-trip and validation.
- **ADR-0091** records phase 2 as landed; ADR-0005's preview list names both surfaces.

Verified locally: `scripts/rue quick` (36 targets); spec `match` (229) and `let` (115); UI `struct_patterns` (11); parser and RIR unit tests; the spec-traceability, machine-index, doc-link, ADR-registry, tutorial-snippet, frontend-diff, oracle-diff and parser-complexity gates; `scripts/rue fmt`.

Fixes RUE-2175