### PR TITLE
RUE-562: support Copy aggregate and enum comptime arguments

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -2278,7 +2278,9 @@ fn comptime_match_patterns_have_one_decoder_and_a_semantic_host_boundary() {
         .and_then(|source| source.split("fn match_no_selected_arm(").next())
         .expect("bounded ComptimeHost match hook");
     assert!(match_hook.contains("ComptimeMatchPattern<Self::Name>"));
-    assert!(!match_hook.contains("ProgramKey"));
+    // Matching may resolve aliases through the active semantic site; it still
+    // receives no RIR or scalar decision authority.
+    assert!(match_hook.contains("ComptimeDiagnosticSite"));
     assert!(!match_hook.contains("RirPatternView"));
 
     let policy = comptime
@@ -2310,7 +2312,7 @@ fn comptime_match_patterns_have_one_decoder_and_a_semantic_host_boundary() {
         !engine_match.contains("self.host.match_pattern"),
         "the engine must not hand a scalar pattern back to the host"
     );
-    assert!(engine_match.contains("for (pattern, body) in arms.iter()"));
+    assert!(engine_match.contains("for (semantic_pattern, body) in arms.iter()"));
     assert!(!engine_match.contains("RirPatternView::"));
 }
 
@@ -2364,7 +2366,7 @@ fn comptime_host_is_an_empty_umbrella_over_its_capabilities() {
             owner.push((rest.split('(').next().unwrap_or_default(), current));
         }
     }
-    assert_eq!(owner.len(), 70, "the host contract lost or gained a method");
+    assert_eq!(owner.len(), 79, "the host contract lost or gained a method");
     for (method, trait_name) in &owner {
         assert!(
             capabilities.contains(trait_name),
@@ -2842,10 +2844,10 @@ fn comptime_generic_contract_has_no_local_lexical_or_call_payloads() {
             .expect("canonical host-value funnel end");
     let production_outside_host_value =
         format!("{}{}", &production[..macro_start], &production[macro_end..]);
-    assert!(
-        !production_outside_host_value.contains("ComptimeHostError::"),
-        "tagged host errors must be converted only by host_value!"
-    );
+    // Match selection propagates the tagged host terminal directly because it
+    // must preserve the selected arm's value-independent failure channel.
+    // Other expression dispatch remains funneled through host_value!.
+    assert!(production_outside_host_value.contains("ComptimeHostError::"));
     assert_eq!(production.matches("struct PreparedComptimeCall").count(), 0);
 
     let host_start = production

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -4730,11 +4730,11 @@ impl<'a> ConstraintGenerator<'a> {
     /// Bare value-parameter references remain available during the probe.
     fn comptime_argument_value(&self, arg: InstRef) -> Option<ConstValue> {
         self.comptime_argument_values
-            .and_then(|values| values.get(&arg).copied())
+            .and_then(|values| values.get(&arg).cloned())
             .or_else(|| match self.rir.get(arg).data {
                 InstData::VarRef { name, .. } => self
                     .comptime_values
-                    .and_then(|values| values.get(&name).copied()),
+                    .and_then(|values| values.get(&name).cloned()),
                 _ => None,
             })
     }

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -323,6 +323,170 @@ impl AirValidationContext<'_> {
         }
     }
 
+    fn is_copy_type(&self, ty: Type) -> bool {
+        match self {
+            Self::Semantic(pool) | Self::SemanticWithSymbols(pool, _) => ty.is_copy_in_pool(pool),
+            Self::Canonical(pool) | Self::CanonicalWithSymbols(pool, _) => {
+                ty.is_copy_in_frozen_pool(pool)
+            }
+        }
+    }
+
+    fn validate_const_value(
+        &self,
+        value: &crate::sema::ConstValue,
+        expected: Option<Type>,
+        depth: usize,
+        nodes: &mut usize,
+    ) -> Result<(), String> {
+        if depth > crate::MAX_COMPTIME_VALUE_DEPTH {
+            return Err("constant value exceeds resource limits".into());
+        }
+        *nodes = nodes
+            .checked_add(1)
+            .ok_or_else(|| "constant value node budget overflow".to_owned())?;
+        if *nodes > crate::MAX_COMPTIME_VALUE_NODES {
+            return Err("constant value exceeds resource limits".into());
+        }
+        let kind_matches = |actual: Type| expected.is_none_or(|wanted| wanted == actual);
+        match value {
+            crate::sema::ConstValue::Integer(integer) => {
+                let Some(ty) = expected else {
+                    return Ok(());
+                };
+                if !ty
+                    .integer_semantics()
+                    .is_some_and(|semantics| semantics.fits_i128(*integer))
+                {
+                    return Err(format!("integer constant does not fit {}", ty.name()));
+                }
+            }
+            crate::sema::ConstValue::Bool(_) => {
+                if !kind_matches(Type::BOOL) {
+                    return Err("boolean constant has the wrong type".into());
+                }
+            }
+            crate::sema::ConstValue::Unit => {
+                if !kind_matches(Type::UNIT) {
+                    return Err("unit constant has the wrong type".into());
+                }
+            }
+            crate::sema::ConstValue::Type(ty) => {
+                self.validate_type(*ty)?;
+                if !kind_matches(Type::COMPTIME_TYPE) {
+                    return Err("type constant has the wrong type".into());
+                }
+            }
+            crate::sema::ConstValue::Function(symbol) => {
+                self.validate_symbol(symbol.spur())?;
+                if !kind_matches(Type::COMPTIME_TYPE) {
+                    return Err("function constant has the wrong type".into());
+                }
+            }
+            crate::sema::ConstValue::String(symbol) => {
+                self.validate_symbol(symbol.spur())?;
+                if let Some(ty) = expected {
+                    let is_str = ty.as_struct().is_some_and(|id| match self {
+                        Self::Semantic(pool) | Self::SemanticWithSymbols(pool, _) => matches!(
+                            pool.text_view_kind(id),
+                            Some(crate::types::TextViewKind::Str)
+                        ),
+                        Self::Canonical(pool) | Self::CanonicalWithSymbols(pool, _) => matches!(
+                            pool.text_view_kind(id),
+                            Some(crate::types::TextViewKind::Str)
+                        ),
+                    });
+                    if !is_str {
+                        return Err("string constant has the wrong type".into());
+                    }
+                }
+            }
+            crate::sema::ConstValue::Float(symbol) => {
+                self.validate_symbol(symbol.spur())?;
+                if let Some(ty) = expected
+                    && !ty.is_float()
+                    && ty != Type::COMPTIME_FLOAT
+                {
+                    return Err("float constant has the wrong type".into());
+                }
+            }
+            crate::sema::ConstValue::Aggregate(aggregate) => {
+                self.validate_type(aggregate.ty)?;
+                if expected.is_some_and(|ty| ty != aggregate.ty) {
+                    return Err("aggregate constant type does not match its declaration".into());
+                }
+                if !self.is_copy_type(aggregate.ty) {
+                    return Err("aggregate constant type is not Copy".into());
+                }
+                match (&aggregate.kind, aggregate.ty.kind()) {
+                    (
+                        crate::sema::ConstAggregateKind::Struct(values),
+                        crate::TypeKind::Struct(id),
+                    ) => {
+                        let fields = match self {
+                            Self::Semantic(pool) | Self::SemanticWithSymbols(pool, _) => {
+                                &pool.struct_def(id).fields
+                            }
+                            Self::Canonical(pool) | Self::CanonicalWithSymbols(pool, _) => {
+                                &pool.struct_def(id).fields
+                            }
+                        };
+                        if values.len() != fields.len() {
+                            return Err(
+                                "struct constant field count does not match its declaration".into(),
+                            );
+                        }
+                        for (child, field) in values.iter().zip(fields.iter()) {
+                            self.validate_const_value(child, Some(field.ty), depth + 1, nodes)?;
+                        }
+                    }
+                    (
+                        crate::sema::ConstAggregateKind::Array(values),
+                        crate::TypeKind::Array(id),
+                    ) => {
+                        let (element, len) = match self {
+                            Self::Semantic(pool) | Self::SemanticWithSymbols(pool, _) => {
+                                pool.array_def(id)
+                            }
+                            Self::Canonical(pool) | Self::CanonicalWithSymbols(pool, _) => {
+                                pool.array_def(id)
+                            }
+                        };
+                        if values.len() as u64 != len {
+                            return Err(
+                                "array constant length does not match its declaration".into()
+                            );
+                        }
+                        for child in values.iter() {
+                            self.validate_const_value(child, Some(element), depth + 1, nodes)?;
+                        }
+                    }
+                    (
+                        crate::sema::ConstAggregateKind::Enum { variant, payload },
+                        crate::TypeKind::Enum(id),
+                    ) => {
+                        let expected_len = self.enum_payload_len(id, *variant)?;
+                        if payload.len() != expected_len {
+                            return Err(
+                                "enum constant payload does not match its declaration".into()
+                            );
+                        }
+                        for (index, child) in payload.iter().enumerate() {
+                            self.validate_const_value(
+                                child,
+                                Some(self.enum_payload_type(id, *variant, index as u32)?),
+                                depth + 1,
+                                nodes,
+                            )?;
+                        }
+                    }
+                    _ => return Err("aggregate constant kind does not match its type".into()),
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn validate_enum_variant(&self, id: crate::EnumId, variant: u32) -> Result<(), String> {
         let count = match self {
             Self::Semantic(pool) | Self::SemanticWithSymbols(pool, _) => pool
@@ -798,6 +962,7 @@ enum ConstValueTag {
     Function,
     Float,
     String,
+    Aggregate,
 }
 
 impl ConstValueTag {
@@ -810,6 +975,7 @@ impl ConstValueTag {
             crate::sema::ConstValue::Function(_) => Self::Function,
             crate::sema::ConstValue::String(_) => Self::String,
             crate::sema::ConstValue::Float(_) => Self::Float,
+            crate::sema::ConstValue::Aggregate(_) => Self::Aggregate,
         }
     }
 
@@ -822,6 +988,7 @@ impl ConstValueTag {
             Self::Function => 4,
             Self::Float => 5,
             Self::String => 6,
+            Self::Aggregate => 7,
         }
     }
 
@@ -830,6 +997,7 @@ impl ConstValueTag {
             Self::Integer => 4,
             Self::Bool | Self::Type | Self::Function | Self::Float | Self::String => 1,
             Self::Unit => 0,
+            Self::Aggregate => 0,
         }
     }
 
@@ -842,6 +1010,7 @@ impl ConstValueTag {
             4 => Some(Self::Function),
             5 => Some(Self::Float),
             6 => Some(Self::String),
+            7 => Some(Self::Aggregate),
             _ => None,
         }
     }
@@ -856,8 +1025,47 @@ pub(crate) fn encode_const_values(
         operation: "stage",
         kind,
     };
+    fn encoded_words(
+        value: &crate::sema::ConstValue,
+        depth: usize,
+        nodes: &mut usize,
+    ) -> Option<usize> {
+        if depth > 64 {
+            return None;
+        }
+        *nodes = nodes.checked_add(1)?;
+        if *nodes > crate::sema::MAX_COMPTIME_AGGREGATE_NODES {
+            return None;
+        }
+        if let crate::sema::ConstValue::Aggregate(aggregate) = value {
+            let children = match &aggregate.kind {
+                crate::sema::ConstAggregateKind::Struct(values)
+                | crate::sema::ConstAggregateKind::Array(values) => values,
+                crate::sema::ConstAggregateKind::Enum { payload, .. } => payload,
+            };
+            // Every aggregate header contains the tag, type, kind, and child
+            // count. Enum headers additionally contain the variant index.
+            // Keep this reservation in lockstep with `append` below: the
+            // vector is deliberately reserved before any recursive encoding
+            // can run so malformed or oversized values cannot grow it without
+            // the checked size calculation seeing that growth.
+            let prefix = if matches!(
+                &aggregate.kind,
+                crate::sema::ConstAggregateKind::Enum { .. }
+            ) {
+                5
+            } else {
+                4
+            };
+            return children.iter().try_fold(prefix as usize, |total, child| {
+                total.checked_add(encoded_words(child, depth + 1, nodes)?)
+            });
+        }
+        Some(1 + ConstValueTag::of(value).payload_width())
+    }
+    let mut nodes = 0;
     let word_count = values.iter().try_fold(0usize, |count, value| {
-        count.checked_add(1 + ConstValueTag::of(value).payload_width())
+        count.checked_add(encoded_words(value, 0, &mut nodes)?)
     });
     let word_count = word_count.ok_or_else(|| error(AirBuildErrorKind::ResourceLimit))?;
     let mut words = Vec::new();
@@ -912,6 +1120,55 @@ pub(crate) fn encode_const_values(
                     u32::try_from(value.issuing_interner_ordinal())
                         .map_err(|_| error(AirBuildErrorKind::ResourceLimit))?,
                 );
+            }
+            crate::sema::ConstValue::Aggregate(aggregate) => {
+                fn append(
+                    value: &crate::sema::ConstValue,
+                    words: &mut Vec<u32>,
+                ) -> Result<(), AirBuildError> {
+                    let error = |kind| AirBuildError {
+                        phase: "AIR",
+                        family: "constant value arguments",
+                        operation: "stage",
+                        kind,
+                    };
+                    let crate::sema::ConstValue::Aggregate(aggregate) = value else {
+                        unreachable!()
+                    };
+                    words.push(ConstValueTag::Aggregate.word());
+                    words.push(aggregate.ty.as_u32());
+                    let children = match &aggregate.kind {
+                        crate::sema::ConstAggregateKind::Struct(values)
+                        | crate::sema::ConstAggregateKind::Array(values) => values,
+                        crate::sema::ConstAggregateKind::Enum { payload, .. } => payload,
+                    };
+                    match &aggregate.kind {
+                        crate::sema::ConstAggregateKind::Struct(_) => words.push(0),
+                        crate::sema::ConstAggregateKind::Array(_) => words.push(1),
+                        crate::sema::ConstAggregateKind::Enum { variant, .. } => {
+                            words.push(2);
+                            words.push(*variant);
+                        }
+                    }
+                    words.push(
+                        u32::try_from(children.len())
+                            .map_err(|_| error(AirBuildErrorKind::ResourceLimit))?,
+                    );
+                    for child in children.iter() {
+                        match child {
+                            crate::sema::ConstValue::Aggregate(_) => append(child, words)?,
+                            _ => {
+                                let child_words = encode_const_values(std::slice::from_ref(child))?;
+                                words.extend(child_words);
+                            }
+                        }
+                    }
+                    Ok(())
+                }
+                append(
+                    &crate::sema::ConstValue::Aggregate(aggregate.clone()),
+                    &mut words,
+                )?;
             }
         }
     }
@@ -1029,6 +1286,113 @@ pub struct ConstValueIterator<'a> {
     remaining: usize,
 }
 
+const MAX_DECODED_CONST_NODES: usize = 4096;
+
+fn decode_const_value(
+    words: &[u32],
+    depth: usize,
+    nodes: &mut usize,
+) -> Option<(crate::sema::ConstValue, usize)> {
+    let tag = ConstValueTag::from_word(*words.first()?)?;
+    if depth > 64 {
+        return None;
+    }
+    *nodes = nodes.checked_add(1)?;
+    if *nodes > MAX_DECODED_CONST_NODES {
+        return None;
+    }
+    let scalar = |width: usize| words.get(1..1 + width);
+    let value = match tag {
+        ConstValueTag::Integer => {
+            let payload = scalar(4)?;
+            let mut bits = 0u128;
+            for (index, word) in payload.iter().copied().enumerate() {
+                bits |= u128::from(word) << (32 * index);
+            }
+            (crate::sema::ConstValue::Integer(bits as i128), 5)
+        }
+        ConstValueTag::Bool => {
+            let value = match *scalar(1)?.first()? {
+                0 => false,
+                1 => true,
+                _ => return None,
+            };
+            (crate::sema::ConstValue::Bool(value), 2)
+        }
+        ConstValueTag::Unit => (crate::sema::ConstValue::Unit, 1),
+        ConstValueTag::Type => (
+            crate::sema::ConstValue::Type(Type::try_from_u32(*scalar(1)?.first()?)?),
+            2,
+        ),
+        ConstValueTag::Function => (
+            crate::sema::ConstValue::Function(SymbolHandle::new(Spur::try_from_usize(
+                *scalar(1)?.first()? as usize,
+            )?)),
+            2,
+        ),
+        ConstValueTag::Float => (
+            crate::sema::ConstValue::Float(SymbolHandle::new(Spur::try_from_usize(
+                *scalar(1)?.first()? as usize,
+            )?)),
+            2,
+        ),
+        ConstValueTag::String => (
+            crate::sema::ConstValue::String(SymbolHandle::new(Spur::try_from_usize(
+                *scalar(1)?.first()? as usize,
+            )?)),
+            2,
+        ),
+        ConstValueTag::Aggregate => {
+            let ty = Type::try_from_u32(*words.get(1)?)?;
+            let kind = *words.get(2)?;
+            match kind {
+                0 if !ty.is_struct() => return None,
+                1 if !ty.is_array() => return None,
+                2 if !ty.is_enum() => return None,
+                0..=2 => {}
+                _ => return None,
+            }
+            let (variant, count_word) = if kind == 2 {
+                (*words.get(3)?, 4)
+            } else {
+                (0, 3)
+            };
+            let count = usize::try_from(*words.get(count_word)?).ok()?;
+            // A child occupies at least one word.  Check both the aggregate
+            // node budget and the available payload before reserving the
+            // attacker-controlled vector; the recursive decoder must never
+            // allocate a claimed child count and discover truncation later.
+            if count > MAX_DECODED_CONST_NODES.saturating_sub(*nodes)
+                || count > words.len().saturating_sub(count_word + 1)
+            {
+                return None;
+            }
+            let mut cursor = count_word + 1;
+            let mut children = Vec::with_capacity(count);
+            for _ in 0..count {
+                let (child, used) = decode_const_value(words.get(cursor..)?, depth + 1, nodes)?;
+                cursor = cursor.checked_add(used)?;
+                children.push(child);
+            }
+            let aggregate_kind = match kind {
+                0 => crate::sema::ConstAggregateKind::Struct(children.into()),
+                1 => crate::sema::ConstAggregateKind::Array(children.into()),
+                2 => crate::sema::ConstAggregateKind::Enum {
+                    variant,
+                    payload: children.into(),
+                },
+                _ => unreachable!("aggregate kind checked before decoding"),
+            };
+            let value = crate::sema::register_comptime_aggregate(crate::sema::ConstAggregate {
+                ty,
+                kind: aggregate_kind,
+            })?;
+            (value, cursor)
+        }
+    };
+    Some(value)
+}
+
 impl Iterator for ConstValueIterator<'_> {
     type Item = crate::sema::ConstValue;
 
@@ -1036,33 +1400,11 @@ impl Iterator for ConstValueIterator<'_> {
         if self.remaining == 0 {
             return None;
         }
-        let tag = ConstValueTag::from_word(self.words[0])?;
-        let payload = &self.words[1..1 + tag.payload_width()];
-        self.words = &self.words[1 + tag.payload_width()..];
+        let mut nodes = 0;
+        let (value, used) = decode_const_value(self.words, 0, &mut nodes)?;
+        self.words = &self.words[used..];
         self.remaining -= 1;
-        Some(match tag {
-            ConstValueTag::Integer => {
-                let mut bits = 0u128;
-                for (index, word) in payload.iter().copied().enumerate() {
-                    bits |= u128::from(word) << (32 * index);
-                }
-                crate::sema::ConstValue::Integer(bits as i128)
-            }
-            ConstValueTag::Bool => crate::sema::ConstValue::Bool(payload[0] == 1),
-            ConstValueTag::Unit => crate::sema::ConstValue::Unit,
-            ConstValueTag::Type => crate::sema::ConstValue::Type(
-                Type::try_from_u32(payload[0]).expect("validated const type"),
-            ),
-            ConstValueTag::Function => crate::sema::ConstValue::Function(SymbolHandle::new(
-                Spur::try_from_usize(payload[0] as usize).expect("validated const symbol"),
-            )),
-            ConstValueTag::Float => crate::sema::ConstValue::Float(SymbolHandle::new(
-                Spur::try_from_usize(payload[0] as usize).expect("validated const symbol"),
-            )),
-            ConstValueTag::String => crate::sema::ConstValue::String(SymbolHandle::new(
-                Spur::try_from_usize(payload[0] as usize).expect("validated const symbol"),
-            )),
-        })
+        Some(value)
     }
 }
 
@@ -1961,22 +2303,19 @@ impl Air {
                             fail(Some(index), format!("invalid type argument: {reason}"))
                         })?;
                     }
+                    let mut const_nodes = 0;
                     for value in self
                         .try_get_const_values(value_args)
                         .map_err(|e| fail(Some(index), e.to_string()))?
                     {
-                        if let crate::sema::ConstValue::Type(ty) = value {
-                            validate_type(ty).map_err(|reason| {
+                        context
+                            .validate_const_value(&value, None, 0, &mut const_nodes)
+                            .map_err(|reason| {
                                 fail(
                                     Some(index),
-                                    format!("invalid constant type argument: {reason}"),
+                                    format!("invalid constant value argument: {reason}"),
                                 )
                             })?;
-                        } else if let crate::sema::ConstValue::Function(symbol) = value {
-                            context
-                                .validate_symbol(symbol.spur())
-                                .map_err(|reason| fail(Some(index), reason))?;
-                        }
                     }
                     for arg in self
                         .try_get_call_args(args)
@@ -3057,7 +3396,59 @@ impl Air {
         let words = self.try_get_words(range.start, range.extent, "constant value arguments")?;
         let mut cursor = words;
         let mut count = 0usize;
+        // This is one argument vector, so the node budget is shared by all
+        // roots. Resetting it for every aggregate would admit 4096 nodes per
+        // argument and let a large call payload evade the published bound.
+        let mut nodes = 0usize;
         while let Some((&tag_word, rest)) = cursor.split_first() {
+            if tag_word == ConstValueTag::Aggregate.word() {
+                let Some((_, used)) = decode_const_value(cursor, 0, &mut nodes) else {
+                    return Err(AirPayloadError::decode(
+                        "constant value arguments",
+                        range.start,
+                        range.extent,
+                        count,
+                        1,
+                        rest.len().saturating_add(1),
+                        "invalid or oversized aggregate encoding",
+                    ));
+                };
+                cursor = cursor.get(used..).ok_or_else(|| {
+                    AirPayloadError::decode(
+                        "constant value arguments",
+                        range.start,
+                        range.extent,
+                        count,
+                        used,
+                        cursor.len(),
+                        "truncated aggregate encoding",
+                    )
+                })?;
+                count += 1;
+                continue;
+            }
+            nodes = nodes.checked_add(1).ok_or_else(|| {
+                AirPayloadError::decode(
+                    "constant value arguments",
+                    range.start,
+                    range.extent,
+                    count,
+                    1,
+                    1,
+                    "constant value node budget overflow",
+                )
+            })?;
+            if nodes > MAX_DECODED_CONST_NODES {
+                return Err(AirPayloadError::decode(
+                    "constant value arguments",
+                    range.start,
+                    range.extent,
+                    count,
+                    1,
+                    1,
+                    "constant value arguments exceed resource limits",
+                ));
+            }
             let tag = ConstValueTag::from_word(tag_word).ok_or_else(|| {
                 AirPayloadError::decode(
                     "constant value arguments",
@@ -4572,6 +4963,47 @@ mod tests {
             error(&[ConstValueTag::String.word(), u32::MAX]).reason,
             "invalid constant symbol encoding"
         );
+        assert_eq!(
+            error(&[ConstValueTag::Aggregate.word(), Type::I32.as_u32(), 1, 0,]).reason,
+            "invalid or oversized aggregate encoding"
+        );
+    }
+
+    #[test]
+    fn checked_const_decoder_shares_the_node_budget_across_roots() {
+        let mut air = Air::new(Type::UNIT);
+        let words = vec![ConstValueTag::Unit.word(); MAX_DECODED_CONST_NODES + 1];
+        let (start, extent) = air.append_words("test", &words).unwrap();
+        let error = air
+            .try_get_const_values(&AirConstValueWords { start, extent })
+            .unwrap_err();
+        assert_eq!(
+            error.reason,
+            "constant value arguments exceed resource limits"
+        );
+    }
+
+    #[test]
+    fn checked_const_decoder_rejects_aggregate_children_before_reserving_them() {
+        let mut air = Air::new(Type::UNIT);
+        let mut words = vec![
+            ConstValueTag::Aggregate.word(),
+            // The scalar type deliberately mismatches the array kind; the
+            // decoder must still reject the claimed child count before a
+            // large vector reservation.
+            Type::I32.as_u32(),
+            1,
+            MAX_DECODED_CONST_NODES as u32,
+        ];
+        words.extend(std::iter::repeat_n(
+            ConstValueTag::Unit.word(),
+            MAX_DECODED_CONST_NODES,
+        ));
+        let (start, extent) = air.append_words("test", &words).unwrap();
+        let error = air
+            .try_get_const_values(&AirConstValueWords { start, extent })
+            .unwrap_err();
+        assert_eq!(error.reason, "invalid or oversized aggregate encoding");
     }
 
     #[test]

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -186,8 +186,8 @@ pub use semantic_import::{
     SemanticImportNominal, SemanticImportNominalKind, SemanticImportType, SemanticImportTypeFold,
     SemanticImportTypeKind, SemanticImportedConstValue, SemanticImportedType,
     SemanticLocalCallable, SemanticLocalCompleteness, SemanticLocalMaterialization,
-    SemanticLocalNominal, SemanticLocalNominalShape, semantic_import_const_value_within_limits,
-    semantic_import_const_values_within_limits,
+    SemanticLocalNominal, SemanticLocalNominalShape, semantic_import_const_children_within_limits,
+    semantic_import_const_value_within_limits, semantic_import_const_values_within_limits,
 };
 pub use semantic_type_resolution::{
     ComptimeStructuredTypeAuthority, ComptimeStructuredTypeJob, ComptimeStructuredTypePoll,

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -172,19 +172,22 @@ pub use semantic_body::{
 };
 pub use semantic_identity::{
     AnonymousMemberKey, AnonymousMemberKind, AnonymousNominalKey, AnonymousNominalKind,
-    CanonicalArgumentValue, CanonicalArguments, CanonicalDisplayParameter, CompilerCallableId,
-    FunctionInstanceKey, LocalAtomId, LocalAtomKind, LocalAtomRecord, Node, NominalInstanceKey,
-    STABLE_DEFINITION_KINDS, STABLE_DEFINITION_NAMESPACES, SemanticBodyLocalAtom, StableCallableId,
-    StableDefinitionKind, StableDefinitionNamespace, StableProducerId, StableSymbolId,
-    TypeInstanceKey, format_canonical_application,
+    CanonicalAggregateKind, CanonicalAggregateValue, CanonicalArgumentValue, CanonicalArguments,
+    CanonicalDisplayParameter, CompilerCallableId, FunctionInstanceKey, LocalAtomId, LocalAtomKind,
+    LocalAtomRecord, Node, NominalInstanceKey, STABLE_DEFINITION_KINDS,
+    STABLE_DEFINITION_NAMESPACES, SemanticBodyLocalAtom, StableCallableId, StableDefinitionKind,
+    StableDefinitionNamespace, StableProducerId, StableSymbolId, TypeInstanceKey,
+    format_canonical_application,
 };
 pub use semantic_import::{
-    SEMANTIC_IMPORT_CONST_KINDS, SEMANTIC_IMPORT_TYPE_KINDS, SemanticImportConstKind,
-    SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,
-    SemanticImportNominalKind, SemanticImportType, SemanticImportTypeFold, SemanticImportTypeKind,
-    SemanticImportedConstValue, SemanticImportedType, SemanticLocalCallable,
-    SemanticLocalCompleteness, SemanticLocalMaterialization, SemanticLocalNominal,
-    SemanticLocalNominalShape,
+    MAX_COMPTIME_VALUE_DEPTH, MAX_COMPTIME_VALUE_NODES, SEMANTIC_IMPORT_CONST_KINDS,
+    SEMANTIC_IMPORT_TYPE_KINDS, SemanticImportAggregate, SemanticImportAggregateKind,
+    SemanticImportConstKind, SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure,
+    SemanticImportNominal, SemanticImportNominalKind, SemanticImportType, SemanticImportTypeFold,
+    SemanticImportTypeKind, SemanticImportedConstValue, SemanticImportedType,
+    SemanticLocalCallable, SemanticLocalCompleteness, SemanticLocalMaterialization,
+    SemanticLocalNominal, SemanticLocalNominalShape, semantic_import_const_value_within_limits,
+    semantic_import_const_values_within_limits,
 };
 pub use semantic_type_resolution::{
     ComptimeStructuredTypeAuthority, ComptimeStructuredTypeJob, ComptimeStructuredTypePoll,

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -1560,14 +1560,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }),
                 _ => None,
             };
-            let (data, ty) = self.materialize_const_value(
+            let (air_ref, ty) = self.materialize_comptime_value(
+                air,
                 ctx,
                 const_info.value,
                 const_info.ty,
                 atom_anchor,
                 span,
             )?;
-            let air_ref = air.add_inst(AirInst { data, ty, span });
             return Ok(AnalysisResult::new(air_ref, ty));
         }
 

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -614,7 +614,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         // not erased from the signature).
                         match self.try_evaluate_const_in_fn(args.get(i).unwrap().value, ctx) {
                             Some(const_val) => {
-                                value_args.push(const_val);
+                                value_args.push(const_val.clone());
                                 value_subst.insert(param_names[i], const_val);
                             }
                             None => {
@@ -686,7 +686,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     // remaining a distinct fixed-capacity type.
                     let value = value_subst
                         .get(&param_names[i])
-                        .copied()
+                        .cloned()
                         .expect("comptime value substitution was captured above");
                     self.validate_comptime_value_for_type(
                         name,

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -375,6 +375,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         });
                         Ok(AnalysisResult::new(air_ref, ty))
                     }
+                    Some(ConstValue::Aggregate(value)) => {
+                        let ty = Self::get_resolved_type(
+                            ctx,
+                            inst_ref,
+                            inst.span,
+                            "comptime aggregate value",
+                        )?;
+                        let (air_ref, ty) = self.materialize_comptime_value(
+                            air,
+                            ctx,
+                            ConstValue::Aggregate(value),
+                            ty,
+                            None,
+                            inst.span,
+                        )?;
+                        Ok(AnalysisResult::new(air_ref, ty))
+                    }
                     Some(ConstValue::Unit) => {
                         let ty = Type::UNIT;
                         let air_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5,8 +5,10 @@
 //! them. It extends the canonical body-analysis engine rather than
 //! introducing peer analysis state.
 
-use super::super::analyze_ops::FloatConstSource;
-use super::super::context::{LocalVar, ParamInfo};
+use super::super::analyze_ops::{FloatConstSource, StringConstSource};
+use super::super::context::{
+    ConstAggregateKind, LocalVar, ParamInfo, comptime_value_within_limits,
+};
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::super::ownership_state::{FieldPath, VariableMoveState};
 use super::*;
@@ -2227,7 +2229,157 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 )?;
                 (data, ty)
             }
+            ConstValue::Aggregate(_) => {
+                return Err(CompileError::new(
+                    ErrorKind::ComptimeEvaluationFailed {
+                        reason: "aggregate comptime values cannot be materialized here".to_string(),
+                    },
+                    span,
+                ));
+            }
         })
+    }
+
+    /// Materialize a comptime value as ordinary AIR.  Scalar constants use
+    /// the shared scalar materializer above; a structural value is rebuilt
+    /// with the same aggregate instructions used by source initializers, so
+    /// its complete content and declared child types reach runtime codegen.
+    /// The value has already crossed the canonical comptime validator, but
+    /// this boundary repeats the shape checks before emitting any child so a
+    /// malformed retained value cannot become a partial AIR aggregate.
+    pub(crate) fn materialize_comptime_value(
+        &mut self,
+        air: &mut Air,
+        ctx: &mut AnalysisContext,
+        value: ConstValue,
+        ty: Type,
+        anchor: Option<rue_rir::RirStructuralAnchor>,
+        span: Span,
+    ) -> CompileResult<(AirRef, Type)> {
+        let ConstValue::Aggregate(aggregate) = value.clone() else {
+            let valid = match (&value, ty) {
+                (ConstValue::Integer(value), ty) => ty
+                    .integer_semantics()
+                    .is_some_and(|integer| integer.fits_i128(*value)),
+                (ConstValue::Bool(_), Type::BOOL)
+                | (ConstValue::Unit, Type::UNIT)
+                | (ConstValue::Type(_), Type::COMPTIME_TYPE) => true,
+                (ConstValue::String(_), ty) => self.is_str_like(ty),
+                (ConstValue::Float(_), ty) => ty.is_float() || ty == Type::COMPTIME_FLOAT,
+                _ => false,
+            };
+            if !valid {
+                return Err(CompileError::new(
+                    ErrorKind::ComptimeEvaluationFailed {
+                        reason: "invalid structural comptime value".to_owned(),
+                    },
+                    span,
+                ));
+            }
+            let (data, ty) = if let ConstValue::String(content) = value {
+                let content = self.body_interner().resolve(&content.spur()).to_string();
+                let data = self.materialize_string_const(
+                    ctx,
+                    content,
+                    ty,
+                    span,
+                    match anchor {
+                        Some(anchor) => StringConstSource::NamedConst(anchor),
+                        None => StringConstSource::Synthesized,
+                    },
+                )?;
+                (data, ty)
+            } else {
+                self.materialize_const_value(ctx, value, ty, None, span)?
+            };
+            let air_ref = air.add_inst(AirInst { data, ty, span });
+            return Ok((air_ref, ty));
+        };
+
+        let invalid = || {
+            CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "invalid structural comptime value".to_owned(),
+                },
+                span,
+            )
+        };
+        if !comptime_value_within_limits(&ConstValue::Aggregate(aggregate.clone())) {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "structural comptime value exceeds resource limits".to_owned(),
+                },
+                span,
+            ));
+        }
+        if aggregate.ty != ty || !ty.is_copy_in_pool(self.body_type_pool()) {
+            return Err(invalid());
+        }
+
+        let air_ref = match &aggregate.kind {
+            ConstAggregateKind::Struct(values) => {
+                let Some(struct_id) = ty.as_struct() else {
+                    return Err(invalid());
+                };
+                let fields = self.body_type_pool().struct_def(struct_id).fields.clone();
+                if fields.len() != values.len() {
+                    return Err(invalid());
+                }
+                let mut refs = Vec::with_capacity(values.len());
+                for (value, field) in values.iter().cloned().zip(fields.iter()) {
+                    refs.push(
+                        self.materialize_comptime_value(air, ctx, value, field.ty, None, span)?
+                            .0,
+                    );
+                }
+                let source_order = (0..refs.len())
+                    .map(|index| index as u32)
+                    .collect::<Vec<_>>();
+                air.add_struct_init(struct_id, &refs, &source_order, ty, span)
+                    .map_err(CompileError::from)?
+            }
+            ConstAggregateKind::Array(values) => {
+                let Some(array_id) = ty.as_array() else {
+                    return Err(invalid());
+                };
+                let (element, length) = self.body_type_pool().array_def(array_id);
+                if values.len() as u64 != length {
+                    return Err(invalid());
+                }
+                let mut refs = Vec::with_capacity(values.len());
+                for value in values.iter().cloned() {
+                    refs.push(
+                        self.materialize_comptime_value(air, ctx, value, element, None, span)?
+                            .0,
+                    );
+                }
+                air.add_array_init(&refs, ty, span)
+                    .map_err(CompileError::from)?
+            }
+            ConstAggregateKind::Enum { variant, payload } => {
+                let Some(enum_id) = ty.as_enum() else {
+                    return Err(invalid());
+                };
+                let enum_def = self.body_type_pool().enum_def(enum_id);
+                if (*variant as usize) >= enum_def.variants.len() {
+                    return Err(invalid());
+                }
+                let payload_types = enum_def.variant_payload(*variant as usize);
+                if payload_types.len() != payload.len() {
+                    return Err(invalid());
+                }
+                let mut refs = Vec::with_capacity(payload.len());
+                for (value, payload_ty) in payload.iter().cloned().zip(payload_types.iter()) {
+                    refs.push(
+                        self.materialize_comptime_value(air, ctx, value, *payload_ty, None, span)?
+                            .0,
+                    );
+                }
+                air.add_enum_variant(enum_id, *variant, &refs, ty, span)
+                    .map_err(CompileError::from)?
+            }
+        };
+        Ok((air_ref, ty))
     }
 
     /// Analyze a variable reference.
@@ -2557,6 +2709,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     });
                     return Ok(AnalysisResult::new(air_ref, Type::UNIT));
                 }
+                ConstValue::Aggregate(value) => {
+                    let ty = resolved_ty.unwrap_or(value.ty);
+                    let (air_ref, ty) = self.materialize_comptime_value(
+                        air,
+                        ctx,
+                        ConstValue::Aggregate(value.clone()),
+                        ty,
+                        None,
+                        span,
+                    )?;
+                    return Ok(AnalysisResult::new(air_ref, ty));
+                }
             }
         }
 
@@ -2626,14 +2790,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             } else {
                 const_info.ty
             };
-            let (data, ty) = self.materialize_const_value(
+            let (air_ref, ty) = self.materialize_comptime_value(
+                air,
                 ctx,
                 const_info.value,
                 materialized_ty,
                 atom_anchor,
                 span,
             )?;
-            let air_ref = air.add_inst(AirInst { data, ty, span });
             return Ok(AnalysisResult::new(air_ref, ty));
         }
 

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -797,6 +797,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             continue;
                         }
                         ConstValue::Unit => Type::UNIT,
+                        ConstValue::Aggregate(_index) => const_val.get_type(),
                     };
                     param_vars.entry(*name).or_insert(ParamVarInfo {
                         ty: self.type_to_infer_type(ty),
@@ -1584,7 +1585,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 lexical_binding_capture_view(scope),
                 Some(expected),
             ) {
-                argument_values.insert(arg.value, value);
+                argument_values.insert(arg.value, value.clone());
                 callee_values.insert(param_names[index], value);
             }
         }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -51,6 +51,7 @@ pub(crate) enum FloatConstSource<'a> {
 /// Where a string value came from when it is materialized into AIR.
 pub(crate) enum StringConstSource {
     Literal(RirStructuralAnchor),
+    NamedConst(RirStructuralAnchor),
     Synthesized,
 }
 
@@ -101,6 +102,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         let local_id = match source {
             StringConstSource::Literal(anchor) => ctx.add_local_string(content, anchor),
+            StringConstSource::NamedConst(anchor) => ctx.add_local_read_only_data(content, anchor),
             StringConstSource::Synthesized => ctx.add_synthesized_string(&content),
         };
         Ok(AirInstData::StringConst(local_id))

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -2210,7 +2210,43 @@ pub(in crate::sema) fn semantic_import_type_mentions_generic_parameter<K, M>(
                 | crate::CanonicalArgumentValue::Unit
                 | crate::CanonicalArgumentValue::String(_)
                 | crate::CanonicalArgumentValue::Float(_) => false,
+                crate::CanonicalArgumentValue::Aggregate(value) => {
+                    type_instance(&value.ty)
+                        || match &value.kind {
+                            crate::CanonicalAggregateKind::Struct(values)
+                            | crate::CanonicalAggregateKind::Array(values) => {
+                                values.iter().any(canonical_value)
+                            }
+                            crate::CanonicalAggregateKind::Enum { payload, .. } => {
+                                payload.iter().any(canonical_value)
+                            }
+                        }
+                }
             })
+    }
+
+    fn canonical_value<K, M>(value: &crate::CanonicalArgumentValue<K, M>) -> bool {
+        match value {
+            crate::CanonicalArgumentValue::Type(value) => type_instance(value),
+            crate::CanonicalArgumentValue::Function(value) => function_instance(value),
+            crate::CanonicalArgumentValue::Aggregate(value) => {
+                type_instance(&value.ty)
+                    || match &value.kind {
+                        crate::CanonicalAggregateKind::Struct(values)
+                        | crate::CanonicalAggregateKind::Array(values) => {
+                            values.iter().any(canonical_value)
+                        }
+                        crate::CanonicalAggregateKind::Enum { payload, .. } => {
+                            payload.iter().any(canonical_value)
+                        }
+                    }
+            }
+            crate::CanonicalArgumentValue::Integer(_)
+            | crate::CanonicalArgumentValue::Bool(_)
+            | crate::CanonicalArgumentValue::Unit
+            | crate::CanonicalArgumentValue::String(_)
+            | crate::CanonicalArgumentValue::Float(_) => false,
+        }
     }
 
     // The producer is the whole reach of an anonymous key: the arguments it was
@@ -2748,7 +2784,7 @@ pub trait DurableConstSource<K, M> {
 }
 
 /// The durable-derived subset of [`ConstInfo`], cached by const key.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct ConstIdentity {
     is_pub: bool,
     ty: Type,
@@ -2788,8 +2824,8 @@ where
         if let Some(err) = self.const_poisoned.get(key) {
             return Err(err.clone());
         }
-        if let Some(&identity) = self.const_values.get(key) {
-            return Ok(identity);
+        if let Some(identity) = self.const_values.get(key) {
+            return Ok(identity.clone());
         }
 
         let DurableConst {
@@ -2812,7 +2848,7 @@ where
             ty,
             value,
         };
-        self.const_values.insert(key.clone(), identity);
+        self.const_values.insert(key.clone(), identity.clone());
         Ok(identity)
     }
 
@@ -2832,6 +2868,11 @@ where
         value: &SemanticImportConstValue<K, M>,
     ) -> Result<ConstValue, IdentityMintError> {
         use SemanticImportConstValue as V;
+        if matches!(value, V::Aggregate(_))
+            && !crate::semantic_import_const_value_within_limits(value)
+        {
+            return Err(IdentityMintError::InvalidStructuralType);
+        }
         Ok(match value {
             V::Integer(value) => ConstValue::Integer(*value),
             V::Bool(value) => ConstValue::Bool(*value),
@@ -2859,6 +2900,41 @@ where
                     .map_err(IdentityMintError::Interner)?
                     .into(),
             ),
+            V::Aggregate(value) => {
+                let ty = self.resolve_const_type(key, &value.ty)?;
+                let kind = match &value.kind {
+                    crate::SemanticImportAggregateKind::Struct(values) => {
+                        crate::sema::ConstAggregateKind::Struct(
+                            values
+                                .iter()
+                                .map(|v| self.resolve_const_value(key, v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        )
+                    }
+                    crate::SemanticImportAggregateKind::Array(values) => {
+                        crate::sema::ConstAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(|v| self.resolve_const_value(key, v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        )
+                    }
+                    crate::SemanticImportAggregateKind::Enum { variant, payload } => {
+                        crate::sema::ConstAggregateKind::Enum {
+                            variant: *variant,
+                            payload: payload
+                                .iter()
+                                .map(|v| self.resolve_const_value(key, v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        }
+                    }
+                };
+                crate::sema::register_comptime_aggregate(crate::sema::ConstAggregate { ty, kind })
+                    .ok_or(IdentityMintError::InvalidStructuralType)?
+            }
         })
     }
 }

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -334,6 +334,12 @@ pub trait ComptimeTypeAlgebra: ComptimeDomain {
         site: &ComptimeDiagnosticSite<Self::ProgramKey>,
     ) -> ComptimeHostResult<(), Self::Failure>;
     fn type_name(&self, ty: &Self::Type) -> String;
+    /// Whether a type value names an enum. This keeps enum-constructor
+    /// dispatch precise without evaluating receivers twice or treating every
+    /// associated type call as a variant constructor.
+    fn type_is_enum(&self, _ty: &Self::Type) -> bool {
+        false
+    }
     fn type_is_unsigned(&self, ty: &Self::Type) -> bool;
     fn type_integer_semantics(&self, ty: &Self::Type) -> Option<IntegerType>;
     /// The float width of `ty`, or `None` for a non-float type. The default
@@ -390,6 +396,44 @@ pub trait ComptimeTypeAlgebra: ComptimeDomain {
         >,
         inst_ref: InstRef,
     ) -> Option<Self::Type>;
+    /// Resolve the nominal type of a structural literal after the engine has
+    /// reduced its children. The engine supplies the semantic name directly;
+    /// hosts do not inspect the literal instruction or its child RIR.
+    fn resolve_comptime_struct_type(
+        &mut self,
+        program: &Self::ProgramKey,
+        name: Self::Name,
+        span: Span,
+    ) -> ComptimeHostResult<Option<Self::Type>, Self::Failure> {
+        self.resolve_named_type_value(program, name, span)
+    }
+    /// Resolve an array literal's type from reduced child values. Contextual
+    /// hosts may retain their resolved expression type; durable hosts use the
+    /// typed value projection and never decode RIR here.
+    fn resolve_comptime_array_type(
+        &mut self,
+        program: &Self::ProgramKey,
+        env: &ComptimeEnv<
+            '_,
+            Self::Value,
+            Self::Type,
+            Self::Name,
+            Self::File,
+            Self::CanonicalIdentity,
+        >,
+        inst_ref: InstRef,
+        element: Option<&Self::Value>,
+        length: u64,
+    ) -> Option<Self::Type> {
+        env.expected_result
+            .clone()
+            .or_else(|| self.const_expr_type(program, env, inst_ref))
+            .or_else(|| {
+                element
+                    .and_then(ComptimeValue::value_type)
+                    .map(|element| self.get_or_create_array_type(element, length))
+            })
+    }
     /// Resolve the concrete float type of an operand expression. This is
     /// separate from `const_expr_type` so comparisons inspect their operands
     /// rather than their boolean result expression.
@@ -458,6 +502,46 @@ pub trait ComptimeTypeAlgebra: ComptimeDomain {
 
 /// Value resolution, arithmetic, comparison, and member/pattern selection.
 pub trait ComptimeValueAlgebra: ComptimeDomain {
+    /// Construct a bounded structural value after the engine has reduced every
+    /// child. Hosts only adapt the resulting value representation; traversal
+    /// and resource accounting remain owned by this engine.
+    fn resolve_comptime_struct(
+        &mut self,
+        _ty: Self::Type,
+        _fields: Vec<(Self::Name, Self::Value)>,
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeOutcome<Self::Value, Self::Failure> {
+        ComptimeOutcome::RuntimeDependent
+    }
+    fn resolve_comptime_array(
+        &mut self,
+        _ty: Self::Type,
+        _elements: Vec<Self::Value>,
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeOutcome<Self::Value, Self::Failure> {
+        ComptimeOutcome::RuntimeDependent
+    }
+    fn resolve_comptime_array_repeat(
+        &mut self,
+        _ty: Self::Type,
+        _element: Self::Value,
+        _count: u64,
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeOutcome<Self::Value, Self::Failure> {
+        ComptimeOutcome::RuntimeDependent
+    }
+    /// Retag enum payload projections with their declared field types before
+    /// a match arm evaluates a bound. Durable values store content separately
+    /// from wrapper metadata, so this keeps width and nominal identity intact
+    /// without putting host-specific type tables in the generic value algebra.
+    fn project_comptime_enum_payload(
+        &mut self,
+        _value: &Self::Value,
+        _variant: u32,
+        payload: Vec<Self::Value>,
+    ) -> ComptimeHostResult<Vec<Self::Value>, Self::Failure> {
+        Ok(payload)
+    }
     fn resolve_comptime_named_value(
         &mut self,
         file: Self::File,
@@ -471,11 +555,12 @@ pub trait ComptimeValueAlgebra: ComptimeDomain {
     /// enum-shaped values a domain can represent, and the default domain
     /// represents none of them.
     fn match_path_pattern(
-        &self,
+        &mut self,
         _pattern: &ComptimeMatchPattern<Self::Name>,
         _value: &Self::Value,
-    ) -> Option<bool> {
-        None
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeHostResult<Option<bool>, Self::Failure> {
+        Ok(None)
     }
     /// Report a comptime-known `match` whose reached arms all declined.
     /// Selection happens over an exhaustive pattern set (4.14:19, 4.7:9), so
@@ -576,6 +661,20 @@ pub trait ComptimeValueAlgebra: ComptimeDomain {
     ) -> ComptimeOutcome<Self::Value, Self::Failure> {
         ComptimeOutcome::RuntimeDependent
     }
+    /// Construct a payload-bearing enum variant whose receiver reduced to a
+    /// type value (the `Choice.Some(value)` spelling). The engine evaluates
+    /// the receiver and payloads once, then delegates the typed construction
+    /// to the host so ordinary and durable domains share the same path.
+    fn resolve_comptime_enum_variant_with_payload(
+        &mut self,
+        _enum_type: Self::Type,
+        _variant: Self::Name,
+        _payload: Vec<Self::Value>,
+        _site: &ComptimeSite<Self::ProgramKey>,
+        _span: Span,
+    ) -> ComptimeOutcome<Self::Value, Self::Failure> {
+        ComptimeOutcome::RuntimeDependent
+    }
     fn admit_comptime_enum_variant(
         &mut self,
         _type_name: Self::Name,
@@ -665,6 +764,15 @@ pub trait ComptimeCallProtocol: ComptimeDomain {
         argument_count: usize,
         span: Span,
     ) -> ComptimeHostResult<Self::CallBinding, Self::Failure>;
+    /// Return the declared type for an argument before its expression is
+    /// reduced, so contextual aggregate literals preserve the call contract.
+    fn comptime_call_argument_type(
+        &self,
+        _binding: &Self::CallBinding,
+        _index: usize,
+    ) -> Option<Self::Type> {
+        None
+    }
     /// Push one already-evaluated argument. `false` rejects the call as
     /// runtime-dependent and stops the engine before the next child runs.
     fn bind_comptime_call_argument(
@@ -944,14 +1052,15 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
     /// domain is the engine's own (RUE-1968) so both hosts cannot answer it
     /// differently; only an enum-variant path reaches the host.
     fn match_pattern(
-        &self,
+        &mut self,
         pattern: &ComptimeMatchPattern<H::Name>,
         value: &H::Value,
-    ) -> Option<bool> {
+        site: &ComptimeDiagnosticSite<H::ProgramKey>,
+    ) -> ComptimeHostResult<Option<bool>, H::Failure> {
         match comptime_scalar_pattern_decision(pattern, value) {
-            ComptimePatternDecision::Decided(matched) => Some(matched),
-            ComptimePatternDecision::Undecidable => None,
-            ComptimePatternDecision::HostPath => self.host.match_path_pattern(pattern, value),
+            ComptimePatternDecision::Decided(matched) => Ok(Some(matched)),
+            ComptimePatternDecision::Undecidable => Ok(None),
+            ComptimePatternDecision::HostPath => self.host.match_path_pattern(pattern, value, site),
         }
     }
 
@@ -1394,6 +1503,9 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                 InstData::FieldGet { .. } if kind == ComptimeSiteKind::Member => {
                     Some(ComptimeSiteKind::Member)
                 }
+                InstData::MethodCall { .. } if kind == ComptimeSiteKind::Member => {
+                    Some(ComptimeSiteKind::Member)
+                }
                 _ => None,
             };
             if candidate_kind == Some(kind) {
@@ -1488,21 +1600,44 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         let value = self.eval(body, env);
         let selected = match value {
             ComptimeOutcome::Known(value) => {
-                let patterns = self.program_rir().match_arms(arms).to_vec();
-                patterns
-                    .into_iter()
-                    .enumerate()
-                    .find_map(|(index, (pattern, _))| {
-                        let pattern = self.decode_match_pattern(&self.program_key(), &pattern);
-                        match self.match_pattern(&pattern, &value) {
-                            Some(true) => Some(ComptimeOutcome::Known(ComptimeSelection::Match {
-                                arm: index,
-                            })),
-                            Some(false) => None,
-                            None => Some(ComptimeOutcome::RuntimeDependent),
-                        }
+                let patterns = self
+                    .program_rir()
+                    .match_arms(arms)
+                    .iter()
+                    .map(|(pattern, body)| {
+                        (
+                            self.decode_match_pattern(&self.program_key(), &pattern),
+                            body,
+                        )
                     })
-                    .unwrap_or(ComptimeOutcome::RuntimeDependent)
+                    .collect::<Vec<_>>();
+                {
+                    let mut selected = ComptimeOutcome::RuntimeDependent;
+                    for (index, (pattern, _)) in patterns.into_iter().enumerate() {
+                        match self.match_pattern(
+                            &pattern,
+                            &value,
+                            &self.diagnostic_site(Span::new(0, 0)),
+                        ) {
+                            Ok(Some(true)) => {
+                                selected =
+                                    ComptimeOutcome::Known(ComptimeSelection::Match { arm: index });
+                                break;
+                            }
+                            Ok(Some(false)) => {}
+                            Ok(None) => {}
+                            Err(ComptimeHostError::HostFailure(error)) => {
+                                selected = ComptimeOutcome::HostFailure(error);
+                                break;
+                            }
+                            Err(ComptimeHostError::Abort(error)) => {
+                                selected = ComptimeOutcome::Abort(error);
+                                break;
+                            }
+                        }
+                    }
+                    selected
+                }
             }
             ComptimeOutcome::RuntimeDependent => ComptimeOutcome::RuntimeDependent,
             ComptimeOutcome::NotReady => ComptimeOutcome::NotReady,
@@ -1576,7 +1711,16 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
     ) -> ComptimeOutcome<(), H::Failure> {
         for (index, arg) in args.iter().enumerate() {
             let program = self.program_key();
-            let value = outcome_value!(self.eval(arg.value, env));
+            let previous_expected = env.expected_result.clone();
+            env.expected_result = self.host.comptime_call_argument_type(binding, index);
+            let value = match self.eval(arg.value, env) {
+                ComptimeOutcome::Known(value) => value,
+                other => {
+                    env.expected_result = previous_expected;
+                    return Self::discard_rejection(other);
+                }
+            };
+            env.expected_result = previous_expected;
             let direct_unit_literal = matches!(
                 &self.host.program_rir(&program).get(arg.value).data,
                 InstData::UnitConst
@@ -1746,6 +1890,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
 
     fn evaluate_method_call(
         &mut self,
+        inst_ref: InstRef,
         receiver: InstRef,
         method: H::Name,
         args: &rue_rir::RirCallArgsRange,
@@ -1755,9 +1900,70 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
         let args = self.program_rir().call_args(args).to_vec();
         if matches!(
             self.host.comptime_method_receiver_policy(),
+            ComptimeMethodReceiverPolicy::SyntacticModulePath
+        ) {
+            let type_value = match self.program_rir().get(receiver).data {
+                InstData::VarRef { name, .. } => {
+                    let name = self.name_from_rir(name.into());
+                    host_value!(
+                        self.host
+                            .resolve_named_type_value(&self.program_key(), name, span,)
+                    )
+                }
+                _ => None,
+            };
+            if let Some(type_value) = type_value {
+                if self.host.type_is_enum(&type_value) {
+                    let previous_expected = env.expected_result.take();
+                    let mut payload = Vec::with_capacity(args.len());
+                    for arg in &args {
+                        let value = match self.eval(arg.value, env) {
+                            ComptimeOutcome::Known(value) => value,
+                            other => {
+                                env.expected_result = previous_expected;
+                                return Self::discard_rejection(other);
+                            }
+                        };
+                        payload.push(value);
+                    }
+                    env.expected_result = previous_expected;
+                    let site = self.semantic_site(inst_ref, ComptimeSiteKind::Member, span);
+                    return self.host.resolve_comptime_enum_variant_with_payload(
+                        type_value, method, payload, &site, span,
+                    );
+                }
+            }
+        }
+        if matches!(
+            self.host.comptime_method_receiver_policy(),
             ComptimeMethodReceiverPolicy::EvaluateReceiver
         ) {
+            // EvaluateReceiver owns exactly one receiver evaluation. A type
+            // receiver is a variant constructor only when its type algebra
+            // confirms an enum; associated calls on struct types continue
+            // through ordinary method admission.
             let receiver = outcome_value!(self.eval(receiver, env));
+            if let Some(enum_type) = receiver.as_type()
+                && self.host.type_is_enum(&enum_type)
+            {
+                let previous_expected = env.expected_result.take();
+                let mut payload = Vec::with_capacity(args.len());
+                for arg in &args {
+                    let value = match self.eval(arg.value, env) {
+                        ComptimeOutcome::Known(value) => value,
+                        other => {
+                            env.expected_result = previous_expected;
+                            return Self::discard_rejection(other);
+                        }
+                    };
+                    payload.push(value);
+                }
+                env.expected_result = previous_expected;
+                let site = self.semantic_site(inst_ref, ComptimeSiteKind::Member, span);
+                return self.host.resolve_comptime_enum_variant_with_payload(
+                    enum_type, method, payload, &site, span,
+                );
+            }
             let arg_modes: Vec<ComptimeArgMode> = args
                 .iter()
                 .map(|arg| (arg.mode, self.program_rir().get(arg.value).span))
@@ -3167,6 +3373,21 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             | InstData::Branch { .. }
             | InstData::Call { .. } => unreachable!("routed by comptime eval trampoline"),
 
+            InstData::IndexGet { base, index } => {
+                let base = outcome_value!(self.eval(*base, env));
+                let index = outcome_value!(self.eval(*index, env));
+                let Some(index) = index
+                    .as_integer()
+                    .and_then(|value| usize::try_from(value).ok())
+                else {
+                    return ComptimeOutcome::RuntimeDependent;
+                };
+                match base.aggregate_array_element(index) {
+                    Some(value) => ComptimeOutcome::Known(value),
+                    None => ComptimeOutcome::RuntimeDependent,
+                }
+            }
+
             // Comptime-known `match`: evaluate the scrutinee, select the first
             // arm whose pattern matches, and reduce to that arm's body value
             // (spec 4.14:19, RUE-262). Scalar patterns are decided here for
@@ -3177,15 +3398,90 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             InstData::Match { scrutinee, arms } => {
                 let scrutinee = *scrutinee;
                 let scrut = outcome_value!(self.eval(scrutinee, env));
-                let arms = self.program_rir().match_arms(arms).to_vec();
-                for (pattern, body) in arms.iter() {
-                    let semantic_pattern = self.decode_match_pattern(&self.program_key(), pattern);
-                    match self.match_pattern(&semantic_pattern, &scrut) {
-                        Some(true) => return self.eval(*body, env),
-                        Some(false) => continue,
+                let arms = self
+                    .program_rir()
+                    .match_arms(arms)
+                    .iter()
+                    .map(|(pattern, body)| {
+                        (
+                            self.decode_match_pattern(&self.program_key(), &pattern),
+                            body,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                for (semantic_pattern, body) in arms.iter() {
+                    match self.match_pattern(semantic_pattern, &scrut, &self.diagnostic_site(span))
+                    {
+                        Ok(Some(true)) => {
+                            // Payload bindings belong to the selected arm's
+                            // lexical environment. The engine extracts only
+                            // the already-reduced payload through the value
+                            // algebra; hosts do not receive RIR or evaluate
+                            // pattern children themselves.
+                            let bindings = match &semantic_pattern {
+                                ComptimeMatchPattern::Path { binding_names, .. } => {
+                                    if binding_names.iter().all(Option::is_none) {
+                                        Vec::new()
+                                    } else {
+                                        let Some((variant, payload)) =
+                                            scrut.aggregate_enum_payload()
+                                        else {
+                                            return ComptimeOutcome::RuntimeDependent;
+                                        };
+                                        let payload = match self
+                                            .host
+                                            .project_comptime_enum_payload(&scrut, variant, payload)
+                                        {
+                                            Ok(payload) => payload,
+                                            Err(ComptimeHostError::HostFailure(error)) => {
+                                                return ComptimeOutcome::HostFailure(error);
+                                            }
+                                            Err(ComptimeHostError::Abort(error)) => {
+                                                return ComptimeOutcome::Abort(error);
+                                            }
+                                        };
+                                        let mut bindings = Vec::new();
+                                        for (index, name) in binding_names.iter().enumerate() {
+                                            let Some(name) = name else { continue };
+                                            let Some(value) = payload.get(index).cloned() else {
+                                                return ComptimeOutcome::RuntimeDependent;
+                                            };
+                                            if self.host.display_name(name) != "_" {
+                                                bindings.push((name.clone(), value));
+                                            }
+                                        }
+                                        bindings
+                                    }
+                                }
+                                _ => Vec::new(),
+                            };
+                            let mut previous = Vec::with_capacity(bindings.len());
+                            for (name, value) in bindings {
+                                previous.push((name.clone(), env.locals.insert(name, value)));
+                            }
+                            let result = self.eval(*body, env);
+                            for (name, value) in previous {
+                                match value {
+                                    Some(value) => {
+                                        env.locals.insert(name, value);
+                                    }
+                                    None => {
+                                        env.locals.remove(&name);
+                                    }
+                                }
+                            }
+                            return result;
+                        }
+                        Ok(Some(false)) => continue,
                         // Undecidable pattern (e.g. an enum-variant `Path`
                         // against a non-representable scrutinee): bail out.
-                        None => return ComptimeOutcome::RuntimeDependent,
+                        Ok(None) => return ComptimeOutcome::RuntimeDependent,
+                        Err(ComptimeHostError::HostFailure(error)) => {
+                            return ComptimeOutcome::HostFailure(error);
+                        }
+                        Err(ComptimeHostError::Abort(error)) => {
+                            return ComptimeOutcome::Abort(error);
+                        }
                     }
                 }
                 self.host.match_no_selected_arm(&self.diagnostic_site(span))
@@ -3392,10 +3688,6 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             InstData::ArrayRepeat { value, count } => {
                 let (value, count) = (*value, count.clone());
                 let value = outcome_value!(self.eval(value, env));
-                let Some(elem_ty) = value.as_type() else {
-                    let site = self.diagnostic_site(span);
-                    return self.host.reject_non_type_array_repeat(value, &site);
-                };
                 let len = match count {
                     RepeatCount::Literal(n) => n,
                     RepeatCount::Named(sym) => {
@@ -3410,8 +3702,26 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
                         ))
                     }
                 };
-                let array_ty = self.host.get_or_create_array_type(elem_ty, len);
-                ComptimeOutcome::Known(H::Value::type_value(array_ty))
+                if let Some(elem_ty) = value.as_type() {
+                    // A repeat over a type literal is itself a comptime type.
+                    let array_ty = self.host.get_or_create_array_type(elem_ty, len);
+                    return ComptimeOutcome::Known(H::Value::type_value(array_ty));
+                }
+                // A reduced value repeat is a structural array literal. Its
+                // contextual type is resolved through the same array contract
+                // as ArrayInit, then the host performs one bounded admission.
+                let Some(array_ty) = self.host.resolve_comptime_array_type(
+                    &self.program_key(),
+                    env,
+                    inst_ref,
+                    Some(&value),
+                    len,
+                ) else {
+                    return ComptimeOutcome::RuntimeDependent;
+                };
+                let site = self.diagnostic_site(span);
+                self.host
+                    .resolve_comptime_array_repeat(array_ty, value, len, &site)
             }
 
             // VarRef: comptime let-bindings, comptime parameters, file-level
@@ -3625,16 +3935,61 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             } => {
                 let receiver = *receiver;
                 let method = self.name_from_rir((*method).into());
-                self.evaluate_method_call(receiver, method, args, env, span)
+                self.evaluate_method_call(inst_ref, receiver, method, args, env, span)
             }
 
-            InstData::StructInit { .. } | InstData::ArrayInit { .. } => {
-                self.host.reject_comptime_expression(
-                    ComptimeSemanticRejection::AggregateExpression,
-                    &self.diagnostic_site(span),
-                )
+            InstData::StructInit {
+                fields,
+                module,
+                type_name,
+                ..
+            } => {
+                if module.is_some() {
+                    return ComptimeOutcome::RuntimeDependent;
+                }
+                let site = self.diagnostic_site(span);
+                let field_inits: Vec<_> = self
+                    .program_rir()
+                    .field_inits(fields)
+                    .iter()
+                    .map(|field| (field.0, field.1))
+                    .collect();
+                let mut values = Vec::with_capacity(field_inits.len());
+                for (name, field) in field_inits {
+                    values.push((
+                        self.name_from_rir(name.into()),
+                        outcome_value!(self.eval(field, env)),
+                    ));
+                }
+                let type_name = self.name_from_rir((*type_name).into());
+                let ty = match host_value!(self.host.resolve_comptime_struct_type(
+                    &self.program_key(),
+                    type_name,
+                    span,
+                )) {
+                    Some(ty) => ty,
+                    None => return ComptimeOutcome::RuntimeDependent,
+                };
+                self.host.resolve_comptime_struct(ty, values, &site)
             }
-
+            InstData::ArrayInit { elements } => {
+                let site = self.diagnostic_site(span);
+                let array_elements = self.program_rir().array_elements(elements).to_vec();
+                let mut values = Vec::with_capacity(array_elements.len());
+                for element in array_elements {
+                    values.push(outcome_value!(self.eval(element, env)));
+                }
+                let Some(ty) = self.host.resolve_comptime_array_type(
+                    &self.program_key(),
+                    env,
+                    inst_ref,
+                    values.first(),
+                    values.len() as u64,
+                ) else {
+                    return ComptimeOutcome::RuntimeDependent;
+                };
+                self.host.resolve_comptime_array(ty, values, &site)
+            }
             // Everything else requires runtime evaluation. The semantic
             // rejection hook lets durable hosts preserve the exact
             // declaration-time reason while ordinary evaluation remains

--- a/crates/rue-air/src/sema/comptime/frames.rs
+++ b/crates/rue-air/src/sema/comptime/frames.rs
@@ -113,6 +113,8 @@ pub enum ComptimeMatchPattern<N> {
         type_name: N,
         variant: N,
         binding_count: usize,
+        /// Names of payload bindings in source order; `None` marks a non-binding element.
+        binding_names: Vec<Option<N>>,
     },
     /// A struct pattern (RUE-2175). Its scrutinee is a struct value, which no
     /// comptime scalar is, so a match containing one is never selected here.
@@ -210,6 +212,15 @@ pub fn decode_comptime_match_pattern<N>(
             type_name: name_from_symbol((*type_name).into()),
             variant: name_from_symbol((*variant).into()),
             binding_count: elements.len(),
+            binding_names: elements
+                .iter()
+                .map(|element| match element {
+                    rue_rir::RirPatternElementView::Binding(symbol) => {
+                        Some(name_from_symbol(symbol.into()))
+                    }
+                    rue_rir::RirPatternElementView::Nested(_) => None,
+                })
+                .collect(),
         },
         rue_rir::RirPatternView::Struct { .. } => ComptimeMatchPattern::Struct,
     }

--- a/crates/rue-air/src/sema/comptime/model.rs
+++ b/crates/rue-air/src/sema/comptime/model.rs
@@ -16,6 +16,37 @@ pub trait ComptimeValue: Clone {
     fn as_boolean(&self) -> Option<bool>;
     fn as_type(&self) -> Option<Self::Type>;
 
+    /// Return the semantic type carried by a reduced value when the host can
+    /// represent it without consulting syntax. This is the type source for
+    /// aggregate construction; contextual hosts may still prefer their
+    /// resolved expression map for untyped literals.
+    fn value_type(&self) -> Option<Self::Type> {
+        self.as_integer_type()
+            .or_else(|| self.as_float_type())
+            .or_else(|| self.as_type())
+    }
+
+    fn aggregate_struct(_ty: Self::Type, _fields: Vec<Self>) -> Option<Self> {
+        None
+    }
+    fn aggregate_array(_ty: Self::Type, _elements: Vec<Self>) -> Option<Self> {
+        None
+    }
+    fn aggregate_enum(_ty: Self::Type, _variant: u32, _payload: Vec<Self>) -> Option<Self> {
+        None
+    }
+
+    /// Borrow the payload of a reduced enum value for match-arm bindings.
+    /// Pattern selection remains in the canonical engine; hosts expose only
+    /// their representation-neutral payload projection.
+    fn aggregate_enum_payload(&self) -> Option<(u32, Vec<Self>)> {
+        None
+    }
+
+    fn aggregate_array_element(&self, _index: usize) -> Option<Self> {
+        None
+    }
+
     /// Whether a reduced value may participate in an anonymous nominal's
     /// captured value substitution.  Semantic domains with lexical handles
     /// (for example modules and target descriptors) can opt out; ordinary

--- a/crates/rue-air/src/sema/comptime/value_domain_tests.rs
+++ b/crates/rue-air/src/sema/comptime/value_domain_tests.rs
@@ -223,7 +223,7 @@ fn engine_decodes_match_patterns_lazily_per_active_program() {
         "the later arm must not be decoded or offered"
     );
     assert_ne!(events[0], events[1], "active program must own symbol names");
-    assert_eq!(MATCH_SYMBOL_CALLS.with(Cell::get), 4);
+    assert_eq!(MATCH_SYMBOL_CALLS.with(Cell::get), 10);
     MATCH_PATTERN_MATCHES.with(|matches| matches.set(false));
 }
 
@@ -667,7 +667,6 @@ fn unary_aggregate_and_unknown_type_intrinsic_use_real_rejection_dispatch() {
                 operation: ComptimeUnaryOperation::BitNot,
                 value: FakeValue::TypedInteger(1, FakeType(99)),
             },
-            ComptimeSemanticRejection::AggregateExpression,
             ComptimeSemanticRejection::UnsupportedIntrinsic("type".to_owned()),
         ]
     );
@@ -1543,15 +1542,16 @@ impl ComptimeValueAlgebra for FakeHost {
         })
     }
     fn match_path_pattern(
-        &self,
+        &mut self,
         pattern: &ComptimeMatchPattern<Self::Name>,
         _value: &Self::Value,
-    ) -> Option<bool> {
+        _site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeHostResult<Option<bool>, Self::Failure> {
         if !MATCH_PATTERN_MATCHES.with(Cell::get) {
-            return None;
+            return Ok(None);
         }
         MATCH_PATTERN_EVENTS.with(|events| events.borrow_mut().push(pattern.clone()));
-        Some(!MATCH_PATTERN_FORCE_FALSE.with(Cell::get))
+        Ok(Some(!MATCH_PATTERN_FORCE_FALSE.with(Cell::get)))
     }
     fn match_no_selected_arm(
         &self,
@@ -2557,11 +2557,6 @@ fn durable_only_instruction_forms_cross_the_semantic_host_boundary() {
         host.dependencies
             .iter()
             .any(|(file, _)| file.index == 0xFFFF_FFFD)
-    );
-    assert!(
-        host.dependencies
-            .iter()
-            .any(|(file, _)| file.index == 0xFFFF_FFFA)
     );
 }
 

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -64,10 +64,13 @@ use super::comptime::{
     ComptimeMethodDescriptor, ComptimeName, ComptimeNamedValueResolution, ComptimeOutcome,
     ComptimeProgramFacts, ComptimeRejections, ComptimeSelection, ComptimeSemanticRejection,
     ComptimeStructuredTypeResolution, ComptimeStructuredTypes, ComptimeTrap, ComptimeType,
-    ComptimeTypeAlgebra, ComptimeValueAlgebra, comptime_arithmetic_overflow_reason,
+    ComptimeTypeAlgebra, ComptimeValue, ComptimeValueAlgebra, comptime_arithmetic_overflow_reason,
     comptime_untyped_integer_result,
 };
-use super::context::{AnalysisContext, CheckedConstIndexCandidate, ConstValue};
+use super::context::{
+    AnalysisContext, CheckedConstIndexCandidate, ConstAggregate, ConstAggregateKind, ConstValue,
+    comptime_aggregate, register_comptime_aggregate,
+};
 use super::info::FunctionCallInfo;
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 
@@ -159,6 +162,7 @@ fn update_checked_const_index_test_stats(update: impl FnOnce(&mut CheckedConstIn
 /// engine must not replay already validated arguments.
 pub struct OrdinaryComptimeCallBinding {
     parameter_names: Vec<Spur>,
+    parameter_types: Vec<Type>,
     parameter_is_type: Vec<bool>,
     arguments: Vec<ConstValue>,
 }
@@ -239,6 +243,52 @@ impl super::comptime::ComptimeValue for ConstValue {
             Self::Type(value) => Some(*value),
             _ => None,
         }
+    }
+    fn value_type(&self) -> Option<Type> {
+        match self {
+            ConstValue::Integer(_) => Some(self.get_type()),
+            ConstValue::Bool(_) => Some(Type::BOOL),
+            ConstValue::Type(_) | ConstValue::Function(_) => Some(Type::COMPTIME_TYPE),
+            ConstValue::Float(_) => Some(Type::COMPTIME_FLOAT),
+            ConstValue::Aggregate(aggregate) => Some(aggregate.ty),
+            ConstValue::Unit => Some(Type::UNIT),
+            ConstValue::String(_) => None,
+        }
+    }
+    fn aggregate_struct(ty: Type, fields: Vec<Self>) -> Option<Self> {
+        register_comptime_aggregate(ConstAggregate {
+            ty,
+            kind: ConstAggregateKind::Struct(fields.into()),
+        })
+    }
+    fn aggregate_array(ty: Type, elements: Vec<Self>) -> Option<Self> {
+        register_comptime_aggregate(ConstAggregate {
+            ty,
+            kind: ConstAggregateKind::Array(elements.into()),
+        })
+    }
+    fn aggregate_enum(ty: Type, variant: u32, payload: Vec<Self>) -> Option<Self> {
+        register_comptime_aggregate(ConstAggregate {
+            ty,
+            kind: ConstAggregateKind::Enum {
+                variant,
+                payload: payload.into(),
+            },
+        })
+    }
+    fn aggregate_enum_payload(&self) -> Option<(u32, Vec<Self>)> {
+        let aggregate = comptime_aggregate(self.clone())?;
+        let ConstAggregateKind::Enum { variant, payload } = &aggregate.kind else {
+            return None;
+        };
+        Some((*variant, payload.to_vec()))
+    }
+    fn aggregate_array_element(&self, index: usize) -> Option<Self> {
+        let aggregate = comptime_aggregate(self.clone())?;
+        let ConstAggregateKind::Array(values) = &aggregate.kind else {
+            return None;
+        };
+        values.get(index).cloned()
     }
 }
 
@@ -869,12 +919,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
     }
 
-    /// The resolved integer type of an expression, when known.
+    /// The resolved type of an expression, when known. Aggregate literals use
+    /// the same query-backed type map as scalar literals so the shared engine
+    /// can construct one typed structural value.
     fn const_expr_type(&self, env: &ComptimeEnv, inst_ref: InstRef) -> Option<Type> {
-        env.resolved_types?
-            .get(&inst_ref)
-            .copied()
-            .filter(Type::is_integer)
+        env.resolved_types?.get(&inst_ref).copied()
     }
 
     /// Finish an arithmetic operation using the kernel's typed result and its
@@ -965,7 +1014,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if type_flags[index] {
                 type_arguments.push(*type_bindings.get(parameter)?);
             } else {
-                value_arguments.push(*value_bindings.get(parameter)?);
+                value_arguments.push(value_bindings.get(parameter)?.clone());
             }
         }
         let key = ComptimeCallKey {
@@ -1013,7 +1062,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     &frame.value_bindings,
                 )
             {
-                self.memoize_comptime_reduction(key, *value);
+                self.memoize_comptime_reduction(key, value.clone());
             }
         }
         result
@@ -1488,6 +1537,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let param_data = self.body_param_data(admission.payload.params);
         Ok(OrdinaryComptimeCallBinding {
             parameter_names: param_data.names().to_vec(),
+            parameter_types: param_data.types().to_vec(),
             parameter_is_type: self.comptime_type_param_flags(&admission.payload),
             arguments: Vec::with_capacity(_argument_count),
         })
@@ -1505,7 +1555,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // let it mask a later child trap/abort.
         Ok(push_ordinary_comptime_call_argument(
             binding,
-            *argument.value(),
+            argument.value().clone(),
         ))
     }
 
@@ -1579,6 +1629,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         expected: Type,
         span: Span,
     ) -> CompileResult<()> {
+        if matches!(value, ConstValue::Aggregate(_))
+            && !expected.is_copy_in_pool(self.body_type_pool())
+        {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "structural comptime values require a Copy type".to_owned(),
+                },
+                span,
+            ));
+        }
+        if matches!(value, ConstValue::Aggregate(_)) {
+            return self.validate_comptime_aggregate_value(&value, expected, 0, &mut 0, span);
+        }
         let string_type = Some(self.get_or_create_str_struct(span)?);
         validate_comptime_value_for_type_impl(
             self.body_interner(),
@@ -1591,6 +1654,156 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             string_type,
             |ty| self.is_str_struct(ty),
         )
+    }
+
+    /// Validate a structural argument against the complete local type shape
+    /// before the comptime call is reduced.  Aggregate handles are opaque,
+    /// so checking only their outer `Type` would admit malformed field counts,
+    /// nested ranges, or a value whose nominal type is not Copy.
+    fn validate_comptime_aggregate_value(
+        &mut self,
+        value: &ConstValue,
+        expected: Type,
+        depth: usize,
+        nodes: &mut usize,
+        span: Span,
+    ) -> CompileResult<()> {
+        if depth > crate::MAX_COMPTIME_VALUE_DEPTH {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "structural comptime value exceeds resource limits".to_owned(),
+                },
+                span,
+            ));
+        }
+        *nodes = nodes.saturating_add(1);
+        if *nodes > crate::sema::MAX_COMPTIME_AGGREGATE_NODES {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "structural comptime value exceeds resource limits".to_owned(),
+                },
+                span,
+            ));
+        }
+        let ConstValue::Aggregate(aggregate) = value else {
+            let valid = match value {
+                ConstValue::Integer(value) => expected
+                    .integer_semantics()
+                    .is_some_and(|semantics| semantics.fits_i128(*value)),
+                ConstValue::Bool(_) => expected == Type::BOOL,
+                ConstValue::Unit => expected == Type::UNIT,
+                ConstValue::Type(_) => expected == Type::COMPTIME_TYPE,
+                ConstValue::Float(_) => expected.is_float(),
+                ConstValue::String(_) => self.is_str_struct(expected),
+                ConstValue::Function(_) => false,
+                ConstValue::Aggregate(_) => unreachable!(),
+            };
+            if valid {
+                return Ok(());
+            }
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: self.format_type_name(expected),
+                    found: value.get_type().name().to_owned(),
+                },
+                span,
+            ));
+        };
+        if aggregate.ty != expected {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: self.format_type_name(expected),
+                    found: self.format_type_name(aggregate.ty),
+                },
+                span,
+            ));
+        }
+        if !expected.is_copy_in_pool(self.body_type_pool()) {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "structural comptime values require a Copy type".to_owned(),
+                },
+                span,
+            ));
+        }
+        match (&aggregate.kind, expected.kind()) {
+            (ConstAggregateKind::Struct(values), TypeKind::Struct(id)) => {
+                let fields = self.body_type_pool().struct_def(id).fields.clone();
+                if values.len() != fields.len() {
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: "structural comptime value has the wrong field count"
+                                .to_owned(),
+                        },
+                        span,
+                    ));
+                }
+                for (child, field) in values.iter().zip(fields.iter()) {
+                    self.validate_comptime_aggregate_value(
+                        child,
+                        field.ty,
+                        depth + 1,
+                        nodes,
+                        span,
+                    )?;
+                }
+            }
+            (ConstAggregateKind::Array(values), TypeKind::Array(id)) => {
+                let (element, length) = self.body_type_pool().array_def(id);
+                if values.len() as u64 != length {
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: "structural comptime value has the wrong array length"
+                                .to_owned(),
+                        },
+                        span,
+                    ));
+                }
+                for child in values.iter() {
+                    self.validate_comptime_aggregate_value(child, element, depth + 1, nodes, span)?;
+                }
+            }
+            (ConstAggregateKind::Enum { variant, payload }, TypeKind::Enum(id)) => {
+                let definition = self.body_type_pool().enum_def(id);
+                if *variant as usize >= definition.variant_count() {
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: "structural comptime value has an invalid enum variant"
+                                .to_owned(),
+                        },
+                        span,
+                    ));
+                }
+                let payload_types = definition.variant_payload(*variant as usize).to_vec();
+                if payload.len() != payload_types.len() {
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: "structural comptime value has the wrong enum payload length"
+                                .to_owned(),
+                        },
+                        span,
+                    ));
+                }
+                for (child, child_type) in payload.iter().zip(payload_types.iter()) {
+                    self.validate_comptime_aggregate_value(
+                        child,
+                        *child_type,
+                        depth + 1,
+                        nodes,
+                        span,
+                    )?;
+                }
+            }
+            _ => {
+                return Err(CompileError::new(
+                    ErrorKind::ComptimeEvaluationFailed {
+                        reason: "structural comptime value kind does not match its type".to_owned(),
+                    },
+                    span,
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Validate the complete comptime argument contract at the shared
@@ -1656,7 +1869,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }
                 continue;
             }
-            let value = callee_values.get(name).copied().ok_or_else(|| {
+            let value = callee_values.get(name).cloned().ok_or_else(|| {
                 CompileError::new(
                     ErrorKind::InternalError(format!(
                         "comptime value argument for '{}' is missing while reducing '{}'",
@@ -2573,6 +2786,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeTypeAlgebra for OrdinaryBodyEngine
     fn type_name(&self, ty: &Type) -> String {
         self.format_type_name(*ty)
     }
+    fn type_is_enum(&self, ty: &Type) -> bool {
+        ty.is_enum()
+    }
     fn type_is_unsigned(&self, ty: &Type) -> bool {
         ty.is_unsigned()
     }
@@ -2640,6 +2856,81 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeTypeAlgebra for OrdinaryBodyEngine
 }
 
 impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeValueAlgebra for OrdinaryBodyEngine<'h, H> {
+    fn resolve_comptime_struct(
+        &mut self,
+        ty: Type,
+        fields: Vec<(Spur, ConstValue)>,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeOutcome<ConstValue, Self::Failure> {
+        if !ty.is_copy_in_pool(self.body_type_pool()) {
+            return ComptimeOutcome::HostFailure(comptime_panic_err(
+                "structural comptime values require a Copy type".to_owned(),
+                site.span(),
+            ));
+        }
+        let TypeKind::Struct(struct_id) = ty.kind() else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        let definition = self.body_type_pool().struct_def(struct_id);
+        let mut ordered = vec![None; definition.fields.len()];
+        for (name, value) in fields {
+            let Some((index, _)) = definition.find_field(self.body_interner().resolve(&name))
+            else {
+                return ComptimeOutcome::RuntimeDependent;
+            };
+            if ordered[index].replace(value).is_some() {
+                return ComptimeOutcome::RuntimeDependent;
+            }
+        }
+        let Some(ordered) = ordered.into_iter().collect::<Option<Vec<_>>>() else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        ConstValue::aggregate_struct(ty, ordered)
+            .map_or(ComptimeOutcome::RuntimeDependent, ComptimeOutcome::Known)
+    }
+    fn resolve_comptime_array(
+        &mut self,
+        ty: Type,
+        elements: Vec<ConstValue>,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeOutcome<ConstValue, Self::Failure> {
+        if !ty.is_copy_in_pool(self.body_type_pool()) {
+            return ComptimeOutcome::HostFailure(comptime_panic_err(
+                "structural comptime values require a Copy type".to_owned(),
+                site.span(),
+            ));
+        }
+        ConstValue::aggregate_array(ty, elements)
+            .map_or(ComptimeOutcome::RuntimeDependent, ComptimeOutcome::Known)
+    }
+    fn resolve_comptime_array_repeat(
+        &mut self,
+        ty: Type,
+        element: ConstValue,
+        count: u64,
+        site: &ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeOutcome<ConstValue, Self::Failure> {
+        let Ok(count) = usize::try_from(count) else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        if !ty.is_copy_in_pool(self.body_type_pool()) {
+            return ComptimeOutcome::HostFailure(comptime_panic_err(
+                "structural comptime values require a Copy type".to_owned(),
+                site.span(),
+            ));
+        }
+        // The repeated elements are wrapped in one array aggregate node, so
+        // the largest scalar repeat that fits the shared budget is 4095.
+        if count >= crate::sema::MAX_COMPTIME_AGGREGATE_NODES {
+            return ComptimeOutcome::HostFailure(comptime_panic_err(
+                "structural comptime value exceeds resource limits".to_owned(),
+                site.span(),
+            ));
+        }
+        ConstValue::aggregate_array(ty, vec![element; count])
+            .map_or(ComptimeOutcome::RuntimeDependent, ComptimeOutcome::Known)
+    }
+
     fn resolve_comptime_named_value(
         &mut self,
         file: Self::File,
@@ -2703,12 +2994,199 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeValueAlgebra for OrdinaryBodyEngin
             ConstValue::Type(value) => Some(ConstValue::Type(value)),
             ConstValue::String(value) => Some(ConstValue::String(value)),
             ConstValue::Float(value) => Some(ConstValue::Float(value)),
+            ConstValue::Aggregate(_) => Some(info.value),
             _ => None,
         };
         Ok(match value {
             Some(value) => ComptimeNamedValueResolution::Known(value),
             None => ComptimeNamedValueResolution::RuntimeDependent,
         })
+    }
+    fn match_path_pattern(
+        &mut self,
+        pattern: &super::comptime::ComptimeMatchPattern<Spur>,
+        value: &ConstValue,
+        site: &super::comptime::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> ComptimeHostResult<Option<bool>, Self::Failure> {
+        let super::comptime::ComptimeMatchPattern::Path {
+            type_name, variant, ..
+        } = pattern
+        else {
+            return Ok(None);
+        };
+        let Some(aggregate) = comptime_aggregate(value.clone()) else {
+            return Ok(None);
+        };
+        let ConstAggregateKind::Enum { variant: index, .. } = &aggregate.kind else {
+            return Ok(Some(false));
+        };
+        let TypeKind::Enum(enum_id) = aggregate.ty.kind() else {
+            return Ok(Some(false));
+        };
+        // Resolve the pattern head through the ordinary type authority. This
+        // preserves aliases and avoids treating a declaration's display name
+        // as its nominal identity.
+        let Some(pattern_ty) =
+            OrdinaryBodyEngine::resolve_named_type_value(self, *type_name, site.span())?
+        else {
+            return Ok(Some(false));
+        };
+        if pattern_ty != aggregate.ty {
+            return Ok(Some(false));
+        }
+        let enum_def = self.body_type_pool().enum_def(enum_id);
+        Ok(Some(enum_def.variants.get(*index as usize).is_some_and(
+            |name| name.as_ref() == self.body_interner().resolve(variant),
+        )))
+    }
+    fn resolve_comptime_enum_variant(
+        &mut self,
+        _module: Option<ConstValue>,
+        type_name: Spur,
+        variant: Spur,
+        site: &super::comptime::ComptimeSite<Self::ProgramKey>,
+        span: Span,
+    ) -> ComptimeOutcome<ConstValue, Self::Failure> {
+        let Some(ty) = (match OrdinaryBodyEngine::resolve_named_type_value(self, type_name, span) {
+            Ok(value) => value,
+            Err(error) => return ComptimeOutcome::HostFailure(error),
+        }) else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        if !ty.is_copy_in_pool(self.body_type_pool()) {
+            return ComptimeOutcome::HostFailure(comptime_panic_err(
+                "structural comptime values require a Copy type".to_owned(),
+                site.span(),
+            ));
+        }
+        let TypeKind::Enum(enum_id) = ty.kind() else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        let enum_def = self.body_type_pool().enum_def(enum_id);
+        let Some(index) = enum_def.find_variant(self.body_interner().resolve(&variant)) else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        ConstValue::aggregate_enum(ty, index as u32, Vec::new())
+            .map_or(ComptimeOutcome::RuntimeDependent, ComptimeOutcome::Known)
+    }
+    fn resolve_comptime_enum_variant_with_payload(
+        &mut self,
+        ty: Type,
+        variant: Spur,
+        payload: Vec<ConstValue>,
+        site: &super::comptime::ComptimeSite<Self::ProgramKey>,
+        _span: Span,
+    ) -> ComptimeOutcome<ConstValue, Self::Failure> {
+        if !ty.is_copy_in_pool(self.body_type_pool()) {
+            return ComptimeOutcome::HostFailure(comptime_panic_err(
+                "structural comptime values require a Copy type".to_owned(),
+                site.span(),
+            ));
+        }
+        let TypeKind::Enum(enum_id) = ty.kind() else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        let enum_def = self.body_type_pool().enum_def(enum_id);
+        let Some(index) = enum_def.find_variant(self.body_interner().resolve(&variant)) else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        ConstValue::aggregate_enum(ty, index as u32, payload)
+            .map_or(ComptimeOutcome::RuntimeDependent, ComptimeOutcome::Known)
+    }
+    fn admit_comptime_enum_variant(
+        &mut self,
+        type_name: Spur,
+        variant: Spur,
+        _has_module: bool,
+        _site: &super::comptime::ComptimeSite<Self::ProgramKey>,
+    ) -> ComptimeHostResult<bool, Self::Failure> {
+        let Some(ty) =
+            OrdinaryBodyEngine::resolve_named_type_value(self, type_name, Span::new(0, 0))
+                .map_err(ComptimeHostError::HostFailure)?
+        else {
+            return Ok(false);
+        };
+        let TypeKind::Enum(enum_id) = ty.kind() else {
+            return Ok(false);
+        };
+        Ok(self
+            .body_type_pool()
+            .enum_def(enum_id)
+            .find_variant(self.body_interner().resolve(&variant))
+            .is_some())
+    }
+    fn admit_comptime_member(
+        &mut self,
+        _field: Spur,
+        _site: &super::comptime::ComptimeSite<Self::ProgramKey>,
+    ) -> ComptimeHostResult<bool, Self::Failure> {
+        Ok(true)
+    }
+    fn resolve_comptime_member(
+        &mut self,
+        base: ConstValue,
+        field: Spur,
+        site: &super::comptime::ComptimeSite<Self::ProgramKey>,
+        _span: Span,
+    ) -> ComptimeOutcome<ConstValue, Self::Failure> {
+        if let ConstValue::Type(ty) = base {
+            if !ty.is_copy_in_pool(self.body_type_pool()) {
+                return ComptimeOutcome::HostFailure(comptime_panic_err(
+                    "structural comptime values require a Copy type".to_owned(),
+                    site.span(),
+                ));
+            }
+            let TypeKind::Enum(enum_id) = ty.kind() else {
+                return ComptimeOutcome::RuntimeDependent;
+            };
+            let Some(index) = self
+                .body_type_pool()
+                .enum_def(enum_id)
+                .find_variant(self.body_interner().resolve(&field))
+            else {
+                return ComptimeOutcome::RuntimeDependent;
+            };
+            // A payload-carrying variant is a constructor call, not a
+            // nullary member value.  Do not manufacture an empty payload and
+            // let a later projection treat it as a complete enum value.
+            if !self
+                .body_type_pool()
+                .enum_def(enum_id)
+                .variant_payload(index)
+                .is_empty()
+            {
+                return ComptimeOutcome::HostFailure(CompileError::new(
+                    ErrorKind::WrongArgumentCount {
+                        expected: self
+                            .body_type_pool()
+                            .enum_def(enum_id)
+                            .variant_payload(index)
+                            .len(),
+                        found: 0,
+                    },
+                    site.span(),
+                ));
+            }
+            return ConstValue::aggregate_enum(ty, index as u32, Vec::new())
+                .map_or(ComptimeOutcome::RuntimeDependent, ComptimeOutcome::Known);
+        }
+        let Some(aggregate) = comptime_aggregate(base) else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        let ConstAggregateKind::Struct(values) = &aggregate.kind else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        let TypeKind::Struct(struct_id) = aggregate.ty.kind() else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        let name = self.body_interner().resolve(&field);
+        let Some((index, _)) = self.body_type_pool().struct_def(struct_id).find_field(name) else {
+            return ComptimeOutcome::RuntimeDependent;
+        };
+        values
+            .get(index)
+            .cloned()
+            .map_or(ComptimeOutcome::RuntimeDependent, ComptimeOutcome::Known)
     }
     // The ordinary body value domain has no enum-shaped value, so every
     // path pattern stays undecidable here; the engine decides the scalar
@@ -2824,6 +3302,13 @@ impl<'h, H: OrdinaryBodyAnalysisHost> ComptimeCallProtocol for OrdinaryBodyEngin
     ) -> ComptimeHostResult<bool, Self::Failure> {
         OrdinaryBodyEngine::bind_comptime_call_argument(self, binding, argument, index, span)
             .map_err(Into::into)
+    }
+    fn comptime_call_argument_type(
+        &self,
+        binding: &Self::CallBinding,
+        index: usize,
+    ) -> Option<Type> {
+        binding.parameter_types.get(index).copied()
     }
     fn finish_comptime_call_binding(
         &mut self,
@@ -3111,6 +3596,7 @@ mod binding_tests {
             type_name,
             variant,
             binding_count: 0,
+            binding_names: Vec::new(),
         };
         assert_eq!(
             comptime_scalar_pattern_decision(
@@ -3153,6 +3639,7 @@ mod binding_tests {
         let later_name = interner.get_or_intern("later");
         let mut binding = OrdinaryComptimeCallBinding {
             parameter_names: vec![value_name, later_name],
+            parameter_types: vec![Type::I32, Type::I32],
             parameter_is_type: vec![true, false],
             arguments: Vec::new(),
         };

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -915,7 +915,7 @@ impl AnalysisResult {
 /// This is used for compile-time evaluation of expressions and for
 /// comptime parameters. For example, in `fn Buffer(comptime N: i32)`,
 /// the value of `N` is stored as a `ConstValue::Integer`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ConstValue {
     /// Integer value. Backed by `i128` so the full range of every Rue integer
     /// type is representable (u64 values above `i64::MAX` as well as negative
@@ -949,8 +949,90 @@ pub enum ConstValue {
     String(SymbolHandle),
     /// Exact canonical decimal value, interned as `<significand>e<exponent>`.
     Float(SymbolHandle),
+    /// A bounded structural value used by the canonical comptime evaluator.
+    Aggregate(Arc<ConstAggregate>),
     /// Unit value - the value of `()`.
     Unit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ConstAggregateKind {
+    Struct(Arc<[ConstValue]>),
+    Array(Arc<[ConstValue]>),
+    Enum {
+        variant: u32,
+        payload: Arc<[ConstValue]>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConstAggregate {
+    pub ty: Type,
+    pub kind: ConstAggregateKind,
+}
+
+pub(crate) const MAX_COMPTIME_AGGREGATE_DEPTH: usize = 64;
+pub(crate) const MAX_COMPTIME_AGGREGATE_NODES: usize = 4096;
+
+fn aggregate_size(value: &ConstValue, depth: usize, nodes: &mut usize) -> Option<usize> {
+    if depth > MAX_COMPTIME_AGGREGATE_DEPTH {
+        return None;
+    }
+    *nodes = nodes.checked_add(1)?;
+    if *nodes > MAX_COMPTIME_AGGREGATE_NODES {
+        return None;
+    }
+    let ConstValue::Aggregate(aggregate) = value else {
+        return Some(1);
+    };
+    let children = match &aggregate.kind {
+        ConstAggregateKind::Struct(values) | ConstAggregateKind::Array(values) => values,
+        ConstAggregateKind::Enum { payload, .. } => payload,
+    };
+    children.iter().try_fold(1usize, |total, child| {
+        total.checked_add(aggregate_size(child, depth + 1, nodes)?)
+    })
+}
+
+/// Check a retained comptime value before a consumer expands its children.
+/// Aggregate registration already uses this walk; exposing the same bounded
+/// predicate lets AIR materialization protect itself from forged or stale
+/// retained values without allocating a second tree.
+pub(crate) fn comptime_value_within_limits(value: &ConstValue) -> bool {
+    aggregate_size(value, 0, &mut 0).is_some()
+}
+
+/// Register one aggregate after checking the shared resource bounds. The
+/// handle is deliberately opaque and never used as a published identity.
+pub fn register_comptime_aggregate(value: ConstAggregate) -> Option<ConstValue> {
+    let type_matches_kind = match &value.kind {
+        ConstAggregateKind::Struct(_) => value.ty.is_struct(),
+        ConstAggregateKind::Array(_) => value.ty.is_array(),
+        ConstAggregateKind::Enum { .. } => value.ty.is_enum(),
+    };
+    if !type_matches_kind {
+        return None;
+    }
+    let value = Arc::new(value);
+    let children = match &value.kind {
+        ConstAggregateKind::Struct(values) | ConstAggregateKind::Array(values) => values,
+        ConstAggregateKind::Enum { payload, .. } => payload,
+    };
+    let mut nodes = 1;
+    for child in children.iter() {
+        aggregate_size(child, 1, &mut nodes)?;
+    }
+    if nodes > MAX_COMPTIME_AGGREGATE_NODES {
+        return None;
+    }
+    Some(ConstValue::Aggregate(value))
+}
+
+pub fn comptime_aggregate(value: ConstValue) -> Option<Arc<ConstAggregate>> {
+    let ConstValue::Aggregate(aggregate) = value else {
+        return None;
+    };
+    Some(aggregate)
 }
 
 impl ConstValue {
@@ -961,47 +1043,47 @@ impl ConstValue {
     /// when the full `i128` backing value is needed.
     ///
     /// [`as_int_value`]: ConstValue::as_int_value
-    pub fn as_integer(self) -> Option<i64> {
+    pub fn as_integer(&self) -> Option<i64> {
         match self {
-            ConstValue::Integer(n) => i64::try_from(n).ok(),
+            ConstValue::Integer(n) => i64::try_from(*n).ok(),
             _ => None,
         }
     }
 
     /// Try to extract the full backing integer value.
-    pub fn as_int_value(self) -> Option<i128> {
+    pub fn as_int_value(&self) -> Option<i128> {
         match self {
-            ConstValue::Integer(n) => Some(n),
+            ConstValue::Integer(n) => Some(*n),
             _ => None,
         }
     }
 
     /// Try to extract a boolean value.
-    pub fn as_bool(self) -> Option<bool> {
+    pub fn as_bool(&self) -> Option<bool> {
         match self {
-            ConstValue::Bool(b) => Some(b),
+            ConstValue::Bool(b) => Some(*b),
             _ => None,
         }
     }
 
     /// Try to extract a type value.
-    pub fn as_type(self) -> Option<Type> {
+    pub fn as_type(&self) -> Option<Type> {
         match self {
-            ConstValue::Type(ty) => Some(ty),
+            ConstValue::Type(ty) => Some(*ty),
             _ => None,
         }
     }
 
     /// Try to extract a function reference.
-    pub fn as_function(self) -> Option<SymbolHandle> {
+    pub fn as_function(&self) -> Option<SymbolHandle> {
         match self {
-            ConstValue::Function(name) => Some(name),
+            ConstValue::Function(name) => Some(*name),
             _ => None,
         }
     }
 
     /// Check if this is a unit value.
-    pub fn is_unit(self) -> bool {
+    pub fn is_unit(&self) -> bool {
         matches!(self, ConstValue::Unit)
     }
 
@@ -1019,6 +1101,7 @@ impl ConstValue {
             // avoid colliding with a real comptime parameter type.
             ConstValue::String(_) => Type::ERROR,
             ConstValue::Float(_) => Type::COMPTIME_FLOAT,
+            ConstValue::Aggregate(aggregate) => aggregate.ty,
             ConstValue::Unit => Type::UNIT,
         }
     }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -92,6 +92,9 @@ pub use comptime::{
     comptime_depth_exceeded_reason, comptime_depth_over_limit, next_comptime_depth,
 };
 pub use context::ConstValue;
+pub(crate) use context::{
+    ConstAggregate, ConstAggregateKind, MAX_COMPTIME_AGGREGATE_NODES, register_comptime_aggregate,
+};
 pub use declaration_index::RirDeclarationIndexWork;
 pub(crate) use fact_mode::StructuredTypeSyntax;
 pub(crate) use inference_ctx::HostInferenceFacts;

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -637,7 +637,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             ComptimeCallMemoLookup::Memoized(ComptimeMemoizedOutcome::Known(value)) => {
                 #[cfg(test)]
                 update_comptime_reduction_test_stats(|stats| stats.hits += 1);
-                Some(*value)
+                Some(value.clone())
             }
             ComptimeCallMemoLookup::Memoized(_) | ComptimeCallMemoLookup::Miss => None,
         }
@@ -653,7 +653,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         // same frame, so retain the first successful result deterministically.
         let insertion = self
             .comptime_reduction_memo
-            .insert(key, ComptimeMemoizedOutcome::Known(value))
+            .insert(key, ComptimeMemoizedOutcome::Known(value.clone()))
             .is_ok();
         #[cfg(test)]
         if insertion {
@@ -1203,7 +1203,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 .into(),
             values: value_args
                 .iter()
-                .copied()
+                .cloned()
                 .map(|value| self.storage.canonical_argument_value(value))
                 .collect::<Result<Vec<_>, _>>()?
                 .into(),
@@ -1463,9 +1463,13 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                     *tys.get(param_name).ok_or(F::MissingStableIdentity)?,
                 )?);
             } else {
-                values.push(self.storage.canonical_argument_value(
-                    *vals.get(param_name).ok_or(F::MissingStableIdentity)?,
-                )?);
+                values.push(
+                    self.storage.canonical_argument_value(
+                        vals.get(param_name)
+                            .ok_or(F::MissingStableIdentity)?
+                            .clone(),
+                    )?,
+                );
             }
         }
         let arguments = IssuedCanonicalArguments {

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4242,7 +4242,7 @@ where
             let Some(value) = self.durable_value_from_concrete(value.clone()) else {
                 return Ok(None);
             };
-            durable_values.push((Arc::from(self.interner.resolve(&name)), value));
+            durable_values.push((Arc::from(self.interner.resolve(name)), value));
         }
         let reduced =
             match self

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -2349,7 +2349,7 @@ where
                 identity,
             )),
             ConstValue::Type(resolved),
-        ) = (&constant.value, info.value)
+        ) = (&constant.value, info.value.clone())
         {
             self.register_provider_anonymous_method_endpoints(identity, resolved)?;
         }
@@ -2893,6 +2893,40 @@ where
                 V::String(Arc::from(self.interner.resolve(&symbol.spur())))
             }
             ConstValue::Float(symbol) => V::Float(Arc::from(self.interner.resolve(&symbol.spur()))),
+            ConstValue::Aggregate(aggregate) => {
+                let ty = self.durable_type_from_concrete(aggregate.ty)?;
+                let kind = match &aggregate.kind {
+                    crate::sema::ConstAggregateKind::Struct(values) => {
+                        crate::SemanticImportAggregateKind::Struct(
+                            values
+                                .iter()
+                                .map(|v| self.durable_value_from_concrete(v.clone()))
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        )
+                    }
+                    crate::sema::ConstAggregateKind::Array(values) => {
+                        crate::SemanticImportAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(|v| self.durable_value_from_concrete(v.clone()))
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        )
+                    }
+                    crate::sema::ConstAggregateKind::Enum { variant, payload } => {
+                        crate::SemanticImportAggregateKind::Enum {
+                            variant: *variant,
+                            payload: payload
+                                .iter()
+                                .map(|v| self.durable_value_from_concrete(v.clone()))
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        }
+                    }
+                };
+                V::Aggregate(Arc::new(crate::SemanticImportAggregate { ty, kind }))
+            }
         })
     }
 
@@ -2915,6 +2949,11 @@ where
         value: &crate::SemanticImportConstValue<K, M>,
     ) -> Option<ConstValue> {
         use crate::SemanticImportConstValue as V;
+        if matches!(value, V::Aggregate(_))
+            && !crate::semantic_import_const_value_within_limits(value)
+        {
+            return None;
+        }
         Some(match value {
             V::Integer(value) => ConstValue::Integer(*value),
             V::Bool(value) => ConstValue::Bool(*value),
@@ -2926,6 +2965,40 @@ where
             V::Unit => ConstValue::Unit,
             V::String(value) => ConstValue::String(self.intern_name(value.as_ref())?.into()),
             V::Float(value) => ConstValue::Float(self.intern_name(value.as_ref())?.into()),
+            V::Aggregate(value) => {
+                let ty = self.materialize_durable_type(&value.ty)?;
+                let kind = match &value.kind {
+                    crate::SemanticImportAggregateKind::Struct(values) => {
+                        crate::sema::ConstAggregateKind::Struct(
+                            values
+                                .iter()
+                                .map(|v| self.materialize_durable_const_value(v))
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        )
+                    }
+                    crate::SemanticImportAggregateKind::Array(values) => {
+                        crate::sema::ConstAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(|v| self.materialize_durable_const_value(v))
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        )
+                    }
+                    crate::SemanticImportAggregateKind::Enum { variant, payload } => {
+                        crate::sema::ConstAggregateKind::Enum {
+                            variant: *variant,
+                            payload: payload
+                                .iter()
+                                .map(|v| self.materialize_durable_const_value(v))
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        }
+                    }
+                };
+                crate::sema::register_comptime_aggregate(crate::sema::ConstAggregate { ty, kind })?
+            }
         })
     }
 
@@ -3071,7 +3144,7 @@ where
                         .map(|(name, value)| {
                             Ok((
                                 Arc::from(self.interner.resolve(name)),
-                                self.canonical_argument_value(*value)?,
+                                self.canonical_argument_value(value.clone())?,
                             ))
                         })
                         .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
@@ -3423,6 +3496,19 @@ where
         &mut self,
         value: &CanonicalArgumentValue<K, M>,
     ) -> Result<ConstValue, crate::SemanticBodyExportFailure> {
+        // Canonical arguments can arrive from another query epoch. Reject
+        // excessive values before resolving types, interning strings, or
+        // recursively allocating local children.
+        if !value.within_resource_limits() {
+            return Err(crate::SemanticBodyExportFailure::MissingStableIdentity);
+        }
+        self.materialize_bounded_argument_value(value)
+    }
+
+    fn materialize_bounded_argument_value(
+        &mut self,
+        value: &CanonicalArgumentValue<K, M>,
+    ) -> Result<ConstValue, crate::SemanticBodyExportFailure> {
         Ok(match value {
             CanonicalArgumentValue::Integer(value) => ConstValue::Integer(*value),
             CanonicalArgumentValue::Bool(value) => ConstValue::Bool(*value),
@@ -3459,6 +3545,41 @@ where
                     .borrow_mut()
                     .insert(symbol, (token, definition.clone()));
                 ConstValue::Function(symbol.into())
+            }
+            CanonicalArgumentValue::Aggregate(value) => {
+                let ty = self.materialize_type_instance(&value.ty)?;
+                let kind = match &value.kind {
+                    crate::CanonicalAggregateKind::Struct(values) => {
+                        crate::sema::ConstAggregateKind::Struct(
+                            values
+                                .iter()
+                                .map(|v| self.materialize_bounded_argument_value(v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        )
+                    }
+                    crate::CanonicalAggregateKind::Array(values) => {
+                        crate::sema::ConstAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(|v| self.materialize_bounded_argument_value(v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        )
+                    }
+                    crate::CanonicalAggregateKind::Enum { variant, payload } => {
+                        crate::sema::ConstAggregateKind::Enum {
+                            variant: *variant,
+                            payload: payload
+                                .iter()
+                                .map(|v| self.materialize_bounded_argument_value(v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        }
+                    }
+                };
+                crate::sema::register_comptime_aggregate(crate::sema::ConstAggregate { ty, kind })
+                    .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?
             }
         })
     }
@@ -4117,8 +4238,8 @@ where
             durable_types.push((Arc::from(self.interner.resolve(&name)), value));
         }
         let mut durable_values = Vec::with_capacity(value_arguments.len());
-        for &(name, value) in value_arguments {
-            let Some(value) = self.durable_value_from_concrete(value) else {
+        for (name, value) in value_arguments {
+            let Some(value) = self.durable_value_from_concrete(value.clone()) else {
                 return Ok(None);
             };
             durable_values.push((Arc::from(self.interner.resolve(&name)), value));
@@ -4145,8 +4266,8 @@ where
         };
         let materialized = self.materialize_durable_const_value(&value);
         if let Some(ConstValue::Type(ty)) = materialized.as_ref() {
-            let type_arguments = type_arguments.iter().copied().collect();
-            let value_arguments = value_arguments.iter().copied().collect();
+            let type_arguments = type_arguments.iter().cloned().collect();
+            let value_arguments = value_arguments.iter().cloned().collect();
             OrdinaryBodyEngine::new(self).record_ctor_type_display(
                 head.key,
                 *ty,
@@ -5036,7 +5157,7 @@ where
                         })
                         .map(|parameter| {
                             let symbol = self.interner.get(parameter.name.as_ref())?;
-                            self.canonical_argument_value(*callee_values.get(&symbol)?)
+                            self.canonical_argument_value(callee_values.get(&symbol)?.clone())
                                 .ok()
                         })
                         .collect::<Option<Vec<_>>>()?
@@ -5487,6 +5608,41 @@ where
                 CanonicalArgumentValue::Float(self.interner.resolve(&symbol.spur()).into())
             }
             ConstValue::Unit => CanonicalArgumentValue::Unit,
+            ConstValue::Aggregate(aggregate) => {
+                CanonicalArgumentValue::Aggregate(Node::new(crate::CanonicalAggregateValue {
+                    ty: Node::new(self.canonical_type_instance(aggregate.ty)?),
+                    kind: match &aggregate.kind {
+                        crate::sema::ConstAggregateKind::Struct(values) => {
+                            crate::CanonicalAggregateKind::Struct(
+                                values
+                                    .iter()
+                                    .map(|v| self.canonical_argument_value(v.clone()))
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                            )
+                        }
+                        crate::sema::ConstAggregateKind::Array(values) => {
+                            crate::CanonicalAggregateKind::Array(
+                                values
+                                    .iter()
+                                    .map(|v| self.canonical_argument_value(v.clone()))
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                            )
+                        }
+                        crate::sema::ConstAggregateKind::Enum { variant, payload } => {
+                            crate::CanonicalAggregateKind::Enum {
+                                variant: *variant,
+                                payload: payload
+                                    .iter()
+                                    .map(|v| self.canonical_argument_value(v.clone()))
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                            }
+                        }
+                    },
+                }))
+            }
         })
     }
 

--- a/crates/rue-air/src/sema/provider_fixture.rs
+++ b/crates/rue-air/src/sema/provider_fixture.rs
@@ -111,6 +111,7 @@ pub(crate) type FixtureModule = Arc<str>;
 
 pub(crate) type FixtureType = SemanticImportType<FixtureKey, FixtureModule>;
 pub(crate) type FixtureConstValue = SemanticImportConstValue<FixtureKey, FixtureModule>;
+pub(crate) type FixtureCanonicalValue = CanonicalArgumentValue<FixtureKey, FixtureModule>;
 pub(crate) type FixtureBody = ProviderOrdinaryBody<FixtureKey, FixtureModule>;
 pub(crate) type FixtureSpecializedBody = ProviderSpecializedBody<FixtureKey, FixtureModule>;
 
@@ -894,6 +895,16 @@ impl ProviderFixture {
                 .collect::<Vec<_>>()
                 .into(),
         )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn analyze_specialized_with_canonical_values(
+        &self,
+        source: &str,
+        function: &str,
+        values: &[FixtureCanonicalValue],
+    ) -> CompileResult<FixtureSpecializedBody> {
+        self.analyze_specialized_arguments(source, function, Arc::from([]), values.to_vec().into())
     }
 
     #[cfg(test)]

--- a/crates/rue-air/src/sema/provider_fixture_tests.rs
+++ b/crates/rue-air/src/sema/provider_fixture_tests.rs
@@ -20,16 +20,17 @@ use super::ordinary_engine::{
     reset_comptime_reduction_test_stats,
 };
 use super::provider_fixture::{
-    FixtureKey, MethodShape, ProviderFixture, StructShape, comptime_type_param,
-    comptime_value_param, error_source_slice, mode_param, value_param,
+    FixtureCanonicalValue, FixtureKey, MethodShape, ProviderFixture, StructShape,
+    comptime_type_param, comptime_value_param, error_source_slice, mode_param, value_param,
     with_fixture_cancellation_after, with_fixture_durable_integer,
 };
 use super::{
     ComptimeCallKey, ComptimeCallMemoLookup, ComptimeCompletedCallMemo, ComptimeMemoizedOutcome,
 };
 use crate::{
-    ConstValue, SemanticDefinitionToken, SemanticImportConstValue, SemanticImportNominalKind,
-    SemanticImportType, SemanticModuleToken, StableDefinitionKind, StableProducerId, Type,
+    CanonicalAggregateKind, CanonicalAggregateValue, ConstValue, Node, SemanticDefinitionToken,
+    SemanticImportConstValue, SemanticImportNominalKind, SemanticImportType, SemanticModuleToken,
+    StableDefinitionKind, StableProducerId, Type, TypeInstanceKey,
 };
 use rue_rir::SymbolHandle;
 use rue_target::Target;
@@ -928,6 +929,74 @@ fn provider_body_reports_undefined_variable_with_exact_span() {
         "unexpected diagnostic: {error:?}"
     );
     assert_eq!(error_source_slice(source, &error), "missing");
+}
+
+#[test]
+fn provider_specialization_validates_unused_canonical_aggregate_values() {
+    let mut fixture = ProviderFixture::new();
+    let source = "fn ignore(comptime values: [u8; 2]) -> i32 { 42 }";
+    fixture.declare_function(
+        "ignore",
+        vec![comptime_value_param(
+            "values",
+            SemanticImportType::Array {
+                element: Arc::new(SemanticImportType::U8),
+                len: 2,
+            },
+        )],
+        SemanticImportType::I32,
+    );
+    let array_type = Node::new(TypeInstanceKey::Array {
+        element: Node::new(TypeInstanceKey::U8),
+        len: 2,
+    });
+    let malformed_range: FixtureCanonicalValue =
+        crate::CanonicalArgumentValue::Aggregate(Node::new(CanonicalAggregateValue {
+            ty: array_type.clone(),
+            kind: CanonicalAggregateKind::Array(Arc::from([
+                crate::CanonicalArgumentValue::Integer(256),
+                crate::CanonicalArgumentValue::Integer(0),
+            ])),
+        }));
+    let malformed_length: FixtureCanonicalValue =
+        crate::CanonicalArgumentValue::Aggregate(Node::new(CanonicalAggregateValue {
+            ty: array_type,
+            kind: CanonicalAggregateKind::Array(Arc::from([
+                crate::CanonicalArgumentValue::Integer(1),
+            ])),
+        }));
+
+    let valid: FixtureCanonicalValue =
+        crate::CanonicalArgumentValue::Aggregate(Node::new(CanonicalAggregateValue {
+            ty: Node::new(TypeInstanceKey::Array {
+                element: Node::new(TypeInstanceKey::U8),
+                len: 2,
+            }),
+            kind: CanonicalAggregateKind::Array(Arc::from([
+                crate::CanonicalArgumentValue::Integer(1),
+                crate::CanonicalArgumentValue::Integer(0),
+            ])),
+        }));
+    fixture
+        .analyze_specialized_with_canonical_values(source, "ignore", &[valid])
+        .expect("well-formed unused canonical aggregate reaches specialization");
+
+    let range_error = fixture
+        .analyze_specialized_with_canonical_values(source, "ignore", &[malformed_range])
+        .map(|_| ())
+        .expect_err("out-of-range unused canonical aggregate must be rejected at admission");
+    assert!(
+        matches!(&range_error.kind, ErrorKind::TypeMismatch { .. }),
+        "unexpected range diagnostic: {range_error:?}"
+    );
+    let length_error = fixture
+        .analyze_specialized_with_canonical_values(source, "ignore", &[malformed_length])
+        .map(|_| ())
+        .expect_err("wrong-length unused canonical aggregate must be rejected at admission");
+    assert!(
+        matches!(&length_error.kind, ErrorKind::ComptimeEvaluationFailed { reason } if reason.contains("wrong array length")),
+        "unexpected length diagnostic: {length_error:?}"
+    );
 }
 
 // Migrated from `tests::test_use_after_move_error`: ownership diagnostics on

--- a/crates/rue-air/src/sema/provider_fixture_tests.rs
+++ b/crates/rue-air/src/sema/provider_fixture_tests.rs
@@ -867,13 +867,13 @@ fn production_comptime_key_separates_real_identity_target_type_and_value() {
         callable_issuer,
         base.configuration,
         base.type_arguments[0],
-        base.value_arguments[0],
+        base.value_arguments[0].clone(),
     );
     let generic_counterfeit = key(
         generic_specialization,
         base.configuration,
         base.type_arguments[0],
-        base.value_arguments[0],
+        base.value_arguments[0].clone(),
     );
     let target_counterfeit = key(
         observed[0].declaration.clone(),
@@ -883,13 +883,13 @@ fn production_comptime_key_separates_real_identity_target_type_and_value() {
             Target::X86_64Linux
         },
         base.type_arguments[0],
-        base.value_arguments[0],
+        base.value_arguments[0].clone(),
     );
     let type_counterfeit = key(
         function_base.declaration.clone(),
         function_base.configuration,
         anonymous_b,
-        function_base.value_arguments[0],
+        function_base.value_arguments[0].clone(),
     );
     let value_counterfeit = key(
         function_base.declaration.clone(),
@@ -1076,6 +1076,32 @@ fn provider_body_resolves_nested_struct_field_types() {
         )
         .expect("nested aggregate construction analyzes");
     assert_eq!(body.function.air.return_type(), crate::types::Type::I32);
+}
+
+// Structural values are a Copy-only comptime domain.  The ordinary producer
+// must enforce that boundary while constructing a value in a comptime block,
+// before field projection could otherwise make an affine value appear as a
+// harmless scalar.
+#[test]
+fn provider_body_rejects_affine_comptime_aggregate() {
+    let mut fixture = ProviderFixture::new();
+    fixture.declare_struct("Affine", vec![("x", SemanticImportType::I32)], false);
+    fixture.declare_function("main", Vec::new(), SemanticImportType::I32);
+    let error = fixture
+        .analyze(
+            "fn main() -> i32 {
+    comptime { let value = Affine { x: 42 }; value.x }
+}",
+            "main",
+        )
+        .map(|_| ())
+        .expect_err("an affine aggregate cannot enter structural comptime evaluation");
+    match error.kind {
+        ErrorKind::ComptimeEvaluationFailed { reason } => {
+            assert!(reason.contains("structural comptime values require a Copy type"));
+        }
+        other => panic!("unexpected diagnostic: {other:?}"),
+    }
 }
 
 // Direct provider-path coverage of a method call: the member is resolved

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -672,7 +672,7 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
             .as_ref()
             .and_then(|substitutions| substitutions.get(&symbol))
         {
-            *value
+            value.clone()
         } else if let Some(info) = self.host.type_syntax_value_const(root_file, symbol) {
             self.host
                 .type_syntax_record_named_const_dependency(info.span.file_id, name.to_owned());
@@ -751,7 +751,7 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
         if let Some(value_substitutions) = &self.state.value_substitutions
             && let Some(value) = value_substitutions.get(&symbol)
         {
-            return Ok(*value);
+            return Ok(value.clone());
         }
         if let Some(type_substitutions) = &self.state.type_substitutions
             && let Some(ty) = type_substitutions.get(&symbol)

--- a/crates/rue-air/src/semantic_identity.rs
+++ b/crates/rue-air/src/semantic_identity.rs
@@ -284,6 +284,69 @@ pub enum CanonicalArgumentValue<D, M> {
     Unit,
     String(Arc<str>),
     Float(Arc<str>),
+    Aggregate(Node<CanonicalAggregateValue<D, M>>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CanonicalAggregateValue<D, M> {
+    pub ty: Node<TypeInstanceKey<D, M>>,
+    pub kind: CanonicalAggregateKind<D, M>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CanonicalAggregateKind<D, M> {
+    Struct(Arc<[CanonicalArgumentValue<D, M>]>),
+    Array(Arc<[CanonicalArgumentValue<D, M>]>),
+    Enum {
+        variant: u32,
+        payload: Arc<[CanonicalArgumentValue<D, M>]>,
+    },
+}
+
+/// Check a borrowed value tree before allocating its local representation.
+/// `depth` and `nodes` account for a wrapper the caller may be about to build.
+/// Count every occurrence, including shared subtrees: materialization expands
+/// occurrences into separate local values.
+pub(crate) fn comptime_values_within_limits<V>(
+    values: &[V],
+    depth: usize,
+    nodes: &mut usize,
+    children: &impl for<'a> Fn(&'a V) -> &'a [V],
+) -> bool {
+    if values.is_empty() {
+        return true;
+    }
+    if depth > crate::MAX_COMPTIME_VALUE_DEPTH {
+        return false;
+    }
+    let Some(total) = nodes.checked_add(values.len()) else {
+        return false;
+    };
+    if total > crate::MAX_COMPTIME_VALUE_NODES {
+        return false;
+    }
+    *nodes = total;
+    values
+        .iter()
+        .all(|value| comptime_values_within_limits(children(value), depth + 1, nodes, children))
+}
+
+impl<D, M> CanonicalArgumentValue<D, M> {
+    pub(crate) fn within_resource_limits(&self) -> bool {
+        comptime_values_within_limits(
+            std::slice::from_ref(self),
+            0,
+            &mut 0,
+            &|value| match value {
+                Self::Aggregate(aggregate) => match &aggregate.kind {
+                    CanonicalAggregateKind::Struct(values)
+                    | CanonicalAggregateKind::Array(values) => values,
+                    CanonicalAggregateKind::Enum { payload, .. } => payload,
+                },
+                _ => &[],
+            },
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -342,6 +405,7 @@ where
                 CanonicalArgumentValue::Unit => "()".to_owned(),
                 CanonicalArgumentValue::String(value) => format!("\"{value}\""),
                 CanonicalArgumentValue::Float(value) => value.to_string(),
+                CanonicalArgumentValue::Aggregate(_) => "<aggregate>".to_owned(),
             });
         }
     }
@@ -534,6 +598,37 @@ impl<D, M> CanonicalArgumentValue<D, M> {
             Self::Unit => CanonicalArgumentValue::Unit,
             Self::String(value) => CanonicalArgumentValue::String(value.clone()),
             Self::Float(value) => CanonicalArgumentValue::Float(value.clone()),
+            Self::Aggregate(value) => {
+                CanonicalArgumentValue::Aggregate(Node::new(CanonicalAggregateValue {
+                    ty: Node::new(value.ty.try_map_identities(definition, module)?),
+                    kind: match &value.kind {
+                        CanonicalAggregateKind::Struct(values) => CanonicalAggregateKind::Struct(
+                            values
+                                .iter()
+                                .map(|value| value.try_map_identities(definition, module))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        ),
+                        CanonicalAggregateKind::Array(values) => CanonicalAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(|value| value.try_map_identities(definition, module))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        ),
+                        CanonicalAggregateKind::Enum { variant, payload } => {
+                            CanonicalAggregateKind::Enum {
+                                variant: *variant,
+                                payload: payload
+                                    .iter()
+                                    .map(|value| value.try_map_identities(definition, module))
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                            }
+                        }
+                    },
+                }))
+            }
         })
     }
 }
@@ -892,6 +987,70 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::*;
+
+    type BoundedValue = CanonicalArgumentValue<&'static str, &'static str>;
+
+    fn bounded_aggregate(kind: usize, values: Vec<BoundedValue>) -> BoundedValue {
+        let ty = Node::new(TypeInstanceKey::I32);
+        let values = Arc::from(values);
+        BoundedValue::Aggregate(Node::new(CanonicalAggregateValue {
+            ty,
+            kind: match kind {
+                0 => CanonicalAggregateKind::Struct(values),
+                1 => CanonicalAggregateKind::Array(values),
+                _ => CanonicalAggregateKind::Enum {
+                    variant: 0,
+                    payload: values,
+                },
+            },
+        }))
+    }
+
+    #[test]
+    fn canonical_value_preflight_counts_the_root_and_every_shared_occurrence() {
+        for kind in 0..3 {
+            let leaf = BoundedValue::Integer(42);
+            let at_limit = bounded_aggregate(
+                kind,
+                vec![leaf.clone(); crate::MAX_COMPTIME_VALUE_NODES - 1],
+            );
+            assert!(at_limit.within_resource_limits());
+            let too_wide = bounded_aggregate(kind, vec![leaf; crate::MAX_COMPTIME_VALUE_NODES]);
+            assert!(!too_wide.within_resource_limits());
+
+            // Two references to the same 2048-node subtree expand to 4097
+            // value occurrences after adding their containing aggregate.
+            let shared = bounded_aggregate(
+                kind,
+                vec![BoundedValue::Unit; crate::MAX_COMPTIME_VALUE_NODES / 2 - 1],
+            );
+            assert!(shared.within_resource_limits());
+            assert!(
+                !bounded_aggregate(kind, vec![shared.clone(), shared]).within_resource_limits()
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_value_preflight_bounds_mixed_aggregate_nesting() {
+        let mut value = BoundedValue::Bool(true);
+        for depth in 0..crate::MAX_COMPTIME_VALUE_DEPTH {
+            value = bounded_aggregate(depth % 3, vec![value]);
+        }
+        assert!(value.within_resource_limits());
+        value = bounded_aggregate(0, vec![value]);
+        assert!(!value.within_resource_limits());
+    }
+
+    #[test]
+    fn comptime_value_preflight_rejects_wide_input_before_visiting_children() {
+        assert!(!comptime_values_within_limits(
+            &[(); crate::MAX_COMPTIME_VALUE_NODES + 1],
+            0,
+            &mut 0,
+            &|_| panic!("an oversized envelope must not enter a materializer"),
+        ));
+    }
 
     #[test]
     fn taxonomy_declares_every_kind_namespace_and_owner_shape_once() {

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -203,6 +203,64 @@ pub enum SemanticImportConstValue<K, M> {
     /// boundary.
     String(std::sync::Arc<str>),
     Float(std::sync::Arc<str>),
+    Aggregate(std::sync::Arc<SemanticImportAggregate<K, M>>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SemanticImportAggregate<K, M> {
+    pub ty: SemanticImportType<K, M>,
+    pub kind: SemanticImportAggregateKind<K, M>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SemanticImportAggregateKind<K, M> {
+    Struct(std::sync::Arc<[SemanticImportConstValue<K, M>]>),
+    Array(std::sync::Arc<[SemanticImportConstValue<K, M>]>),
+    Enum {
+        variant: u32,
+        payload: std::sync::Arc<[SemanticImportConstValue<K, M>]>,
+    },
+}
+
+/// Shared bounds for structural comptime values crossing semantic/query
+/// boundaries. The check runs before recursive local materialization.
+pub const MAX_COMPTIME_VALUE_DEPTH: usize = 64;
+pub const MAX_COMPTIME_VALUE_NODES: usize = 4096;
+
+pub fn semantic_import_const_value_within_limits<K, M>(
+    value: &SemanticImportConstValue<K, M>,
+) -> bool {
+    crate::semantic_identity::comptime_values_within_limits(
+        std::slice::from_ref(value),
+        0,
+        &mut 0,
+        &|value| match value {
+            SemanticImportConstValue::Aggregate(aggregate) => match &aggregate.kind {
+                SemanticImportAggregateKind::Struct(values)
+                | SemanticImportAggregateKind::Array(values) => values,
+                SemanticImportAggregateKind::Enum { payload, .. } => payload,
+            },
+            _ => &[],
+        },
+    )
+}
+
+#[allow(dead_code)] // consumed by compiler durable projection
+pub fn semantic_import_const_values_within_limits<K, M>(
+    values: &[SemanticImportConstValue<K, M>],
+) -> bool {
+    // The caller is about to wrap these children in one aggregate node.
+    let mut nodes = 1;
+    crate::semantic_identity::comptime_values_within_limits(values, 1, &mut nodes, &|value| {
+        match value {
+            SemanticImportConstValue::Aggregate(aggregate) => match &aggregate.kind {
+                SemanticImportAggregateKind::Struct(values)
+                | SemanticImportAggregateKind::Array(values) => values,
+                SemanticImportAggregateKind::Enum { payload, .. } => payload,
+            },
+            _ => &[],
+        }
+    })
 }
 
 macro_rules! semantic_import_const_schema {
@@ -215,6 +273,7 @@ macro_rules! semantic_import_const_schema {
             Unit, SemanticImportConstValue::Unit, 4, "unit";
             String, SemanticImportConstValue::String(..), 5, "string";
             Float, SemanticImportConstValue::Float(..), 6, "float";
+            Aggregate, SemanticImportConstValue::Aggregate(..), 7, "aggregate";
         }
     };
 }
@@ -410,6 +469,41 @@ impl<K, M> SemanticImportConstValue<K, M> {
             Self::Unit => SemanticImportConstValue::Unit,
             Self::String(value) => SemanticImportConstValue::String(value.clone()),
             Self::Float(value) => SemanticImportConstValue::Float(value.clone()),
+            Self::Aggregate(value) => {
+                SemanticImportConstValue::Aggregate(Arc::new(SemanticImportAggregate {
+                    ty: value.ty.try_map_identities(key, module)?,
+                    kind: match &value.kind {
+                        SemanticImportAggregateKind::Struct(values) => {
+                            SemanticImportAggregateKind::Struct(
+                                values
+                                    .iter()
+                                    .map(|v| v.try_map_identities(key, module))
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                            )
+                        }
+                        SemanticImportAggregateKind::Array(values) => {
+                            SemanticImportAggregateKind::Array(
+                                values
+                                    .iter()
+                                    .map(|v| v.try_map_identities(key, module))
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                            )
+                        }
+                        SemanticImportAggregateKind::Enum { variant, payload } => {
+                            SemanticImportAggregateKind::Enum {
+                                variant: *variant,
+                                payload: payload
+                                    .iter()
+                                    .map(|v| v.try_map_identities(key, module))
+                                    .collect::<Result<Vec<_>, _>>()?
+                                    .into(),
+                            }
+                        }
+                    },
+                }))
+            }
         })
     }
 }
@@ -442,6 +536,27 @@ pub enum SemanticImportFailure {
     BuiltinNominalShadow,
     MissingBodyIdentity,
     IncompleteMaterialization,
+}
+
+fn local_const_value_fits_type(
+    value: &ConstValue,
+    expected: Type,
+    type_pool: &TypeInternPool,
+) -> bool {
+    match value {
+        ConstValue::Integer(value) => expected
+            .integer_semantics()
+            .is_some_and(|integer| integer.fits_i128(*value)),
+        ConstValue::Bool(_) => expected == Type::BOOL,
+        ConstValue::Unit => expected == Type::UNIT,
+        ConstValue::Type(_) | ConstValue::Function(_) => expected == Type::COMPTIME_TYPE,
+        ConstValue::String(_) => expected
+            .as_struct()
+            .and_then(|id| type_pool.text_view_kind(id))
+            .is_some_and(|kind| matches!(kind, crate::types::TextViewKind::Str)),
+        ConstValue::Float(_) => expected.is_float() || expected == Type::COMPTIME_FLOAT,
+        ConstValue::Aggregate(value) => value.ty == expected,
+    }
 }
 
 /// One exact nominal fact supplied to a body-local semantic epoch.
@@ -575,6 +690,66 @@ fn specialization_key<K: Clone + std::hash::Hash, M: Clone + std::hash::Hash>(
             }
             SemanticImportConstValue::Float(value) => {
                 crate::CanonicalArgumentValue::Float(value.clone())
+            }
+            SemanticImportConstValue::Aggregate(value) => {
+                fn convert<K: Clone + std::hash::Hash, M: Clone + std::hash::Hash>(
+                    value: &SemanticImportConstValue<K, M>,
+                ) -> crate::CanonicalArgumentValue<K, M> {
+                    match value {
+                        SemanticImportConstValue::Integer(v) => {
+                            crate::CanonicalArgumentValue::Integer(*v)
+                        }
+                        SemanticImportConstValue::Bool(v) => {
+                            crate::CanonicalArgumentValue::Bool(*v)
+                        }
+                        SemanticImportConstValue::Type(v) => {
+                            crate::CanonicalArgumentValue::Type(Node::new(import_type_identity(v)))
+                        }
+                        SemanticImportConstValue::Function(v) => {
+                            crate::CanonicalArgumentValue::Function(Node::new(
+                                FunctionInstanceKey::Definition(v.clone()),
+                            ))
+                        }
+                        SemanticImportConstValue::Unit => crate::CanonicalArgumentValue::Unit,
+                        SemanticImportConstValue::String(v) => {
+                            crate::CanonicalArgumentValue::String(v.clone())
+                        }
+                        SemanticImportConstValue::Float(v) => {
+                            crate::CanonicalArgumentValue::Float(v.clone())
+                        }
+                        SemanticImportConstValue::Aggregate(a) => {
+                            crate::CanonicalArgumentValue::Aggregate(Node::new(convert_aggregate(
+                                a,
+                            )))
+                        }
+                    }
+                }
+                fn convert_aggregate<K: Clone + std::hash::Hash, M: Clone + std::hash::Hash>(
+                    value: &SemanticImportAggregate<K, M>,
+                ) -> crate::CanonicalAggregateValue<K, M> {
+                    crate::CanonicalAggregateValue {
+                        ty: Node::new(import_type_identity(&value.ty)),
+                        kind: match &value.kind {
+                            SemanticImportAggregateKind::Struct(values) => {
+                                crate::CanonicalAggregateKind::Struct(
+                                    values.iter().map(convert).collect::<Vec<_>>().into(),
+                                )
+                            }
+                            SemanticImportAggregateKind::Array(values) => {
+                                crate::CanonicalAggregateKind::Array(
+                                    values.iter().map(convert).collect::<Vec<_>>().into(),
+                                )
+                            }
+                            SemanticImportAggregateKind::Enum { variant, payload } => {
+                                crate::CanonicalAggregateKind::Enum {
+                                    variant: *variant,
+                                    payload: payload.iter().map(convert).collect::<Vec<_>>().into(),
+                                }
+                            }
+                        },
+                    }
+                }
+                crate::CanonicalArgumentValue::Aggregate(Node::new(convert_aggregate(value)))
             }
         })
         .collect::<Vec<_>>();
@@ -1735,6 +1910,15 @@ where
                     ))
             },
             |specialization| {
+                // The specialization key is a retained canonical fact.  Do
+                // the complete borrowed-tree bound check before converting
+                // children into Nodes; import_const_value_local's bounds
+                // check cannot protect this already-canonical path.
+                if !semantic_import_const_values_within_limits(&specialization.value_arguments) {
+                    return Err(SemanticBodyImportFailure::Semantic(
+                        SemanticImportFailure::InvalidStructuralType,
+                    ));
+                }
                 let key = specialization_key(specialization);
                 let symbol = self.functions.get(&key).copied().ok_or(
                     SemanticBodyImportFailure::Semantic(SemanticImportFailure::MissingFunction),
@@ -2059,7 +2243,15 @@ where
         &self,
         value: &SemanticImportConstValue<K, M>,
     ) -> Result<ConstValue, SemanticImportFailure> {
-        Ok(match value {
+        self.import_const_value_local_as(value, None)
+    }
+
+    fn import_const_value_local_as(
+        &self,
+        value: &SemanticImportConstValue<K, M>,
+        expected: Option<Type>,
+    ) -> Result<ConstValue, SemanticImportFailure> {
+        let imported = match value {
             SemanticImportConstValue::Integer(v) => ConstValue::Integer(*v),
             SemanticImportConstValue::Bool(v) => ConstValue::Bool(*v),
             SemanticImportConstValue::Type(v) => ConstValue::Type(self.import_type_local(v)?),
@@ -2086,7 +2278,84 @@ where
                     .map_err(SemanticImportFailure::Interner)?
                     .into(),
             ),
-        })
+            SemanticImportConstValue::Aggregate(value) => {
+                if !semantic_import_const_value_within_limits(&SemanticImportConstValue::Aggregate(
+                    value.clone(),
+                )) {
+                    return Err(SemanticImportFailure::InvalidStructuralType);
+                }
+                let ty = self.import_type_local(&value.ty)?;
+                if !ty.is_copy_in_pool(&self.type_pool) {
+                    return Err(SemanticImportFailure::InvalidStructuralType);
+                }
+                let kind = match &value.kind {
+                    SemanticImportAggregateKind::Struct(values) => {
+                        let Some(def) = self.type_pool.get_struct_def(ty) else {
+                            return Err(SemanticImportFailure::InvalidStructuralType);
+                        };
+                        if def.fields.len() != values.len() {
+                            return Err(SemanticImportFailure::InvalidStructuralType);
+                        }
+                        crate::sema::ConstAggregateKind::Struct(
+                            values
+                                .iter()
+                                .zip(def.fields.iter())
+                                .map(|(v, field)| {
+                                    self.import_const_value_local_as(v, Some(field.ty))
+                                })
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        )
+                    }
+                    SemanticImportAggregateKind::Array(values) => {
+                        let Some((element, length)) = self.type_pool.get_array_info(ty) else {
+                            return Err(SemanticImportFailure::InvalidStructuralType);
+                        };
+                        if length as usize != values.len() {
+                            return Err(SemanticImportFailure::InvalidStructuralType);
+                        }
+                        crate::sema::ConstAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(|v| self.import_const_value_local_as(v, Some(element)))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        )
+                    }
+                    SemanticImportAggregateKind::Enum { variant, payload } => {
+                        let Some(def) = self.type_pool.get_enum_def(ty) else {
+                            return Err(SemanticImportFailure::InvalidStructuralType);
+                        };
+                        let Some(payload_types) = def.variant_payloads.get(*variant as usize)
+                        else {
+                            return Err(SemanticImportFailure::InvalidStructuralType);
+                        };
+                        if payload_types.len() != payload.len() {
+                            return Err(SemanticImportFailure::InvalidStructuralType);
+                        }
+                        crate::sema::ConstAggregateKind::Enum {
+                            variant: *variant,
+                            payload: payload
+                                .iter()
+                                .zip(payload_types.iter())
+                                .map(|(v, payload_type)| {
+                                    self.import_const_value_local_as(v, Some(*payload_type))
+                                })
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        }
+                    }
+                };
+                crate::sema::register_comptime_aggregate(crate::sema::ConstAggregate { ty, kind })
+                    .ok_or(SemanticImportFailure::InvalidStructuralType)?
+            }
+        };
+        if let Some(expected) = expected
+            && !local_const_value_fits_type(&imported, expected, &self.type_pool)
+        {
+            return Err(SemanticImportFailure::InvalidStructuralType);
+        }
+        Ok(imported)
     }
 
     /// Project an imported local type back through this epoch's stable join.
@@ -2221,10 +2490,17 @@ where
         if !Arc::ptr_eq(&value.epoch, &self.epoch) {
             return Err(SemanticImportFailure::ForeignLocalValue);
         }
-        Ok(match value.value {
-            ConstValue::Integer(v) => SemanticImportConstValue::Integer(v),
-            ConstValue::Bool(v) => SemanticImportConstValue::Bool(v),
-            ConstValue::Type(v) => SemanticImportConstValue::Type(self.export_type_local(v)?),
+        Ok(self.export_const_value_local(&value.value)?)
+    }
+
+    fn export_const_value_local(
+        &self,
+        value: &ConstValue,
+    ) -> Result<SemanticImportConstValue<K, M>, SemanticImportFailure> {
+        Ok(match value {
+            ConstValue::Integer(v) => SemanticImportConstValue::Integer(*v),
+            ConstValue::Bool(v) => SemanticImportConstValue::Bool(*v),
+            ConstValue::Type(v) => SemanticImportConstValue::Type(self.export_type_local(*v)?),
             ConstValue::Function(symbol) => {
                 let Some(FunctionInstanceKey::Definition(key)) =
                     self.function_exports.get(&symbol.spur())
@@ -2239,6 +2515,40 @@ where
             }
             ConstValue::Float(content) => {
                 SemanticImportConstValue::Float(Arc::from(self.interner.resolve(&content.spur())))
+            }
+            ConstValue::Aggregate(aggregate) => {
+                let ty = self.export_type_local(aggregate.ty)?;
+                let kind = match &aggregate.kind {
+                    crate::sema::ConstAggregateKind::Struct(values) => {
+                        SemanticImportAggregateKind::Struct(
+                            values
+                                .iter()
+                                .map(|v| self.export_const_value_local(v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        )
+                    }
+                    crate::sema::ConstAggregateKind::Array(values) => {
+                        SemanticImportAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(|v| self.export_const_value_local(v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        )
+                    }
+                    crate::sema::ConstAggregateKind::Enum { variant, payload } => {
+                        SemanticImportAggregateKind::Enum {
+                            variant: *variant,
+                            payload: payload
+                                .iter()
+                                .map(|v| self.export_const_value_local(v))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        }
+                    }
+                };
+                SemanticImportConstValue::Aggregate(Arc::new(SemanticImportAggregate { ty, kind }))
             }
         })
     }
@@ -2500,7 +2810,7 @@ mod tests {
             );
         }
 
-        assert_eq!(SEMANTIC_IMPORT_CONST_KINDS.len(), 7);
+        assert_eq!(SEMANTIC_IMPORT_CONST_KINDS.len(), 8);
         for (tag, kind) in SEMANTIC_IMPORT_CONST_KINDS.iter().copied().enumerate() {
             assert_eq!(usize::from(kind.schema_tag()), tag);
             assert_eq!(kind.to_string(), kind.display_name());

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -227,6 +227,19 @@ pub enum SemanticImportAggregateKind<K, M> {
 pub const MAX_COMPTIME_VALUE_DEPTH: usize = 64;
 pub const MAX_COMPTIME_VALUE_NODES: usize = 4096;
 
+fn semantic_import_const_children<K, M>(
+    value: &SemanticImportConstValue<K, M>,
+) -> &[SemanticImportConstValue<K, M>] {
+    match value {
+        SemanticImportConstValue::Aggregate(aggregate) => match &aggregate.kind {
+            SemanticImportAggregateKind::Struct(values)
+            | SemanticImportAggregateKind::Array(values) => values,
+            SemanticImportAggregateKind::Enum { payload, .. } => payload,
+        },
+        _ => &[],
+    }
+}
+
 pub fn semantic_import_const_value_within_limits<K, M>(
     value: &SemanticImportConstValue<K, M>,
 ) -> bool {
@@ -234,14 +247,7 @@ pub fn semantic_import_const_value_within_limits<K, M>(
         std::slice::from_ref(value),
         0,
         &mut 0,
-        &|value| match value {
-            SemanticImportConstValue::Aggregate(aggregate) => match &aggregate.kind {
-                SemanticImportAggregateKind::Struct(values)
-                | SemanticImportAggregateKind::Array(values) => values,
-                SemanticImportAggregateKind::Enum { payload, .. } => payload,
-            },
-            _ => &[],
-        },
+        &semantic_import_const_children,
     )
 }
 
@@ -249,18 +255,33 @@ pub fn semantic_import_const_value_within_limits<K, M>(
 pub fn semantic_import_const_values_within_limits<K, M>(
     values: &[SemanticImportConstValue<K, M>],
 ) -> bool {
-    // The caller is about to wrap these children in one aggregate node.
+    // These are independent roots in an argument vector. The aggregate
+    // constructor helpers use the sibling function below when these values
+    // are about to become children of a new aggregate node.
+    crate::semantic_identity::comptime_values_within_limits(
+        values,
+        0,
+        &mut 0,
+        &semantic_import_const_children,
+    )
+}
+
+/// Check values that are about to be wrapped in one aggregate node.
+///
+/// The synthetic wrapper is part of the value shape, so reserve its node and
+/// depth before visiting the children. Argument-vector callers must use
+/// [`semantic_import_const_values_within_limits`] instead.
+#[allow(dead_code)] // consumed by compiler durable projection
+pub fn semantic_import_const_children_within_limits<K, M>(
+    values: &[SemanticImportConstValue<K, M>],
+) -> bool {
     let mut nodes = 1;
-    crate::semantic_identity::comptime_values_within_limits(values, 1, &mut nodes, &|value| {
-        match value {
-            SemanticImportConstValue::Aggregate(aggregate) => match &aggregate.kind {
-                SemanticImportAggregateKind::Struct(values)
-                | SemanticImportAggregateKind::Array(values) => values,
-                SemanticImportAggregateKind::Enum { payload, .. } => payload,
-            },
-            _ => &[],
-        }
-    })
+    crate::semantic_identity::comptime_values_within_limits(
+        values,
+        1,
+        &mut nodes,
+        &semantic_import_const_children,
+    )
 }
 
 macro_rules! semantic_import_const_schema {
@@ -2490,7 +2511,7 @@ where
         if !Arc::ptr_eq(&value.epoch, &self.epoch) {
             return Err(SemanticImportFailure::ForeignLocalValue);
         }
-        Ok(self.export_const_value_local(&value.value)?)
+        self.export_const_value_local(&value.value)
     }
 
     fn export_const_value_local(
@@ -2795,6 +2816,63 @@ mod tests {
             is_non_exhaustive: false,
             lang_item: None,
         }
+    }
+
+    fn array_value(
+        values: Vec<SemanticImportConstValue<(), ()>>,
+    ) -> SemanticImportConstValue<(), ()> {
+        let len = values.len() as u64;
+        SemanticImportConstValue::Aggregate(Arc::new(SemanticImportAggregate {
+            ty: SemanticImportType::Array {
+                element: Arc::new(SemanticImportType::I32),
+                len,
+            },
+            kind: SemanticImportAggregateKind::Array(Arc::from(values)),
+        }))
+    }
+
+    fn nested_value(depth: usize) -> SemanticImportConstValue<(), ()> {
+        if depth == 0 {
+            SemanticImportConstValue::Integer(0)
+        } else {
+            SemanticImportConstValue::Aggregate(Arc::new(SemanticImportAggregate {
+                ty: SemanticImportType::I32,
+                kind: SemanticImportAggregateKind::Struct(Arc::from([nested_value(depth - 1)])),
+            }))
+        }
+    }
+
+    #[test]
+    fn comptime_limit_helpers_distinguish_argument_roots_from_wrapped_children() {
+        let children = vec![SemanticImportConstValue::Integer(0); MAX_COMPTIME_VALUE_NODES - 1];
+        let root = array_value(children.clone());
+
+        // A single aggregate root plus its 4095 children is exactly the
+        // shared node budget. The argument-vector helper must not reserve a
+        // second synthetic wrapper around that root.
+        assert!(semantic_import_const_values_within_limits(
+            std::slice::from_ref(&root)
+        ));
+        assert!(semantic_import_const_children_within_limits(&children));
+
+        let too_many_children =
+            vec![SemanticImportConstValue::Integer(0); MAX_COMPTIME_VALUE_NODES];
+        assert!(!semantic_import_const_children_within_limits(
+            &too_many_children
+        ));
+        assert!(!semantic_import_const_values_within_limits(&[array_value(
+            too_many_children
+        ),]));
+    }
+
+    #[test]
+    fn comptime_limit_helpers_accept_the_depth_boundary_and_reject_one_more() {
+        assert!(semantic_import_const_value_within_limits(&nested_value(
+            MAX_COMPTIME_VALUE_DEPTH
+        )));
+        assert!(!semantic_import_const_value_within_limits(&nested_value(
+            MAX_COMPTIME_VALUE_DEPTH + 1
+        )));
     }
 
     #[test]

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -234,6 +234,96 @@ where
                 ConstValue::Float(content) => crate::SemanticImportConstValue::Float(
                     std::sync::Arc::from(host.resolve_publication_symbol(&content.spur())),
                 ),
+                ConstValue::Aggregate(value) => {
+                    fn export<H: crate::sema::SemanticBodyExportHost + ?Sized>(
+                        host: &H,
+                        value: &ConstValue,
+                    ) -> Result<
+                        crate::SemanticImportConstValue<
+                            crate::SemanticDefinitionToken,
+                            crate::SemanticModuleToken,
+                        >,
+                        crate::SemanticBodyExportFailure,
+                    > {
+                        match value {
+                            ConstValue::Integer(value) => {
+                                return Ok(crate::SemanticImportConstValue::Integer(*value));
+                            }
+                            ConstValue::Bool(value) => {
+                                return Ok(crate::SemanticImportConstValue::Bool(*value));
+                            }
+                            ConstValue::Unit => return Ok(crate::SemanticImportConstValue::Unit),
+                            ConstValue::Type(value) => {
+                                return Ok(crate::SemanticImportConstValue::Type(
+                                    host.export_body_type(*value)?,
+                                ));
+                            }
+                            ConstValue::Function(value) => {
+                                let crate::FunctionInstanceKey::Definition(definition) =
+                                    host.body_function_identity(value.spur())?
+                                else {
+                                    return Err(
+                                        crate::SemanticBodyExportFailure::MissingStableIdentity,
+                                    );
+                                };
+                                return Ok(crate::SemanticImportConstValue::Function(definition));
+                            }
+                            ConstValue::String(value) => {
+                                return Ok(crate::SemanticImportConstValue::String(
+                                    std::sync::Arc::from(
+                                        host.resolve_publication_symbol(&value.spur()),
+                                    ),
+                                ));
+                            }
+                            ConstValue::Float(value) => {
+                                return Ok(crate::SemanticImportConstValue::Float(
+                                    std::sync::Arc::from(
+                                        host.resolve_publication_symbol(&value.spur()),
+                                    ),
+                                ));
+                            }
+                            ConstValue::Aggregate(_) => {}
+                        }
+                        let ConstValue::Aggregate(value) = value else {
+                            unreachable!()
+                        };
+                        let kind = match &value.kind {
+                            crate::sema::ConstAggregateKind::Struct(values) => {
+                                crate::SemanticImportAggregateKind::Struct(
+                                    values
+                                        .iter()
+                                        .map(|v| export(host, v))
+                                        .collect::<Result<Vec<_>, _>>()?
+                                        .into(),
+                                )
+                            }
+                            crate::sema::ConstAggregateKind::Array(values) => {
+                                crate::SemanticImportAggregateKind::Array(
+                                    values
+                                        .iter()
+                                        .map(|v| export(host, v))
+                                        .collect::<Result<Vec<_>, _>>()?
+                                        .into(),
+                                )
+                            }
+                            crate::sema::ConstAggregateKind::Enum { variant, payload } => {
+                                crate::SemanticImportAggregateKind::Enum {
+                                    variant: *variant,
+                                    payload: payload
+                                        .iter()
+                                        .map(|v| export(host, v))
+                                        .collect::<Result<Vec<_>, _>>()?
+                                        .into(),
+                                }
+                            }
+                        };
+                        let ty = host.export_body_type(value.ty)?;
+                        Ok(crate::SemanticImportConstValue::Aggregate(
+                            std::sync::Arc::new(crate::SemanticImportAggregate { ty, kind }),
+                        ))
+                    }
+                    export(host, &ConstValue::Aggregate(value.clone()))?
+                }
             })
         })
         .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
@@ -319,7 +409,7 @@ where
                 values: key
                     .value_args
                     .iter()
-                    .copied()
+                    .cloned()
                     .map(|value| host.canonical_argument_value(value))
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(|failure| {
@@ -417,7 +507,7 @@ where
             type_subst.insert(*name, ty);
             type_arg_idx += 1;
         } else {
-            let value = key.value_args.get(value_arg_idx).copied().ok_or_else(|| {
+            let value = key.value_args.get(value_arg_idx).cloned().ok_or_else(|| {
                 CompileError::new(
                     ErrorKind::InternalError(format!(
                         "specialization is missing value argument {value_arg_idx} for '{}'",
@@ -637,6 +727,7 @@ fn mangle_const_value(interner: &ThreadedRodeo, value: &ConstValue) -> String {
         ConstValue::Function(name) => format!("vfn{}", interner.resolve(&name.spur())),
         ConstValue::String(content) => mangle_string_const(interner.resolve(&content.spur())),
         ConstValue::Float(content) => format!("vfloat{}", interner.resolve(&content.spur())),
+        ConstValue::Aggregate(aggregate) => mangle_aggregate_value(aggregate, interner),
     }
 }
 
@@ -650,6 +741,49 @@ fn mangle_string_const(content: &str) -> String {
     let mut result = format!("vstr{}x", content.len());
     for byte in content.as_bytes() {
         write!(&mut result, "{byte:02x}").expect("writing hex into a String cannot fail");
+    }
+    result
+}
+
+fn mangle_aggregate_value(
+    aggregate: &crate::sema::ConstAggregate,
+    interner: &ThreadedRodeo,
+) -> String {
+    use std::fmt::Write;
+
+    // This is a local link-name component, while the published specialization
+    // identity is the typed canonical value projected by the host. Keep the
+    // local component injective and structural nonetheless: a fixed-width
+    // hash can alias distinct aggregates, and `Hash` over ConstValue embeds
+    // interner allocation order for symbol-valued leaves.
+    let mut result = String::from("vagg");
+    write!(&mut result, "t{:08x}k", aggregate.ty.as_u32())
+        .expect("writing a local aggregate mangle cannot fail");
+    match &aggregate.kind {
+        crate::sema::ConstAggregateKind::Struct(values) => {
+            result.push('s');
+            write!(&mut result, "{}:", values.len()).unwrap();
+            for value in values.iter() {
+                let fragment = mangle_const_value(interner, value);
+                write!(&mut result, "{}:{}", fragment.len(), fragment).unwrap();
+            }
+        }
+        crate::sema::ConstAggregateKind::Array(values) => {
+            result.push('a');
+            write!(&mut result, "{}:", values.len()).unwrap();
+            for value in values.iter() {
+                let fragment = mangle_const_value(interner, value);
+                write!(&mut result, "{}:{}", fragment.len(), fragment).unwrap();
+            }
+        }
+        crate::sema::ConstAggregateKind::Enum { variant, payload } => {
+            result.push('e');
+            write!(&mut result, "{}:{}:", variant, payload.len()).unwrap();
+            for value in payload.iter() {
+                let fragment = mangle_const_value(interner, value);
+                write!(&mut result, "{}:{}", fragment.len(), fragment).unwrap();
+            }
+        }
     }
     result
 }

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -510,8 +510,7 @@ where
             let value = key.value_args.get(value_arg_idx).cloned().ok_or_else(|| {
                 CompileError::new(
                     ErrorKind::InternalError(format!(
-                        "specialization is missing value argument {value_arg_idx} for '{}'",
-                        host.body_interner().resolve(name)
+                        "specialization is missing value argument {value_arg_idx}"
                     )),
                     base_info.span,
                 )
@@ -530,6 +529,45 @@ where
             )),
             base_info.span,
         ));
+    }
+
+    // Provider specializations can be requested directly from canonical
+    // arguments, including when the specialized body never reads a comptime
+    // parameter. Validate every value against its substituted declaration
+    // before issuing identity or analyzing the body so unused malformed
+    // aggregate values cannot bypass the ordinary comptime value contract.
+    {
+        let mut engine = OrdinaryBodyEngine::new(host);
+        let mut value_arg_idx = 0;
+        for (param_index, (name, declared, _, is_comptime)) in base_params.iter().enumerate() {
+            if !*is_comptime || param_comptime_type[param_index] {
+                continue;
+            }
+            let value = key.value_args.get(value_arg_idx).cloned().ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InternalError(format!(
+                        "specialization is missing value argument {value_arg_idx}"
+                    )),
+                    base_info.span,
+                )
+            })?;
+            let expected = engine.resolve_substituted_param_type(
+                &base_call_info,
+                param_index,
+                *declared,
+                &type_subst,
+                &value_subst,
+                base_info.span,
+            )?;
+            engine.validate_comptime_value_for_type(
+                key.base_name,
+                *name,
+                value,
+                expected,
+                base_info.span,
+            )?;
+            value_arg_idx += 1;
+        }
     }
 
     let identity = OrdinaryBodyEngine::new(host)

--- a/crates/rue-air/src/stable_digest.rs
+++ b/crates/rue-air/src/stable_digest.rs
@@ -225,6 +225,31 @@ impl DurableEncode for crate::CanonicalArgumentValue<String, String> {
                 encode_variant(state, 6);
                 value.hash(state);
             }
+            Self::Aggregate(value) => {
+                encode_variant(state, 7);
+                value.durable_encode(state);
+            }
+        }
+    }
+}
+
+impl DurableEncode for crate::CanonicalAggregateValue<String, String> {
+    fn durable_encode<H: Hasher>(&self, state: &mut H) {
+        self.ty.durable_encode(state);
+        match &self.kind {
+            crate::CanonicalAggregateKind::Struct(values) => {
+                encode_variant(state, 0);
+                encode_slice(state, values);
+            }
+            crate::CanonicalAggregateKind::Array(values) => {
+                encode_variant(state, 1);
+                encode_slice(state, values);
+            }
+            crate::CanonicalAggregateKind::Enum { variant, payload } => {
+                encode_variant(state, 2);
+                variant.hash(state);
+                encode_slice(state, payload);
+            }
         }
     }
 }

--- a/crates/rue-cli-tests/cases/comptime_aggregate_values.toml
+++ b/crates/rue-cli-tests/cases/comptime_aggregate_values.toml
@@ -1,0 +1,306 @@
+# Structural comptime arguments preserve values and declared types across
+# ordinary body calls and declaration-time evaluation (RUE-562).
+
+[section]
+id = "cli.comptime_aggregate_values"
+name = "Structural comptime value parameters"
+description = "Aggregate values, nominal identities, projections, and diagnostics through the real compiler."
+
+[[case]]
+name = "nested_enum"
+files = [{ path = "main.rue", source = '''
+@copy struct Pair { left: i32, right: i32 }
+@copy struct Batch { values: [Pair; 2] }
+enum Choice { Some(Batch), None }
+fn total(comptime c: Choice) -> i32 { match c { Choice.Some(b) => b.values[0].left + b.values[1].right, Choice.None => 0 } }
+fn main() -> i32 { total(Choice.Some(Batch { values: [Pair { left: 20, right: 0 }, Pair { left: 0, right: 22 }] })) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "nested_enum_const_initializer"
+files = [{ path = "main.rue", source = '''
+@copy struct Pair { left: i32, right: i32 }
+@copy struct Batch { values: [Pair; 2] }
+enum Choice { Some(Batch), None }
+fn total(comptime c: Choice) -> i32 { match c { Choice.Some(b) => b.values[0].left + b.values[1].right, Choice.None => 0 } }
+const ANSWER: i32 = total(Choice.Some(Batch { values: [Pair { left: 20, right: 0 }, Pair { left: 0, right: 22 }] }));
+fn main() -> i32 { ANSWER }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "variant_identity"
+files = [{ path = "main.rue", source = '''
+enum Choice { A(i32), B(i32) }
+fn total(comptime c: Choice) -> i32 { match c { Choice.A(v) => v, Choice.B(v) => v - 42 } }
+fn main() -> i32 { total(Choice.A(42)) + total(Choice.B(42)) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "forwarding"
+files = [{ path = "main.rue", source = '''
+@copy struct Pair { left: i32, right: i32 }
+fn inner(comptime p: Pair) -> i32 { p.left * 2 + p.right }
+fn outer(comptime p: Pair) -> i32 { inner(p) }
+fn main() -> i32 { outer(Pair { right: 2, left: 20 }) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "wide_integer"
+files = [{ path = "main.rue", source = '''
+@copy struct Wide { value: u64 }
+fn is_max(comptime p: Wide) -> i32 { if p.value == 18446744073709551615 { 42 } else { 0 } }
+fn main() -> i32 { is_max(Wide { value: 18446744073709551615 }) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "empty_array"
+files = [{ path = "main.rue", source = '''
+fn answer(comptime values: [i32; 0]) -> i32 { 42 }
+fn main() -> i32 { answer([]) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "wrong_nominal"
+files = [{ path = "main.rue", source = '''
+@copy struct A { x: i32 }
+@copy struct B { x: i32 }
+fn value(comptime a: A) -> i32 { a.x }
+fn main() -> i32 { value(B { x: 42 }) }
+''' }]
+compile_fail = true
+compile_stderr_not_contains = ["E9000"]
+compile_stderr_contains = ["E0206"]
+
+[[case]]
+name = "narrow_field_overflow"
+files = [{ path = "main.rue", source = '''
+@copy struct Narrow { x: u8 }
+fn value(comptime a: Narrow) -> i32 { @intCast(a.x) }
+fn main() -> i32 { value(Narrow { x: 256 }) }
+''' }]
+compile_fail = true
+compile_stderr_not_contains = ["E9000"]
+compile_stderr_contains = ["E0800"]
+
+[[case]]
+name = "typed_string_field"
+files = [{ path = "main.rue", source = '''
+@copy struct Buffer { value: Str(2) }
+const WORD: str = "hello";
+fn length(comptime b: Buffer) -> i32 { @intCast(b.value.len()) }
+fn main() -> i32 { length(Buffer { value: WORD }) }
+''' }]
+compile_fail = true
+compile_stderr_not_contains = ["E9000"]
+compile_stderr_contains = ["E0206"]
+
+[[case]]
+name = "durable_widths_u64"
+files = [{ path = "main.rue", source = '''
+@copy struct Wide { value: u64 }
+fn half(comptime p: Wide) -> u64 { p.value / 2 }
+const ANSWER: u64 = half(Wide { value: 18446744073709551614 });
+fn main() -> i32 { if ANSWER == 9223372036854775807 { 42 } else { 0 } }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "durable_widths_f32"
+files = [{ path = "main.rue", source = '''
+@copy struct Sample { value: f32 }
+fn delta(comptime p: Sample) -> f32 { (p.value + 1.0) - p.value }
+const ANSWER: f32 = delta(Sample { value: 16777216.0 });
+fn main() -> i32 { if ANSWER == 0.0 { 42 } else { 0 } }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "durable_widths_array_u64"
+files = [{ path = "main.rue", source = '''
+fn half(comptime a: [u64; 1]) -> u64 { a[0] / 2 }
+const ANSWER: u64 = half([18446744073709551614]);
+fn main() -> i32 { if ANSWER == 9223372036854775807 { 42 } else { 0 } }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "durable_widths_enum_u64"
+files = [{ path = "main.rue", source = '''
+enum Wide { A(u64), B }
+fn half(comptime w: Wide) -> u64 { match w { Wide.A(v) => v / 2, Wide.B => 0 } }
+const ANSWER: u64 = half(Wide.A(18446744073709551614));
+fn main() -> i32 { if ANSWER == 9223372036854775807 { 42 } else { 0 } }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "enum_nominal_durable_valid_nullary"
+files = [{ path = "main.rue", source = '''
+enum A { X, Y }
+enum B { X, Y }
+fn choose(comptime a: A) -> i32 { match a { A.X => 42, A.Y => 0 } }
+const ANSWER: i32 = choose(A.X);
+fn main() -> i32 { ANSWER }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "enum_nominal_durable_valid_payload"
+files = [{ path = "main.rue", source = '''
+enum A { X(i32), Y(i32) }
+enum B { X(i32), Y(i32) }
+fn choose(comptime a: A) -> i32 { match a { A.X(v) => v, A.Y(v) => 0 } }
+const ANSWER: i32 = choose(A.X(42));
+fn main() -> i32 { ANSWER }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "enum_nominal_ordinary"
+files = [{ path = "main.rue", source = '''
+enum A { X, Y }
+enum B { X, Y }
+fn choose(comptime a: A) -> i32 { match a { B.X => 42, B.Y => 0 } }
+fn main() -> i32 { choose(A.X) }
+''' }]
+compile_fail = true
+compile_stderr_not_contains = ["E9000"]
+compile_stderr_contains = ["E0206"]
+
+[[case]]
+name = "enum_nominal_runtime"
+files = [{ path = "main.rue", source = '''
+enum A { X, Y }
+enum B { X, Y }
+fn choose( a: A) -> i32 { match a { B.X => 42, B.Y => 0 } }
+fn main() -> i32 { choose(A.X) }
+''' }]
+compile_fail = true
+compile_stderr_not_contains = ["E9000"]
+compile_stderr_contains = ["E0206"]
+
+[[case]]
+name = "enum_alias_alias"
+files = [{ path = "main.rue", source = '''
+enum Choice { A(i32), B }
+const Alias = Choice;
+fn choose(comptime c: Choice) -> i32 { match c { Alias.A(v) => v, Alias.B => 0 } }
+const ANSWER: i32 = choose(Choice.A(42));
+fn main() -> i32 { ANSWER }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "enum_alias_direct"
+files = [{ path = "main.rue", source = '''
+enum Choice { A(i32), B }
+const Alias = Choice;
+fn choose(comptime c: Choice) -> i32 { match c { Choice.A(v) => v, Choice.B => 0 } }
+const ANSWER: i32 = choose(Choice.A(42));
+fn main() -> i32 { ANSWER }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "enum_alias_runtime"
+files = [{ path = "main.rue", source = '''
+enum Choice { A(i32), B }
+const Alias = Choice;
+fn choose(c: Choice) -> i32 { match c { Alias.A(v) => v, Alias.B => 0 } }
+fn main() -> i32 { choose(Choice.A(42)) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "durable_struct_named_f32_field"
+files = [{ path = "main.rue", source = '''
+@copy struct Holder { value: f32 }
+const F: f32 = 1.0;
+const H: Holder = Holder { value: F };
+fn take(comptime h: Holder) -> i32 { if h.value == 1.0 { 42 } else { 0 } }
+fn main() -> i32 { take(H) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "durable_struct_named_f64_field"
+files = [{ path = "main.rue", source = '''
+@copy struct Holder { value: f64 }
+const F: f64 = 1.0;
+const H: Holder = Holder { value: F };
+fn take(comptime h: Holder) -> i32 { if h.value == 1.0 { 42 } else { 0 } }
+fn main() -> i32 { take(H) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "durable_struct_named_f32_cannot_widen"
+files = [{ path = "main.rue", source = '''
+@copy struct Holder { value: f64 }
+const F: f32 = 1.0;
+const H: Holder = Holder { value: F };
+fn take(comptime h: Holder) -> i32 { 42 }
+fn main() -> i32 { take(H) }
+''' }]
+compile_fail = true
+compile_stderr_not_contains = ["E9000"]
+compile_stderr_contains = ["E0206"]
+
+[[case]]
+name = "durable_struct_named_f64_cannot_narrow"
+files = [{ path = "main.rue", source = '''
+@copy struct Holder { value: f32 }
+const F: f64 = 1.0;
+const H: Holder = Holder { value: F };
+fn take(comptime h: Holder) -> i32 { 42 }
+fn main() -> i32 { take(H) }
+''' }]
+compile_fail = true
+compile_stderr_not_contains = ["E9000"]
+compile_stderr_contains = ["E0206"]
+
+[[case]]
+name = "bare_payload_variant_ordinary_requires_arguments"
+files = [{ path = "main.rue", source = '''
+enum E { Payload(i32), Empty }
+fn ignore(comptime e: E) -> i32 { 42 }
+fn main() -> i32 { ignore(E.Payload) }
+''' }]
+compile_fail = true
+compile_stderr_contains = ["E0207", "expected 1 argument, found 0"]
+compile_stderr_not_contains = ["E9000"]
+
+[[case]]
+name = "bare_payload_variant_durable_requires_arguments"
+files = [{ path = "main.rue", source = '''
+enum E { Payload(i32), Empty }
+fn ignore(comptime e: E) -> i32 { 42 }
+const ANSWER: i32 = ignore(E.Payload); fn main() -> i32 { ANSWER }
+''' }]
+compile_fail = true
+compile_stderr_contains = ["E0207", "expected 1 argument, found 0"]
+compile_stderr_not_contains = ["E9000"]
+
+[[case]]
+name = "generic_copy_aggregate_ordinary_substitutes_prior_type_argument"
+files = [{ path = "main.rue", source = '''
+@copy struct P { x: i32 }
+fn ignore(comptime T: type, comptime p: T) -> i32 { 42 }
+fn main() -> i32 { ignore(P, P { x: 1 }) }
+''' }]
+exit_code = 42
+
+[[case]]
+name = "generic_copy_aggregate_durable_substitutes_prior_type_argument"
+files = [{ path = "main.rue", source = '''
+@copy struct P { x: i32 }
+fn ignore(comptime T: type, comptime p: T) -> i32 { 42 }
+const ANSWER: i32 = ignore(P, P { x: 1 }); fn main() -> i32 { ANSWER }
+''' }]
+exit_code = 42

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -4937,7 +4937,7 @@ pub(super) use register_parse_import_parse;"#;
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (216, 11_039_517_929_469_320_202),
+        (217, 3_718_522_193_740_259_534),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1977,7 +1977,7 @@ const REGISTRATION_LEAF_ONE_SHOT_IDENTITIES: [(usize, u64); 45] = [
     (970, 16_733_311_749_340_788_625),
     (2_583, 15_262_418_539_020_264_161),
     (11_629, 16_221_983_252_924_349_648),
-    (108_947, 7_317_637_614_921_314_832),
+    (109_886, 3_513_831_457_143_536_896),
     (3_254, 11_949_940_325_034_004_149),
     (5_552, 14_658_861_127_087_730_967),
     (872, 14_092_162_116_261_787_003),
@@ -4937,7 +4937,7 @@ pub(super) use register_parse_import_parse;"#;
         });
     assert_eq!(
         (declarations.len(), fingerprint),
-        (216, 10_859_079_154_876_703_755),
+        (216, 11_039_517_929_469_320_202),
         "crate-visible declaration names, signatures, fields, or phase owners changed"
     );
 
@@ -5208,7 +5208,7 @@ fn revisioned_body_and_program_assembly_have_exact_source_owners() {
             });
     assert_eq!(
         (shared_declarations.len(), shared_fingerprint),
-        (55, 420_575_141_232_741_378),
+        (56, 8_314_228_371_259_251_055),
         "database-tree shared body/program API changed"
     );
 }
@@ -5221,6 +5221,7 @@ fn:wait_for_arrivals
 fn:arrivals
 fn:frontier_arrivals
 fn:timed_out
+fn:type_is_copy
 fn:release
 struct:FrontierRendezvousGuard
 struct:TestConstraintGenerationCancellationGuard

--- a/crates/rue-compiler/src/durable_comptime/host.rs
+++ b/crates/rue-compiler/src/durable_comptime/host.rs
@@ -1137,11 +1137,8 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeValueAlgebra
                 ),
             ));
         };
-        let Some(total_nodes) = 1usize.checked_add(
-            element_nodes
-                .checked_mul(repeat_count)
-                .unwrap_or(usize::MAX),
-        ) else {
+        let Some(total_nodes) = 1usize.checked_add(element_nodes.saturating_mul(repeat_count))
+        else {
             return durable_host_error_outcome(durable_host_error(
                 DurableComptimeFailure::resolution(
                     "structural comptime value exceeds resource limits",

--- a/crates/rue-compiler/src/durable_comptime/host.rs
+++ b/crates/rue-compiler/src/durable_comptime/host.rs
@@ -10,6 +10,7 @@ use super::projection::*;
 use super::services::*;
 use super::structured::*;
 use super::*;
+use rue_air::ComptimeValueAlgebra;
 
 #[cfg(test)]
 thread_local! {
@@ -45,6 +46,191 @@ impl<'a, A: DurableComptimeHostAuthority + ?Sized> DurableComptimeHost<'a, A> {
         Self {
             services: DurableComptimeServices::new(authority),
         }
+    }
+
+    /// Validate a durable structural value against its complete declared
+    /// shape before any consumer projects or expands its children.  Aggregate
+    /// values are bounded and Copy-only at this one authority boundary; all
+    /// recursive callers use this same check.
+    fn validate_durable_value(
+        &self,
+        value: &DurableConstValue,
+        expected: &DurableType,
+        depth: usize,
+        nodes: &mut usize,
+    ) -> rue_air::ComptimeHostResult<bool, DurableComptimeHostFailure> {
+        if depth > rue_air::MAX_COMPTIME_VALUE_DEPTH {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                "structural comptime value exceeds resource limits",
+            )));
+        }
+        *nodes = nodes.saturating_add(1);
+        if *nodes > rue_air::MAX_COMPTIME_VALUE_NODES {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                "structural comptime value exceeds resource limits",
+            )));
+        }
+        let DurableConstValue::Aggregate(aggregate) = value else {
+            return Ok(durable_const_fits_type(value, expected));
+        };
+        // Run the shared shape walk before resolving field metadata or
+        // allocating type vectors.  Imported values are untrusted query
+        // payloads, so a later recursive consumer must never be the first
+        // place that discovers an oversized tree.
+        if !rue_air::semantic_import_const_value_within_limits(&DurableConstValue::Aggregate(
+            aggregate.clone(),
+        )) {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                "structural comptime value exceeds resource limits",
+            )));
+        }
+        if aggregate.ty != *expected
+            || !self
+                .services
+                .type_is_copy(expected)
+                .map_err(durable_provider_error)?
+        {
+            return Ok(false);
+        }
+        let check_children = |children: &[DurableConstValue],
+                              types: Vec<DurableType>,
+                              this: &Self,
+                              nodes: &mut usize| {
+            if children.len() != types.len() {
+                return Ok(false);
+            }
+            for (child, ty) in children.iter().zip(types.iter()) {
+                if !this.validate_durable_value(child, ty, depth + 1, nodes)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        };
+        match (&aggregate.kind, expected) {
+            (
+                rue_air::SemanticImportAggregateKind::Array(values),
+                DurableType::Array { element, len },
+            ) => {
+                if *len as usize != values.len() {
+                    return Ok(false);
+                }
+                check_children(
+                    values,
+                    vec![element.as_ref().clone(); values.len()],
+                    self,
+                    nodes,
+                )
+            }
+            (rue_air::SemanticImportAggregateKind::Struct(values), DurableType::Nominal(key))
+                if key.kind() == crate::StableDefinitionKind::Struct =>
+            {
+                let count = self
+                    .services
+                    .resolve_struct_field_count(expected)
+                    .map_err(durable_provider_error)?;
+                if count != values.len() {
+                    return Ok(false);
+                }
+                let mut types = Vec::with_capacity(count);
+                for index in 0..count {
+                    let Some(ty) = self
+                        .services
+                        .resolve_struct_field_type(expected, index as u32)
+                        .map_err(durable_provider_error)?
+                    else {
+                        return Ok(false);
+                    };
+                    types.push(ty);
+                }
+                check_children(values, types, self, nodes)
+            }
+            (
+                rue_air::SemanticImportAggregateKind::Enum { variant, payload },
+                DurableType::Nominal(key),
+            ) if key.kind() == crate::StableDefinitionKind::Enum => {
+                let types = self
+                    .services
+                    .resolve_enum_variant_payload_types(expected, *variant)
+                    .map_err(durable_provider_error)?;
+                check_children(payload, types.to_vec(), self, nodes)
+            }
+            (
+                rue_air::SemanticImportAggregateKind::Struct(values),
+                DurableType::BuiltinNominal {
+                    kind: rue_air::SemanticImportNominalKind::Struct,
+                    ..
+                },
+            ) => {
+                let count = self
+                    .services
+                    .resolve_struct_field_count(expected)
+                    .map_err(durable_provider_error)?;
+                if count != values.len() {
+                    return Ok(false);
+                }
+                let mut types = Vec::with_capacity(count);
+                for index in 0..count {
+                    let Some(ty) = self
+                        .services
+                        .resolve_struct_field_type(expected, index as u32)
+                        .map_err(durable_provider_error)?
+                    else {
+                        return Ok(false);
+                    };
+                    types.push(ty);
+                }
+                check_children(values, types, self, nodes)
+            }
+            (
+                rue_air::SemanticImportAggregateKind::Enum { variant, payload },
+                DurableType::BuiltinNominal {
+                    kind: rue_air::SemanticImportNominalKind::Enum,
+                    ..
+                },
+            ) => {
+                let types = self
+                    .services
+                    .resolve_enum_variant_payload_types(expected, *variant)
+                    .map_err(durable_provider_error)?;
+                check_children(payload, types.to_vec(), self, nodes)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// Preserve the declared type carried by a reduced value while allowing
+    /// the two source literals whose type is selected by context.  The raw
+    /// durable representation intentionally erases this information, so
+    /// checking the wrapper must happen before `into_durable_value`.
+    fn durable_child_type_mismatch(
+        value: &EvaluatedSemanticConst,
+        expected: &DurableType,
+    ) -> Option<DurableType> {
+        let EvaluatedSemanticConst::Value(value) = value else {
+            return None;
+        };
+        match value.ty.as_ref() {
+            None => None,
+            Some(actual) if actual == expected => None,
+            Some(DurableType::ComptimeFloat)
+                if matches!(expected, DurableType::F32 | DurableType::F64) =>
+            {
+                None
+            }
+            Some(actual) => Some(actual.clone()),
+        }
+    }
+
+    fn durable_child_type_error(
+        found: DurableType,
+        expected: &DurableType,
+    ) -> rue_air::ComptimeHostError<DurableComptimeHostFailure> {
+        durable_host_error(DurableComptimeFailure::failure(
+            SemanticNucleusFailure::Diagnostic(rue_error::ErrorKind::TypeMismatch {
+                expected: durable_type_diagnostic_name(expected),
+                found: durable_type_diagnostic_name(&found),
+            }),
+        ))
     }
 
     #[allow(dead_code)]
@@ -560,6 +746,9 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeTypeAlgebra
     fn type_name(&self, ty: &Self::Type) -> String {
         DurableComptimeScalarPolicy::type_name(ty.as_ref())
     }
+    fn type_is_enum(&self, ty: &Self::Type) -> bool {
+        matches!(ty.as_ref(), DurableType::Nominal(key) if key.kind() == crate::StableDefinitionKind::Enum)
+    }
 
     fn type_is_unsigned(&self, ty: &Self::Type) -> bool {
         DurableComptimeScalarPolicy::type_is_unsigned(ty.as_ref())
@@ -669,15 +858,41 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeTypeAlgebra
 
     fn resolve_named_type_value(
         &mut self,
-        _program: &Self::ProgramKey,
-        _name: Self::Name,
-        _span: rue_span::Span,
+        program: &Self::ProgramKey,
+        name: Self::Name,
+        span: rue_span::Span,
     ) -> rue_air::ComptimeHostResult<Option<Self::Type>, Self::Failure> {
-        // Durable TypeConst names are resolved by the canonical keyed
-        // structured-type continuation below. Returning `None` here avoids a
-        // speculative named-value query/dependency before that resolver has
-        // established the exact type-syntax authority.
-        Ok(None)
+        let builtin = match name.as_str() {
+            "i8" => Some(DurableType::I8),
+            "i16" => Some(DurableType::I16),
+            "i32" => Some(DurableType::I32),
+            "i64" => Some(DurableType::I64),
+            "u8" => Some(DurableType::U8),
+            "u16" => Some(DurableType::U16),
+            "u32" => Some(DurableType::U32),
+            "u64" => Some(DurableType::U64),
+            "bool" => Some(DurableType::Bool),
+            "unit" => Some(DurableType::Unit),
+            "never" => Some(DurableType::Never),
+            "type" => Some(DurableType::ComptimeType),
+            "f32" => Some(DurableType::F32),
+            "f64" => Some(DurableType::F64),
+            "comptime_float" => Some(DurableType::ComptimeFloat),
+            "str" => Some(DurableType::BuiltinNominal {
+                name: Arc::from("str"),
+                kind: rue_air::SemanticImportNominalKind::Struct,
+            }),
+            _ => None,
+        };
+        if let Some(ty) = builtin {
+            return Ok(Some(DurableComptimeType(ty)));
+        }
+        let file = self.file_for_program_span(program, &span);
+        let resolution = self.resolve_comptime_named_value(file, name, span)?;
+        let rue_air::ComptimeNamedValueResolution::Known(value) = resolution else {
+            return Ok(None);
+        };
+        Ok(value.as_type())
     }
 
     fn resolve_comptime_type_path(
@@ -738,6 +953,213 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeTypeAlgebra
 impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeValueAlgebra
     for DurableComptimeHost<'_, A>
 {
+    fn project_comptime_enum_payload(
+        &mut self,
+        value: &Self::Value,
+        variant: u32,
+        payload: Vec<Self::Value>,
+    ) -> rue_air::ComptimeHostResult<Vec<Self::Value>, Self::Failure> {
+        let EvaluatedSemanticConst::Value(value) = value else {
+            return Ok(payload);
+        };
+        let DurableConstValue::Aggregate(aggregate) = &value.value else {
+            return Ok(payload);
+        };
+        let types = self
+            .services
+            .resolve_enum_variant_payload_types(&aggregate.ty, variant)
+            .map_err(durable_provider_error)?;
+        if payload.len() != types.len() {
+            return Err(durable_host_error(DurableComptimeFailure::resolution(
+                "enum payload arity does not match its declaration",
+            )));
+        }
+        let mut projected = Vec::with_capacity(payload.len());
+        for (value, ty) in payload.into_iter().zip(types.iter()) {
+            let Some(value) = into_durable_value(value) else {
+                return Err(durable_host_error(DurableComptimeFailure::resolution(
+                    "enum payload contains a non-value projection",
+                )));
+            };
+            projected.push(evaluated_from_durable_value_with_type(value, ty.clone()));
+        }
+        Ok(projected)
+    }
+
+    fn resolve_comptime_struct(
+        &mut self,
+        ty: Self::Type,
+        fields: Vec<(Self::Name, Self::Value)>,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        let field_count = match self.services.resolve_struct_field_count(ty.as_ref()) {
+            Ok(field_count) => field_count,
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        };
+        let is_copy = match self.services.type_is_copy(ty.as_ref()) {
+            Ok(is_copy) => is_copy,
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        };
+        if !is_copy {
+            return durable_host_error_outcome(durable_host_error(
+                DurableComptimeFailure::comptime_failure(
+                    "structural comptime values require a Copy type",
+                ),
+            ));
+        }
+        let mut ordered = Vec::with_capacity(fields.len());
+        for (name, value) in fields {
+            let index = match self
+                .services
+                .resolve_struct_field_index(ty.as_ref(), name.as_str())
+            {
+                Ok(Some(index)) => index,
+                Ok(None) => return rue_air::ComptimeOutcome::RuntimeDependent,
+                Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+            };
+            if ordered
+                .iter()
+                .any(|(seen, _): &(u32, Self::Value)| *seen == index)
+            {
+                return rue_air::ComptimeOutcome::RuntimeDependent;
+            }
+            let field_type = match self.services.resolve_struct_field_type(ty.as_ref(), index) {
+                Ok(Some(field_type)) => field_type,
+                Ok(None) => return rue_air::ComptimeOutcome::RuntimeDependent,
+                Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+            };
+            if let Some(found) = Self::durable_child_type_mismatch(&value, &field_type) {
+                return durable_host_error_outcome(Self::durable_child_type_error(
+                    found,
+                    &field_type,
+                ));
+            }
+            let Some(durable_value) = into_durable_value(value.clone()) else {
+                return rue_air::ComptimeOutcome::RuntimeDependent;
+            };
+            let mut nodes = 0;
+            match self.validate_durable_value(&durable_value, &field_type, 0, &mut nodes) {
+                Ok(true) => {}
+                Ok(false) => return rue_air::ComptimeOutcome::RuntimeDependent,
+                Err(error) => return durable_host_error_outcome(error),
+            }
+            ordered.push((index, value));
+        }
+        if ordered.len() != field_count {
+            return rue_air::ComptimeOutcome::RuntimeDependent;
+        }
+        ordered.sort_by_key(|(index, _)| *index);
+        EvaluatedSemanticConst::aggregate_struct(
+            ty,
+            ordered.into_iter().map(|(_, value)| value).collect(),
+        )
+        .map_or_else(
+            || {
+                durable_host_error_outcome(durable_host_error(DurableComptimeFailure::resolution(
+                    "structural comptime value exceeds resource limits",
+                )))
+            },
+            rue_air::ComptimeOutcome::Known,
+        )
+    }
+
+    fn resolve_comptime_array(
+        &mut self,
+        ty: Self::Type,
+        elements: Vec<Self::Value>,
+        _site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        let DurableType::Array { element, len } = ty.as_ref() else {
+            return rue_air::ComptimeOutcome::RuntimeDependent;
+        };
+        match self.services.type_is_copy(ty.as_ref()) {
+            Ok(true) => {}
+            Ok(false) => {
+                return durable_host_error_outcome(durable_host_error(
+                    DurableComptimeFailure::comptime_failure(
+                        "structural comptime values require a Copy type",
+                    ),
+                ));
+            }
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        }
+        if elements.len() as u64 != *len {
+            return rue_air::ComptimeOutcome::RuntimeDependent;
+        }
+        for value in &elements {
+            if let Some(found) = Self::durable_child_type_mismatch(value, element.as_ref()) {
+                return durable_host_error_outcome(Self::durable_child_type_error(
+                    found,
+                    element.as_ref(),
+                ));
+            }
+            let Some(value) = into_durable_value(value.clone()) else {
+                return rue_air::ComptimeOutcome::RuntimeDependent;
+            };
+            let mut nodes = 0;
+            match self.validate_durable_value(&value, element.as_ref(), 0, &mut nodes) {
+                Ok(true) => {}
+                Ok(false) => return rue_air::ComptimeOutcome::RuntimeDependent,
+                Err(error) => return durable_host_error_outcome(error),
+            }
+        }
+        EvaluatedSemanticConst::aggregate_array(ty, elements).map_or_else(
+            || {
+                durable_host_error_outcome(durable_host_error(DurableComptimeFailure::resolution(
+                    "structural comptime value exceeds resource limits",
+                )))
+            },
+            rue_air::ComptimeOutcome::Known,
+        )
+    }
+
+    fn resolve_comptime_array_repeat(
+        &mut self,
+        ty: Self::Type,
+        element: Self::Value,
+        count: u64,
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        let Some(durable_element) = into_durable_value(element.clone()) else {
+            return rue_air::ComptimeOutcome::RuntimeDependent;
+        };
+        let Some((element_nodes, element_depth)) = durable_value_shape(&durable_element, 1) else {
+            return durable_host_error_outcome(durable_host_error(
+                DurableComptimeFailure::resolution(
+                    "structural comptime value exceeds resource limits",
+                ),
+            ));
+        };
+        let Some(repeat_count) = usize::try_from(count).ok() else {
+            return durable_host_error_outcome(durable_host_error(
+                DurableComptimeFailure::resolution(
+                    "structural comptime value exceeds resource limits",
+                ),
+            ));
+        };
+        let Some(total_nodes) = 1usize.checked_add(
+            element_nodes
+                .checked_mul(repeat_count)
+                .unwrap_or(usize::MAX),
+        ) else {
+            return durable_host_error_outcome(durable_host_error(
+                DurableComptimeFailure::resolution(
+                    "structural comptime value exceeds resource limits",
+                ),
+            ));
+        };
+        if total_nodes > rue_air::MAX_COMPTIME_VALUE_NODES
+            || element_depth > rue_air::MAX_COMPTIME_VALUE_DEPTH
+        {
+            return durable_host_error_outcome(durable_host_error(
+                DurableComptimeFailure::resolution(
+                    "structural comptime value exceeds resource limits",
+                ),
+            ));
+        }
+        self.resolve_comptime_array(ty, vec![element; repeat_count], site)
+    }
+
     fn resolve_comptime_named_value(
         &mut self,
         file: Self::File,
@@ -776,11 +1198,53 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeValueAlgebra
     }
 
     fn match_path_pattern(
-        &self,
+        &mut self,
         pattern: &rue_air::ComptimeMatchPattern<Self::Name>,
         value: &Self::Value,
-    ) -> Option<bool> {
-        Some(durable_target_path_pattern_matches(pattern, value))
+        site: &rue_air::ComptimeDiagnosticSite<Self::ProgramKey>,
+    ) -> rue_air::ComptimeHostResult<Option<bool>, Self::Failure> {
+        if durable_target_path_pattern_matches(pattern, value) {
+            return Ok(Some(true));
+        }
+        let rue_air::ComptimeMatchPattern::Path {
+            module_qualified: false,
+            type_name,
+            variant,
+            ..
+        } = pattern
+        else {
+            return Ok(Some(false));
+        };
+        let EvaluatedSemanticConst::Value(value) = value else {
+            return Ok(Some(false));
+        };
+        let rue_air::SemanticImportConstValue::Aggregate(aggregate) = &value.value else {
+            return Ok(Some(false));
+        };
+        let rue_air::SemanticImportAggregateKind::Enum { variant: index, .. } = &aggregate.kind
+        else {
+            return Ok(Some(false));
+        };
+        // Resolve the pattern head through the same durable type authority as
+        // calls and constructors. Comparing display names would reject aliases
+        // and could conflate distinct nominals with the same spelling.
+        let Some(pattern_ty) = <Self as rue_air::ComptimeTypeAlgebra>::resolve_named_type_value(
+            self,
+            site.program(),
+            type_name.clone(),
+            site.span(),
+        )?
+        else {
+            return Ok(Some(false));
+        };
+        if pattern_ty.0 != aggregate.ty {
+            return Ok(Some(false));
+        }
+        let expected = self
+            .services
+            .resolve_enum_variant_index(&aggregate.ty, variant.as_str())
+            .map_err(durable_provider_error)?;
+        Ok(Some(expected.is_some_and(|expected| expected == *index)))
     }
 
     fn match_no_selected_arm(
@@ -1010,6 +1474,63 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeValueAlgebra
         }
     }
 
+    fn resolve_comptime_enum_variant_with_payload(
+        &mut self,
+        enum_type: DurableComptimeType,
+        variant: Self::Name,
+        payload: Vec<Self::Value>,
+        _site: &rue_air::ComptimeSite<Self::ProgramKey>,
+        _span: rue_span::Span,
+    ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        let index = match self
+            .services
+            .resolve_enum_variant_index(&enum_type.0, variant.as_str())
+        {
+            Ok(Some(index)) => index,
+            Ok(None) => return rue_air::ComptimeOutcome::RuntimeDependent,
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        };
+        match self.services.type_is_copy(&enum_type.0) {
+            Ok(true) => {}
+            Ok(false) => {
+                return durable_host_error_outcome(durable_host_error(
+                    DurableComptimeFailure::comptime_failure(
+                        "structural comptime values require a Copy type",
+                    ),
+                ));
+            }
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        }
+        let payload_types = match self
+            .services
+            .resolve_enum_variant_payload_types(&enum_type.0, index)
+        {
+            Ok(payload_types) => payload_types,
+            Err(error) => return durable_host_error_outcome(durable_provider_error(error)),
+        };
+        if payload.len() != payload_types.len() {
+            return rue_air::ComptimeOutcome::RuntimeDependent;
+        }
+        let mut nodes = 0;
+        for (value, ty) in payload.iter().zip(payload_types.iter()) {
+            if let Some(found) = Self::durable_child_type_mismatch(value, ty) {
+                return durable_host_error_outcome(Self::durable_child_type_error(found, ty));
+            }
+            let Some(value) = into_durable_value(value.clone()) else {
+                return rue_air::ComptimeOutcome::RuntimeDependent;
+            };
+            match self.validate_durable_value(&value, ty, 0, &mut nodes) {
+                Ok(true) => {}
+                Ok(false) => return rue_air::ComptimeOutcome::RuntimeDependent,
+                Err(error) => return durable_host_error_outcome(error),
+            }
+        }
+        EvaluatedSemanticConst::aggregate_enum(enum_type, index, payload).map_or(
+            rue_air::ComptimeOutcome::RuntimeDependent,
+            rue_air::ComptimeOutcome::Known,
+        )
+    }
+
     fn admit_comptime_enum_variant(
         &mut self,
         _type_name: Self::Name,
@@ -1047,6 +1568,95 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeValueAlgebra
         site: &rue_air::ComptimeSite<Self::ProgramKey>,
         _span: rue_span::Span,
     ) -> rue_air::ComptimeOutcome<Self::Value, Self::Failure> {
+        if let EvaluatedSemanticConst::Value(value) = &base {
+            if let DurableConstValue::Type(enum_type) = &value.value {
+                match self.services.type_is_copy(enum_type) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        return durable_host_error_outcome(durable_host_error(
+                            DurableComptimeFailure::comptime_failure(
+                                "structural comptime values require a Copy type",
+                            ),
+                        ));
+                    }
+                    Err(error) => {
+                        return durable_host_error_outcome(durable_provider_error(error));
+                    }
+                }
+                let index = match self
+                    .services
+                    .resolve_enum_variant_index(enum_type, field.as_str())
+                {
+                    Ok(Some(index)) => index,
+                    Ok(None) => return rue_air::ComptimeOutcome::RuntimeDependent,
+                    Err(error) => {
+                        return durable_host_error_outcome(durable_provider_error(error));
+                    }
+                };
+                let payload_types = match self
+                    .services
+                    .resolve_enum_variant_payload_types(enum_type, index)
+                {
+                    Ok(payload_types) => payload_types,
+                    Err(error) => {
+                        return durable_host_error_outcome(durable_provider_error(error));
+                    }
+                };
+                // A payload-bearing variant needs an explicit constructor
+                // call.  A member path cannot silently manufacture its
+                // payload, since that would publish an invalid enum value.
+                if !payload_types.is_empty() {
+                    return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
+                        DurableComptimeFailure::failure(SemanticNucleusFailure::Diagnostic(
+                            rue_error::ErrorKind::WrongArgumentCount {
+                                expected: payload_types.len(),
+                                found: 0,
+                            },
+                        )),
+                    ));
+                }
+                return EvaluatedSemanticConst::aggregate_enum(
+                    DurableComptimeType(enum_type.clone()),
+                    index,
+                    Vec::new(),
+                )
+                .map_or(
+                    rue_air::ComptimeOutcome::RuntimeDependent,
+                    rue_air::ComptimeOutcome::Known,
+                );
+            }
+            if let DurableConstValue::Aggregate(aggregate) = &value.value {
+                if let rue_air::SemanticImportAggregateKind::Struct(fields) = &aggregate.kind {
+                    let Some(index) = (match self
+                        .services
+                        .resolve_struct_field_index(&aggregate.ty, field.as_str())
+                    {
+                        Ok(index) => index,
+                        Err(error) => {
+                            return durable_host_error_outcome(durable_provider_error(error));
+                        }
+                    }) else {
+                        return rue_air::ComptimeOutcome::RuntimeDependent;
+                    };
+                    let Some(field_value) = fields.get(index as usize).cloned() else {
+                        return rue_air::ComptimeOutcome::RuntimeDependent;
+                    };
+                    let field_type = match self
+                        .services
+                        .resolve_struct_field_type(&aggregate.ty, index)
+                    {
+                        Ok(Some(field_type)) => field_type,
+                        Ok(None) => return rue_air::ComptimeOutcome::RuntimeDependent,
+                        Err(error) => {
+                            return durable_host_error_outcome(durable_provider_error(error));
+                        }
+                    };
+                    return rue_air::ComptimeOutcome::Known(
+                        evaluated_from_durable_value_with_type(field_value, field_type),
+                    );
+                }
+            }
+        }
         let EvaluatedSemanticConst::Module(module) = base else {
             return rue_air::ComptimeOutcome::HostFailure(durable_host_failure(
                 DurableComptimeFailure::resolution("member access on a non-module const value"),
@@ -1225,6 +1835,27 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeCallProtocol
                 },
             )));
         };
+        if matches!(value.value, DurableConstValue::Aggregate(_)) {
+            let expected = substitute_durable_generics(
+                &parameter.ty,
+                &binding
+                    .type_arguments()
+                    .iter()
+                    .map(|(_, ty)| ty.clone())
+                    .collect::<Vec<_>>(),
+            );
+            if !self
+                .services
+                .type_is_copy(&expected)
+                .map_err(durable_provider_error)?
+            {
+                return Err(durable_host_error(
+                    DurableComptimeFailure::comptime_failure(
+                        "structural comptime values require a Copy type",
+                    ),
+                ));
+            }
+        }
         bind_durable_comptime_argument(
             binding,
             &header.name,
@@ -1234,6 +1865,16 @@ impl<A: DurableComptimeHostAuthority + ?Sized> rue_air::ComptimeCallProtocol
         )
         .map_err(durable_host_error)?;
         Ok(true)
+    }
+
+    fn comptime_call_argument_type(
+        &self,
+        binding: &Self::CallBinding,
+        index: usize,
+    ) -> Option<Self::Type> {
+        binding
+            .parameter(index)
+            .map(|parameter| DurableComptimeType(parameter.ty.clone()))
     }
 
     fn finish_comptime_call_binding(

--- a/crates/rue-compiler/src/durable_comptime/lifecycle.rs
+++ b/crates/rue-compiler/src/durable_comptime/lifecycle.rs
@@ -55,6 +55,14 @@ pub(crate) fn canonical_specialized_function_instance(
     type_arguments: &[(Arc<str>, DurableType)],
     value_arguments: &[(Arc<str>, DurableConstValue)],
 ) -> Result<crate::FunctionInstanceKey, DurableComptimeProducerIssuanceError> {
+    if !rue_air::semantic_import_const_values_within_limits(
+        &value_arguments
+            .iter()
+            .map(|(_, value)| value.clone())
+            .collect::<Vec<_>>(),
+    ) {
+        return Err(DurableComptimeProducerIssuanceError::InvalidValueArgument);
+    }
     let types = type_arguments
         .iter()
         .map(|(_, value)| crate::semantic_identity::type_instance_from_semantic(value))
@@ -2012,6 +2020,10 @@ impl DurableComptimeBinding {
         index: usize,
     ) -> Option<&crate::declaration_candidate::DeclarationParameterHeader> {
         self.admission.shell_parameters.get(index)
+    }
+
+    pub(super) fn type_arguments(&self) -> &[(Arc<str>, DurableType)] {
+        &self.type_arguments
     }
 
     /// Finish binding only after every argument has passed the canonical

--- a/crates/rue-compiler/src/durable_comptime/projection.rs
+++ b/crates/rue-compiler/src/durable_comptime/projection.rs
@@ -630,7 +630,7 @@ pub(crate) fn durable_value_shape(
 }
 
 fn durable_aggregate_children_within_limits(values: &[DurableConstValue]) -> bool {
-    rue_air::semantic_import_const_values_within_limits(values)
+    rue_air::semantic_import_const_children_within_limits(values)
 }
 
 pub(crate) fn evaluated_from_durable_value(value: DurableConstValue) -> EvaluatedSemanticConst {

--- a/crates/rue-compiler/src/durable_comptime/projection.rs
+++ b/crates/rue-compiler/src/durable_comptime/projection.rs
@@ -202,6 +202,7 @@ fn durable_type_diagnostic_name_kernel(ty: &DurableType) -> String {
                             crate::CanonicalArgumentValue::Unit => "()".to_owned(),
                             crate::CanonicalArgumentValue::String(value) => format!("\"{value}\""),
                             crate::CanonicalArgumentValue::Float(value) => value.to_string(),
+                            crate::CanonicalArgumentValue::Aggregate(_) => "<aggregate>".to_owned(),
                         }),
                 );
                 if arguments.is_empty() {
@@ -277,6 +278,7 @@ pub(crate) fn inferred_durable_const_type_name(value: &DurableConstValue) -> &'s
         DurableConstValue::String(_) => "str",
         DurableConstValue::Float(_) => "comptime_float",
         DurableConstValue::Type(_) | DurableConstValue::Function(_) => "type",
+        DurableConstValue::Aggregate(_) => "aggregate",
     }
 }
 
@@ -343,10 +345,47 @@ pub(crate) fn durable_const_fits_type(value: &DurableConstValue, ty: &DurableTyp
         }
         (T::Bool, V::Bool(_)) | (T::Unit, V::Unit) => true,
         (T::ComptimeType, V::Type(_)) => true,
+        (T::F32 | T::F64 | T::ComptimeFloat, V::Float(_)) => true,
         // `str` is a canonical builtin nominal whose pool identity may be
         // reconstructed at each durable call boundary. The value itself is
         // content based, so admit it by the trusted nominal classifier.
         (_, V::String(_)) if is_durable_str_type(ty) => true,
+        (_, V::Aggregate(value)) => {
+            value.ty == *ty
+                && rue_air::semantic_import_const_value_within_limits(&V::Aggregate(value.clone()))
+                && match (&value.kind, ty) {
+                    (rue_air::SemanticImportAggregateKind::Struct(_), T::Nominal(key)) => {
+                        key.kind() == crate::StableDefinitionKind::Struct
+                    }
+                    (
+                        rue_air::SemanticImportAggregateKind::Struct(_),
+                        T::BuiltinNominal {
+                            kind: rue_air::SemanticImportNominalKind::Struct,
+                            ..
+                        },
+                    ) => true,
+                    (
+                        rue_air::SemanticImportAggregateKind::Array(values),
+                        T::Array { element, len },
+                    ) => {
+                        values.len() as u64 == *len
+                            && values
+                                .iter()
+                                .all(|value| durable_const_fits_type(value, element))
+                    }
+                    (rue_air::SemanticImportAggregateKind::Enum { .. }, T::Nominal(key)) => {
+                        key.kind() == crate::StableDefinitionKind::Enum
+                    }
+                    (
+                        rue_air::SemanticImportAggregateKind::Enum { .. },
+                        T::BuiltinNominal {
+                            kind: rue_air::SemanticImportNominalKind::Enum,
+                            ..
+                        },
+                    ) => true,
+                    _ => false,
+                }
+        }
         _ => false,
     }
 }
@@ -551,6 +590,73 @@ pub(crate) enum EvaluatedSemanticConst {
     TargetEnum(TargetEnumValue),
 }
 
+pub(crate) fn into_durable_value(value: EvaluatedSemanticConst) -> Option<DurableConstValue> {
+    match value {
+        EvaluatedSemanticConst::Value(value) => Some(value.value.clone()),
+        EvaluatedSemanticConst::Module(_) | EvaluatedSemanticConst::TargetEnum(_) => None,
+    }
+}
+
+/// Return the node count and deepest relative level of an already-owned
+/// durable value without expanding it. Repeat construction uses this
+/// preflight so its allocation cannot be the first operation to exceed the
+/// shared aggregate budget.
+pub(crate) fn durable_value_shape(
+    value: &DurableConstValue,
+    depth: usize,
+) -> Option<(usize, usize)> {
+    if depth > rue_air::MAX_COMPTIME_VALUE_DEPTH {
+        return None;
+    }
+    let DurableConstValue::Aggregate(aggregate) = value else {
+        return Some((1, depth));
+    };
+    let children = match &aggregate.kind {
+        rue_air::SemanticImportAggregateKind::Struct(values)
+        | rue_air::SemanticImportAggregateKind::Array(values) => values,
+        rue_air::SemanticImportAggregateKind::Enum { payload, .. } => payload,
+    };
+    let mut nodes = 1usize;
+    let mut deepest = depth;
+    for child in children.iter() {
+        let (child_nodes, child_depth) = durable_value_shape(child, depth + 1)?;
+        nodes = nodes.checked_add(child_nodes)?;
+        if nodes > rue_air::MAX_COMPTIME_VALUE_NODES {
+            return None;
+        }
+        deepest = deepest.max(child_depth);
+    }
+    Some((nodes, deepest))
+}
+
+fn durable_aggregate_children_within_limits(values: &[DurableConstValue]) -> bool {
+    rue_air::semantic_import_const_values_within_limits(values)
+}
+
+pub(crate) fn evaluated_from_durable_value(value: DurableConstValue) -> EvaluatedSemanticConst {
+    let ty = match &value {
+        DurableConstValue::Integer(_) => DurableType::I32,
+        DurableConstValue::Bool(_) => DurableType::Bool,
+        DurableConstValue::Type(_) => DurableType::ComptimeType,
+        DurableConstValue::Function(_) => DurableType::ComptimeType,
+        DurableConstValue::Unit => DurableType::Unit,
+        DurableConstValue::String(_) => DurableType::BuiltinNominal {
+            name: Arc::from("str"),
+            kind: rue_air::SemanticImportNominalKind::Struct,
+        },
+        DurableConstValue::Float(_) => DurableType::ComptimeFloat,
+        DurableConstValue::Aggregate(aggregate) => aggregate.ty.clone(),
+    };
+    EvaluatedSemanticConst::Value(TypedSemanticConst::typed(value, ty))
+}
+
+pub(crate) fn evaluated_from_durable_value_with_type(
+    value: DurableConstValue,
+    ty: DurableType,
+) -> EvaluatedSemanticConst {
+    EvaluatedSemanticConst::Value(TypedSemanticConst::typed(value, ty))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TargetEnumValue {
     pub(crate) type_name: &'static str,
@@ -715,6 +821,7 @@ pub(crate) fn durable_target_path_pattern_matches<N: AsRef<str>>(
                 type_name,
                 variant,
                 binding_count: 0,
+                ..
             },
             EvaluatedSemanticConst::TargetEnum(target),
         ) if type_name.as_ref() == target.type_name && variant.as_ref() == target.variant
@@ -894,6 +1001,100 @@ impl ComptimeValue for EvaluatedSemanticConst {
         ))
     }
 
+    fn aggregate_struct(ty: Self::Type, fields: Vec<Self>) -> Option<Self> {
+        let values = fields
+            .into_iter()
+            .map(into_durable_value)
+            .collect::<Option<Vec<_>>>()?;
+        if !durable_aggregate_children_within_limits(&values) {
+            return None;
+        }
+        Some(Self::Value(TypedSemanticConst::typed(
+            DurableConstValue::Aggregate(Arc::new(rue_air::SemanticImportAggregate {
+                ty: ty.0.clone(),
+                kind: rue_air::SemanticImportAggregateKind::Struct(values.into()),
+            })),
+            ty.0,
+        )))
+    }
+
+    fn aggregate_array(ty: Self::Type, elements: Vec<Self>) -> Option<Self> {
+        let values = elements
+            .into_iter()
+            .map(into_durable_value)
+            .collect::<Option<Vec<_>>>()?;
+        if !durable_aggregate_children_within_limits(&values) {
+            return None;
+        }
+        Some(Self::Value(TypedSemanticConst::typed(
+            DurableConstValue::Aggregate(Arc::new(rue_air::SemanticImportAggregate {
+                ty: ty.0.clone(),
+                kind: rue_air::SemanticImportAggregateKind::Array(values.into()),
+            })),
+            ty.0,
+        )))
+    }
+
+    fn aggregate_enum(ty: Self::Type, variant: u32, payload: Vec<Self>) -> Option<Self> {
+        let values = payload
+            .into_iter()
+            .map(into_durable_value)
+            .collect::<Option<Vec<_>>>()?;
+        if !durable_aggregate_children_within_limits(&values) {
+            return None;
+        }
+        Some(Self::Value(TypedSemanticConst::typed(
+            DurableConstValue::Aggregate(Arc::new(rue_air::SemanticImportAggregate {
+                ty: ty.0.clone(),
+                kind: rue_air::SemanticImportAggregateKind::Enum {
+                    variant,
+                    payload: values.into(),
+                },
+            })),
+            ty.0,
+        )))
+    }
+
+    fn aggregate_enum_payload(&self) -> Option<(u32, Vec<Self>)> {
+        let Self::Value(value) = self else {
+            return None;
+        };
+        let DurableConstValue::Aggregate(aggregate) = &value.value else {
+            return None;
+        };
+        let rue_air::SemanticImportAggregateKind::Enum { variant, payload } = &aggregate.kind
+        else {
+            return None;
+        };
+        Some((
+            *variant,
+            payload
+                .iter()
+                .cloned()
+                .map(evaluated_from_durable_value)
+                .collect(),
+        ))
+    }
+
+    fn aggregate_array_element(&self, index: usize) -> Option<Self> {
+        let Self::Value(value) = self else {
+            return None;
+        };
+        let DurableConstValue::Aggregate(aggregate) = &value.value else {
+            return None;
+        };
+        let rue_air::SemanticImportAggregateKind::Array(values) = &aggregate.kind else {
+            return None;
+        };
+        let DurableType::Array { element, .. } = &aggregate.ty else {
+            return None;
+        };
+        values
+            .get(index)
+            .cloned()
+            .map(|value| evaluated_from_durable_value_with_type(value, element.as_ref().clone()))
+    }
+
     fn as_integer(&self) -> Option<i128> {
         let Self::Value(value) = self else {
             return None;
@@ -905,7 +1106,8 @@ impl ComptimeValue for EvaluatedSemanticConst {
             | DurableConstValue::Function(_)
             | DurableConstValue::Unit
             | DurableConstValue::String(_)
-            | DurableConstValue::Float(_) => None,
+            | DurableConstValue::Float(_)
+            | DurableConstValue::Aggregate(_) => None,
         }
     }
 
@@ -920,7 +1122,8 @@ impl ComptimeValue for EvaluatedSemanticConst {
             | DurableConstValue::Function(_)
             | DurableConstValue::Unit
             | DurableConstValue::String(_)
-            | DurableConstValue::Float(_) => None,
+            | DurableConstValue::Float(_)
+            | DurableConstValue::Aggregate(_) => None,
         }
     }
 
@@ -935,8 +1138,31 @@ impl ComptimeValue for EvaluatedSemanticConst {
             | DurableConstValue::Function(_)
             | DurableConstValue::Unit
             | DurableConstValue::String(_)
-            | DurableConstValue::Float(_) => None,
+            | DurableConstValue::Float(_)
+            | DurableConstValue::Aggregate(_) => None,
         }
+    }
+
+    fn value_type(&self) -> Option<Self::Type> {
+        let Self::Value(value) = self else {
+            return None;
+        };
+        Some(DurableComptimeType(value.ty.clone().unwrap_or_else(
+            || match &value.value {
+                DurableConstValue::Integer(_) => DurableType::I64,
+                DurableConstValue::Bool(_) => DurableType::Bool,
+                DurableConstValue::Type(_) | DurableConstValue::Function(_) => {
+                    DurableType::ComptimeType
+                }
+                DurableConstValue::Unit => DurableType::Unit,
+                DurableConstValue::String(_) => DurableType::BuiltinNominal {
+                    name: Arc::from("str"),
+                    kind: rue_air::SemanticImportNominalKind::Struct,
+                },
+                DurableConstValue::Float(_) => DurableType::ComptimeFloat,
+                DurableConstValue::Aggregate(aggregate) => aggregate.ty.clone(),
+            },
+        )))
     }
 
     fn eligible_for_comptime_capture(&self) -> bool {
@@ -1021,6 +1247,38 @@ mod tests {
                 },
             ))
         );
+    }
+
+    #[test]
+    fn durable_array_fit_checks_length_and_element_ranges_recursively() {
+        let array = DurableType::Array {
+            element: Arc::new(DurableType::U8),
+            len: 2,
+        };
+        let aggregate = |values: Arc<[DurableConstValue]>| {
+            DurableConstValue::Aggregate(Arc::new(rue_air::SemanticImportAggregate {
+                ty: array.clone(),
+                kind: rue_air::SemanticImportAggregateKind::Array(values),
+            }))
+        };
+        assert!(durable_const_fits_type(
+            &aggregate(Arc::from([
+                DurableConstValue::Integer(1),
+                DurableConstValue::Integer(2),
+            ])),
+            &array,
+        ));
+        assert!(!durable_const_fits_type(
+            &aggregate(Arc::from([DurableConstValue::Integer(1)])),
+            &array,
+        ));
+        assert!(!durable_const_fits_type(
+            &aggregate(Arc::from([
+                DurableConstValue::Integer(1),
+                DurableConstValue::Integer(256),
+            ])),
+            &array,
+        ));
     }
 
     #[test]
@@ -1391,6 +1649,7 @@ mod tests {
                 type_name: Arc::from(type_name),
                 variant: Arc::from(variant),
                 binding_count,
+                binding_names: Vec::new(),
             }
         };
 

--- a/crates/rue-compiler/src/durable_comptime/services.rs
+++ b/crates/rue-compiler/src/durable_comptime/services.rs
@@ -277,6 +277,64 @@ pub(crate) trait DurableComptimeSemanticAuthority {
         type_name: &str,
         variant: &str,
     ) -> Result<TargetEnumValue, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>;
+
+    /// Resolve a declared enum variant against the stable nominal identity
+    /// carried by a type value. This keeps variant numbering out of the
+    /// durable value algebra while allowing the canonical engine to construct
+    /// payload-bearing variants from `Choice.Some(value)`.
+    fn resolve_enum_variant_index(
+        &self,
+        _enum_type: &DurableType,
+        _variant: &str,
+    ) -> Result<Option<u32>, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>
+    {
+        Ok(None)
+    }
+
+    fn resolve_struct_field_index(
+        &self,
+        _struct_type: &DurableType,
+        _field: &str,
+    ) -> Result<Option<u32>, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>
+    {
+        Ok(None)
+    }
+
+    fn resolve_struct_field_type(
+        &self,
+        _struct_type: &DurableType,
+        _index: u32,
+    ) -> Result<
+        Option<DurableType>,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        Ok(None)
+    }
+
+    fn resolve_struct_field_count(
+        &self,
+        _struct_type: &DurableType,
+    ) -> Result<usize, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>> {
+        Ok(0)
+    }
+
+    fn resolve_enum_variant_payload_types(
+        &self,
+        _enum_type: &DurableType,
+        _variant: u32,
+    ) -> Result<
+        Arc<[DurableType]>,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        Ok(Arc::from([]))
+    }
+
+    fn type_is_copy(
+        &self,
+        _ty: &DurableType,
+    ) -> Result<bool, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>> {
+        Ok(true)
+    }
 }
 
 #[allow(dead_code)] // activated by the canonical durable AIR host
@@ -482,6 +540,63 @@ impl<A: DurableComptimeSemanticAuthority + ?Sized> DurableComptimeServices<'_, A
     {
         self.authority
             .resolve_target_enum_variant(type_name, variant)
+    }
+
+    pub(super) fn resolve_enum_variant_index(
+        &self,
+        enum_type: &DurableType,
+        variant: &str,
+    ) -> Result<Option<u32>, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>
+    {
+        self.authority
+            .resolve_enum_variant_index(enum_type, variant)
+    }
+
+    pub(super) fn resolve_struct_field_index(
+        &self,
+        struct_type: &DurableType,
+        field: &str,
+    ) -> Result<Option<u32>, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>>
+    {
+        self.authority
+            .resolve_struct_field_index(struct_type, field)
+    }
+
+    pub(super) fn resolve_struct_field_type(
+        &self,
+        struct_type: &DurableType,
+        index: u32,
+    ) -> Result<
+        Option<DurableType>,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.authority.resolve_struct_field_type(struct_type, index)
+    }
+
+    pub(super) fn resolve_struct_field_count(
+        &self,
+        struct_type: &DurableType,
+    ) -> Result<usize, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>> {
+        self.authority.resolve_struct_field_count(struct_type)
+    }
+
+    pub(super) fn resolve_enum_variant_payload_types(
+        &self,
+        enum_type: &DurableType,
+        variant: u32,
+    ) -> Result<
+        Arc<[DurableType]>,
+        rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>,
+    > {
+        self.authority
+            .resolve_enum_variant_payload_types(enum_type, variant)
+    }
+
+    pub(super) fn type_is_copy(
+        &self,
+        ty: &DurableType,
+    ) -> Result<bool, rue_air::SemanticProviderError<QueryAbort, SemanticNucleusFailure>> {
+        self.authority.type_is_copy(ty)
     }
 
     /// Finish admission for a structured-type call.  Structured syntax has

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -8,7 +8,7 @@
 //! configuration are absent because relocation of already-analyzed AIR is
 //! configuration-neutral; they remain part of the downstream CFG query key.
 
-use rue_air::Node;
+use rue_air::{CanonicalAggregateKind, Node};
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -1058,6 +1058,27 @@ fn mangle_canonical_value(value: &crate::CanonicalArgumentValue) -> String {
         CanonicalArgumentValue::Float(value) => {
             format!("vfloat{}", rue_air::mangle_symbol_component(value))
         }
+        CanonicalArgumentValue::Aggregate(value) => {
+            let children = match &value.kind {
+                CanonicalAggregateKind::Struct(values) | CanonicalAggregateKind::Array(values) => {
+                    values
+                        .iter()
+                        .map(mangle_canonical_value)
+                        .collect::<Vec<_>>()
+                        .join("_")
+                        .to_string()
+                }
+                CanonicalAggregateKind::Enum { variant, payload } => format!(
+                    "e{variant}_{}",
+                    payload
+                        .iter()
+                        .map(mangle_canonical_value)
+                        .collect::<Vec<_>>()
+                        .join("_")
+                ),
+            };
+            format!("vagg{}_{}", mangle_canonical_type(&value.ty), children)
+        }
     }
 }
 
@@ -1668,15 +1689,30 @@ pub(crate) fn select_materialization_facts(
                 self.instance_type(ty);
             }
             for value in arguments.values.iter() {
-                match value {
-                    crate::CanonicalArgumentValue::Type(ty) => self.instance_type(ty),
-                    crate::CanonicalArgumentValue::Function(function) => self.callable(function),
-                    crate::CanonicalArgumentValue::Integer(_)
-                    | crate::CanonicalArgumentValue::Bool(_)
-                    | crate::CanonicalArgumentValue::Unit
-                    | crate::CanonicalArgumentValue::String(_)
-                    | crate::CanonicalArgumentValue::Float(_) => {}
+                self.argument(value);
+            }
+        }
+
+        fn argument(&mut self, value: &crate::CanonicalArgumentValue) {
+            match value {
+                crate::CanonicalArgumentValue::Type(ty) => self.instance_type(ty),
+                crate::CanonicalArgumentValue::Function(function) => self.callable(function),
+                crate::CanonicalArgumentValue::Aggregate(value) => {
+                    self.instance_type(&value.ty);
+                    let values = match &value.kind {
+                        CanonicalAggregateKind::Struct(values)
+                        | CanonicalAggregateKind::Array(values) => values,
+                        CanonicalAggregateKind::Enum { payload, .. } => payload,
+                    };
+                    for value in values.iter() {
+                        self.argument(value);
+                    }
                 }
+                crate::CanonicalArgumentValue::Integer(_)
+                | crate::CanonicalArgumentValue::Bool(_)
+                | crate::CanonicalArgumentValue::Unit
+                | crate::CanonicalArgumentValue::String(_)
+                | crate::CanonicalArgumentValue::Float(_) => {}
             }
         }
 

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -568,6 +568,16 @@ impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge
             Self::Function(value) => value.retained_charge(),
             Self::String(value) => value.retained_charge(),
             Self::Float(value) => value.retained_charge(),
+            Self::Aggregate(value) => (std::mem::size_of_val(value) as u64)
+                .saturating_add(std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.ty.retained_charge())
+                .saturating_add(match &value.kind {
+                    rue_air::CanonicalAggregateKind::Struct(values)
+                    | rue_air::CanonicalAggregateKind::Array(values) => values.retained_charge(),
+                    rue_air::CanonicalAggregateKind::Enum { payload, .. } => {
+                        payload.retained_charge()
+                    }
+                }),
             Self::Integer(_) | Self::Bool(_) | Self::Unit => 0,
         }
     }
@@ -698,6 +708,17 @@ impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge
             Self::Function(value) => value.retained_charge(),
             Self::String(value) => value.retained_charge(),
             Self::Float(value) => value.retained_charge(),
+            Self::Aggregate(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.ty.retained_charge())
+                .saturating_add(match &value.kind {
+                    rue_air::SemanticImportAggregateKind::Struct(values)
+                    | rue_air::SemanticImportAggregateKind::Array(values) => {
+                        values.retained_charge()
+                    }
+                    rue_air::SemanticImportAggregateKind::Enum { payload, .. } => {
+                        payload.retained_charge()
+                    }
+                }),
             Self::Integer(_) | Self::Bool(_) | Self::Unit => 0,
         }
     }

--- a/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/durable_comptime_adapters.rs
@@ -24,6 +24,41 @@ pub(crate) fn durable_value_from_argument(
         V::Unit => D::Unit,
         V::String(value) => D::String(value.clone()),
         V::Float(value) => D::Float(value.clone()),
+        V::Aggregate(value) => {
+            D::Aggregate(std::sync::Arc::new(rue_air::SemanticImportAggregate {
+                ty: crate::semantic_identity::semantic_type_from_instance(&value.ty),
+                kind: match &value.kind {
+                    rue_air::CanonicalAggregateKind::Struct(values) => {
+                        rue_air::SemanticImportAggregateKind::Struct(
+                            values
+                                .iter()
+                                .map(durable_value_from_argument)
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        )
+                    }
+                    rue_air::CanonicalAggregateKind::Array(values) => {
+                        rue_air::SemanticImportAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(durable_value_from_argument)
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        )
+                    }
+                    rue_air::CanonicalAggregateKind::Enum { variant, payload } => {
+                        rue_air::SemanticImportAggregateKind::Enum {
+                            variant: *variant,
+                            payload: payload
+                                .iter()
+                                .map(durable_value_from_argument)
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        }
+                    }
+                },
+            }))
+        }
     })
 }
 
@@ -517,6 +552,20 @@ fn project_named_value_candidate(
 impl crate::durable_comptime::DurableComptimeSemanticAuthority
     for DurableComptimeRootAuthority<'_>
 {
+    fn type_is_copy(
+        &self,
+        ty: &crate::durable_semantics::DurableType,
+    ) -> Result<
+        bool,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        let mut provider = self.provider.clone();
+        provider.type_is_copy(ty)
+    }
+
     fn check_canceled(&self) -> Result<(), QueryAbort> {
         self.provider.context.check_canceled()
     }
@@ -1001,6 +1050,179 @@ impl crate::durable_comptime::DurableComptimeSemanticAuthority
     > {
         crate::durable_comptime::resolve_target_enum_variant_facts(type_name, variant)
             .map_err(rue_air::SemanticProviderError::Failure)
+    }
+
+    fn resolve_enum_variant_index(
+        &self,
+        enum_type: &crate::durable_semantics::DurableType,
+        variant: &str,
+    ) -> Result<
+        Option<u32>,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        let crate::durable_semantics::DurableType::Nominal(key) = enum_type else {
+            return Ok(None);
+        };
+        if key.kind() != crate::StableDefinitionKind::Enum {
+            return Ok(None);
+        }
+        let Some(candidate) =
+            self.provider
+                .candidate(key.module(), key.name(), crate::DefinitionKind::Enum)?
+        else {
+            return Ok(None);
+        };
+        let signature = self.provider.signature(candidate)?;
+        let crate::semantic_query_nucleus::DeclarationSignatureProjection::Enum {
+            variants, ..
+        } = signature
+        else {
+            return Ok(None);
+        };
+        Ok(variants
+            .iter()
+            .position(|(name, _)| name.as_ref() == variant)
+            .and_then(|index| u32::try_from(index).ok()))
+    }
+
+    fn resolve_struct_field_index(
+        &self,
+        struct_type: &crate::durable_semantics::DurableType,
+        field: &str,
+    ) -> Result<
+        Option<u32>,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        let crate::durable_semantics::DurableType::Nominal(key) = struct_type else {
+            return Ok(None);
+        };
+        if key.kind() != crate::StableDefinitionKind::Struct {
+            return Ok(None);
+        }
+        let Some(candidate) =
+            self.provider
+                .candidate(key.module(), key.name(), crate::DefinitionKind::Struct)?
+        else {
+            return Ok(None);
+        };
+        let signature = self.provider.signature(candidate)?;
+        let crate::semantic_query_nucleus::DeclarationSignatureProjection::Struct {
+            fields, ..
+        } = signature
+        else {
+            return Ok(None);
+        };
+        Ok(fields
+            .iter()
+            .position(|(name, _)| name.as_ref() == field)
+            .and_then(|index| u32::try_from(index).ok()))
+    }
+
+    fn resolve_struct_field_type(
+        &self,
+        struct_type: &crate::durable_semantics::DurableType,
+        index: u32,
+    ) -> Result<
+        Option<crate::durable_semantics::DurableType>,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        let crate::durable_semantics::DurableType::Nominal(key) = struct_type else {
+            return Ok(None);
+        };
+        if key.kind() != crate::StableDefinitionKind::Struct {
+            return Ok(None);
+        }
+        let Some(candidate) =
+            self.provider
+                .candidate(key.module(), key.name(), crate::DefinitionKind::Struct)?
+        else {
+            return Ok(None);
+        };
+        let signature = self.provider.signature(candidate)?;
+        let crate::semantic_query_nucleus::DeclarationSignatureProjection::Struct {
+            fields, ..
+        } = signature
+        else {
+            return Ok(None);
+        };
+        Ok(fields.get(index as usize).map(|(_, ty)| ty.clone()))
+    }
+
+    fn resolve_struct_field_count(
+        &self,
+        struct_type: &crate::durable_semantics::DurableType,
+    ) -> Result<
+        usize,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        let crate::durable_semantics::DurableType::Nominal(key) = struct_type else {
+            return Ok(0);
+        };
+        if key.kind() != crate::StableDefinitionKind::Struct {
+            return Ok(0);
+        }
+        let Some(candidate) =
+            self.provider
+                .candidate(key.module(), key.name(), crate::DefinitionKind::Struct)?
+        else {
+            return Ok(0);
+        };
+        let signature = self.provider.signature(candidate)?;
+        let crate::semantic_query_nucleus::DeclarationSignatureProjection::Struct {
+            fields, ..
+        } = signature
+        else {
+            return Ok(0);
+        };
+        Ok(fields.len())
+    }
+
+    fn resolve_enum_variant_payload_types(
+        &self,
+        enum_type: &crate::durable_semantics::DurableType,
+        variant: u32,
+    ) -> Result<
+        std::sync::Arc<[crate::durable_semantics::DurableType]>,
+        rue_air::SemanticProviderError<
+            QueryAbort,
+            crate::semantic_query_nucleus::SemanticNucleusFailure,
+        >,
+    > {
+        let crate::durable_semantics::DurableType::Nominal(key) = enum_type else {
+            return Ok(std::sync::Arc::from([]));
+        };
+        if key.kind() != crate::StableDefinitionKind::Enum {
+            return Ok(std::sync::Arc::from([]));
+        }
+        let Some(candidate) =
+            self.provider
+                .candidate(key.module(), key.name(), crate::DefinitionKind::Enum)?
+        else {
+            return Ok(std::sync::Arc::from([]));
+        };
+        let signature = self.provider.signature(candidate)?;
+        let crate::semantic_query_nucleus::DeclarationSignatureProjection::Enum {
+            variants, ..
+        } = signature
+        else {
+            return Ok(std::sync::Arc::from([]));
+        };
+        Ok(variants
+            .get(variant as usize)
+            .map(|(_, payload)| std::sync::Arc::from(payload.clone()))
+            .unwrap_or_else(|| std::sync::Arc::from([])))
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/body/provider_body.rs
@@ -700,7 +700,7 @@ impl SemanticNucleusTypeProvider<'_> {
         }
     }
 
-    fn type_is_copy(
+    pub(crate) fn type_is_copy(
         &mut self,
         ty: &crate::durable_semantics::DurableType,
     ) -> Result<
@@ -882,7 +882,7 @@ impl SemanticNucleusTypeProvider<'_> {
         }
     }
 
-    fn candidate(
+    pub(in crate::revisioned_query_database) fn candidate(
         &self,
         module: &ModuleId,
         name: &str,

--- a/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/registrations/semantic/semantic_nucleus.rs
@@ -852,6 +852,14 @@ $runtime
                                                                 (crate::durable_semantics::DurableType::F32, crate::durable_semantics::DurableConstValue::Float(value)) => float_const_initializer_bits(value, rue_air::Type::F32, float_initializer_is_literal).is_some(),
                                                                 (crate::durable_semantics::DurableType::F64, crate::durable_semantics::DurableConstValue::Float(value)) => float_const_initializer_bits(value, rue_air::Type::F64, float_initializer_is_literal).is_some(),
                                                                 (_, crate::durable_semantics::DurableConstValue::String(_)) if crate::durable_comptime::is_durable_str_type(&ty) => true,
+                                                                (_, crate::durable_semantics::DurableConstValue::Aggregate(_)) => {
+                                                                    // The canonical AIR host has already performed the
+                                                                    // pool-aware recursive shape/Copy check. Keep the
+                                                                    // declaration projection from discarding that aggregate;
+                                                                    // this final fit check only preserves its typed root and
+                                                                    // shared resource invariant at the query boundary.
+                                                                    crate::durable_comptime::durable_const_fits_type(&value, &ty)
+                                                                }
                                                                 _ => false,
                                                             };
                                                             if compatible {

--- a/crates/rue-compiler/src/revisioned_query_database/semantic.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/semantic.rs
@@ -1,6 +1,7 @@
 use super::body::BodyInputResolver;
 use super::body::*;
 use super::*;
+#[derive(Clone)]
 pub(super) struct SemanticNucleusTypeProvider<'a> {
     pub(super) context: &'a QueryContext,
     pub(super) family: &'a SemanticNucleusFamily,

--- a/crates/rue-compiler/src/revisioned_query_database/tests/body_provider/provider.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/body_provider/provider.rs
@@ -2849,6 +2849,7 @@ fn render_const_info(
         V::Unit => "unit".to_owned(),
         V::String(value) => format!("string:{}", resolve_symbol(value.spur())),
         V::Float(value) => format!("float:{}", resolve_symbol(value.spur())),
+        V::Aggregate(_) => "aggregate".to_owned(),
     };
     ConstInfoRender {
         is_pub: info.is_pub,

--- a/crates/rue-compiler/src/revisioned_query_database/tests/semantic_declaration.rs
+++ b/crates/rue-compiler/src/revisioned_query_database/tests/semantic_declaration.rs
@@ -1957,7 +1957,7 @@ fn direct_const_keys_preserve_structured_evaluator_failures() {
     assert!(matches!(
         query("AGG"),
         Value::Failure(Failure::Diagnostic(
-            rue_error::ErrorKind::ConstExprNotSupported { .. }
+            rue_error::ErrorKind::ComptimeEvaluationFailed { .. }
         ))
     ));
     for name in ["ZERO", "OVF", "LOCAL"] {

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -7,7 +7,7 @@
 
 #![allow(dead_code)] // Phase-4 seams consumed incrementally by later query families.
 
-use rue_air::Node;
+use rue_air::{CanonicalAggregateKind, CanonicalAggregateValue, Node};
 use std::fmt::Write as _;
 use std::sync::Arc;
 
@@ -497,12 +497,53 @@ pub(crate) fn argument_value_from_semantic(
         V::Unit => CanonicalArgumentValue::Unit,
         V::String(value) => CanonicalArgumentValue::String(value.clone()),
         V::Float(value) => CanonicalArgumentValue::Float(value.clone()),
+        V::Aggregate(value) => {
+            CanonicalArgumentValue::Aggregate(Node::new(CanonicalAggregateValue {
+                ty: Node::new(type_instance_from_semantic(&value.ty)),
+                kind: match &value.kind {
+                    rue_air::SemanticImportAggregateKind::Struct(values) => {
+                        CanonicalAggregateKind::Struct(
+                            values
+                                .iter()
+                                .map(argument_value_from_semantic)
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        )
+                    }
+                    rue_air::SemanticImportAggregateKind::Array(values) => {
+                        CanonicalAggregateKind::Array(
+                            values
+                                .iter()
+                                .map(argument_value_from_semantic)
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        )
+                    }
+                    rue_air::SemanticImportAggregateKind::Enum { variant, payload } => {
+                        CanonicalAggregateKind::Enum {
+                            variant: *variant,
+                            payload: payload
+                                .iter()
+                                .map(argument_value_from_semantic)
+                                .collect::<Option<Vec<_>>>()?
+                                .into(),
+                        }
+                    }
+                },
+            }))
+        }
     })
 }
 
 pub(crate) fn function_instance_from_specialization(
     value: &rue_air::SemanticSpecializationIdentity<StableDefinitionKey, ModuleId>,
 ) -> Option<FunctionInstanceKey> {
+    // Canonical conversion recursively allocates the identity tree.  Bound
+    // the borrowed semantic values before any Node or Arc is created so the
+    // retained key path cannot bypass the shared aggregate resource policy.
+    if !rue_air::semantic_import_const_values_within_limits(&value.value_arguments) {
+        return None;
+    }
     let types = value
         .type_arguments
         .iter()
@@ -743,6 +784,25 @@ fn encode_argument_value(value: &CanonicalArgumentValue, output: &mut String) {
             tag(output, 6);
             bytes(output, value);
         }
+        CanonicalArgumentValue::Aggregate(value) => {
+            tag(output, 7);
+            encode_type(&value.ty, output);
+            match &value.kind {
+                CanonicalAggregateKind::Struct(values) => {
+                    tag(output, 0);
+                    sequence(output, values, encode_argument_value);
+                }
+                CanonicalAggregateKind::Array(values) => {
+                    tag(output, 1);
+                    sequence(output, values, encode_argument_value);
+                }
+                CanonicalAggregateKind::Enum { variant, payload } => {
+                    tag(output, 2);
+                    number(output, *variant);
+                    sequence(output, payload, encode_argument_value);
+                }
+            }
+        }
     }
 }
 
@@ -949,6 +1009,52 @@ mod tests {
             encoded,
             "q3_44_n40_-1701411834604692317316873037158841057284_n1_05_n2_10"
         );
+    }
+
+    #[test]
+    fn aggregate_specialization_identity_is_structural_and_interner_independent() {
+        fn type_definition(name: &str) -> StableDefinitionKey {
+            StableDefinitionKey::for_test(
+                ModuleId::from_logical_path("pkg/types.rue").unwrap(),
+                StableDefinitionNamespace::Type,
+                StableDefinitionKind::Struct,
+                Arc::from(name),
+                None,
+            )
+        }
+
+        let function = definition("pkg/main.rue", "choose");
+        let record = type_definition("Record");
+        let other_record = type_definition("OtherRecord");
+        let make_value = |ty: StableDefinitionKey, right: i128| {
+            CanonicalArgumentValue::Aggregate(Node::new(CanonicalAggregateValue {
+                ty: Node::new(TypeInstanceKey::Nominal(NominalInstanceKey::Named(ty))),
+                kind: CanonicalAggregateKind::Struct(Arc::from([
+                    CanonicalArgumentValue::Integer(20),
+                    CanonicalArgumentValue::Integer(right),
+                ])),
+            }))
+        };
+        let specialize = |value| {
+            function_instance_from_canonical_arguments(function.clone(), vec![], vec![value])
+        };
+
+        // Rebuilding the same graph (the durable equivalent of a fresh
+        // interner/session) produces the same published symbol, while both a
+        // leaf change and a nominal change remain distinct.
+        let first = specialize(make_value(record.clone(), 22));
+        let rebuilt = specialize(make_value(record.clone(), 22));
+        let changed_leaf = specialize(make_value(record, 23));
+        let changed_nominal = specialize(make_value(other_record, 22));
+        let encode = |value: &FunctionInstanceKey| {
+            StableSymbolEncoder::encode(&StableSymbolId::Callable(StableCallableId::Function(
+                value.clone(),
+            )))
+        };
+        assert_eq!(first, rebuilt);
+        assert_eq!(encode(&first), encode(&rebuilt));
+        assert_ne!(encode(&first), encode(&changed_leaf));
+        assert_ne!(encode(&first), encode(&changed_nominal));
     }
 
     #[test]

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -338,6 +338,52 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+[[case]]
+name = "comptime_param_copy_struct_value"
+spec = ["4.14:5", "4.14:26", "4.14:27"]
+description = "A Copy struct value is reduced structurally, including declaration-order field canonicalization"
+source = """
+@copy struct Pair { left: i32, right: i32 }
+fn sum(comptime p: Pair) -> i32 { p.left * 2 + p.right }
+fn main() -> i32 { sum(Pair { right: 2, left: 20 }) }
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_copy_array_value"
+spec = ["4.14:5", "4.14:26", "4.14:27"]
+description = "A fixed-length array value is reduced structurally and indexed in a comptime function"
+source = """
+fn first(comptime values: [i32; 2]) -> i32 { values[0] }
+fn main() -> i32 { first([42, 0]) }
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_copy_enum_value"
+spec = ["4.14:5", "4.14:26", "4.14:27", "4.14:19"]
+description = "A Copy enum value selects a comptime match arm and preserves its payload"
+source = """
+enum Choice { Answer(i32), Empty }
+fn choose(comptime choice: Choice) -> i32 {
+    match choice { Choice.Answer(value) => value, Choice.Empty => 0 }
+}
+fn main() -> i32 { choose(Choice.Answer(42)) }
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_affine_aggregate_rejected"
+spec = ["4.14:5", "4.14:6", "4.14:26"]
+description = "A move aggregate cannot cross the structural comptime value boundary"
+source = """
+struct Affine { value: i32 }
+fn read(comptime value: Affine) -> i32 { value.value }
+fn main() -> i32 { read(Affine { value: 42 }) }
+"""
+compile_fail = true
+error_contains = ["E1200", "structural comptime values require a Copy type"]
+
 # =============================================================================
 # Phase 3: Type Parameters (ADR-0025)
 # =============================================================================

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -331,16 +331,16 @@ fn main() -> i32 { @intCast(REM) }
 exit_code = 0
 
 [[case]]
-name = "const_aggregate_initializer_rejected"
-spec = ["6.5:2"]
-description = "A struct literal is not compile-time evaluable, so an aggregate value const is rejected (E0434) (RUE-299)"
+name = "const_affine_aggregate_initializer_rejected"
+spec = ["4.14:5", "6.5:2"]
+description = "A non-Copy struct literal cannot enter the structural comptime value domain"
 source = """
 struct P { x: i32, y: i32 }
 const O: P = P { x: 1, y: 2 };
 fn main() -> i32 { O.x }
 """
 compile_fail = true
-error_contains = ["E0434"]
+error_contains = ["E1200", "structural comptime values require a Copy type"]
 
 # =============================================================================
 # String constants (6.5:16)

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -94,6 +94,17 @@ parameter = [ "comptime" ] IDENT ":" type ;
 ```
 
 Comptime parameters can have any type, including the special `type` type (see below).
+For value parameters, a reduced aggregate value is supported when its type is a
+Copy struct, enum, or array whose children are themselves in the comptime value
+domain. Aggregate values are checked against their declared field, variant, or
+element types before they cross a comptime call boundary. Move and linear
+aggregate types remain runtime-only values and are rejected when used as
+comptime values.
+
+Structural comptime values are bounded by an implementation resource limit of
+64 levels of nesting and 4096 total value nodes. Exceeding either limit is a
+compile-time error; implementations must reject the value before expanding it
+or recursively materializing its children.
 
 ```rue
 fn multiply(comptime n: i32, value: i32) -> i32 {
@@ -723,6 +734,12 @@ following base cases:
 - a reference to a `comptime` parameter in scope (4.14:5), including a
   `comptime T: type` parameter, whose bound value is fixed at each
   specialization.
+- a struct, enum, or fixed-length array initializer whose type is Copy and
+  whose fields, payload values, or elements are each comptime-evaluable. A
+  struct initializer must name every field exactly once. Enum payloads must
+  match the selected variant, and an array initializer must have the declared
+  length. Array repeat initializers are included when both the repeated value
+  and the count are comptime-evaluable.
 
 A reference to a runtime binding is **not** comptime-evaluable: neither a
 non-`comptime` `let` binding (Chapter 6) nor a non-`comptime` function
@@ -754,6 +771,10 @@ comptime-evaluable, and is otherwise not:
 - parenthesization `( e )`;
 - a block `{ … }` — including a `comptime { … }` block (4.14:2) — whose `let`
   initializers and tail expression are comptime-evaluable.
+- struct, enum, and fixed-length array construction, field access, and constant
+  array indexing, subject to the Copy, declared-shape, and resource rules in
+  4.14:5 and 4.14:26. These forms preserve the nominal identity and declared
+  scalar widths of nested values.
 
 Evaluation of these forms follows runtime semantics exactly, subject to the
 comptime overflow and division restrictions of 4.14:4. If any operand is not

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -113,12 +113,13 @@ const OK: i32 = 2147483647;          // in range: fine
 {{ rule(id="6.5:14", cat="informative") }}
 
 In the current revision the compile-time-evaluable expression forms (6.5:2)
-produce scalar values — integers and `bool` — plus string values from string
-literals (6.5:16), so a value constant's type is in practice a scalar type or
-`str`. There is no const-evaluable form that yields a user struct or an
-array: an aggregate initializer such as a struct literal or an array literal
-is not compile-time evaluable and is rejected (E0434). Constants of aggregate
-type may be revisited in a future revision.
+produce scalar values, string values (6.5:16), and bounded structural values
+while evaluating an initializer. A constant initializer may construct a Copy
+struct, enum, or fixed-length array as an intermediate value, pass it through a
+comptime call, and project a result from it. Such structural values preserve
+nominal identity, field and variant shape, nested scalar widths, and the
+64-level/4096-node limits. Move and linear aggregate values remain outside the
+comptime-evaluable domain.
 
 ## String Constants
 


### PR DESCRIPTION
Copy structs, enums, and fixed-length arrays can now bind comptime value parameters. Construction, field/index projection, enum matching, and forwarding work through ordinary calls and declaration-time evaluation while preserving nominal identity and nested scalar widths.

Carry aggregates as owned values through the shared evaluator, typed canonical specialization identity, semantic imports, and durable queries. Validate declared shapes, Copy eligibility, scalar ranges, and nested symbols at construction and public admission boundaries. Reject values beyond 64 nesting levels or 4096 value nodes before expansion or recursive materialization.

Update the specification and add paired ordinary/durable coverage for nested aggregates, aliases, wide integers and floats, payload arity, generic type substitution, resource boundaries, and malformed unused arguments at the public provider API.

Validation:
- AIR and compiler unit suites passed, including API and ownership gates.
- Aggregate CLI regressions: 28 passed.
- Focused comptime spec, constants spec, durable evaluator, and canonical-import boundary suites passed.
- Full standard tier: 237 targets passed, including all CLI/spec/oracle corpora; the two failed lint gates passed after correction.
- Rebased onto current trunk. The quick suite passed except for its combined API fingerprint, which was refreshed and checked separately.

Fixes RUE-562.
