### PR TITLE
RUE-1904: record no default arguments

### DIFF
--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -393,6 +393,15 @@ compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
 [[case]]
+name = "wrong_argument_count_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E0207"]
+compile_only = true
+compile_stdout_contains = ["E0207: Wrong argument count", "Rue has no default arguments, so a missing call argument is never filled in from the declaration.", "docs/spec/src/04-expressions/10-call-expressions.md (spec rule 4.10:3)", "docs/spec/src/06-items/01-functions.md (spec rule 6.1:45)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
 name = "duplicate_parameter_code_is_explained"
 files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
 args = ["explain", "E0491"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -651,8 +651,8 @@ define_error_codes! {
         }],
     };
     WRONG_ARGUMENT_COUNT = 207 => {
-        explanation: "A call-like construct supplied the wrong number of values or bindings. This applies to function and built-in calls, enum tuple-variant construction (including a payload variant used as a bare value), and enum payload patterns with an explicit binding list.",
-        likely_cause: "A function or built-in call has a missing or extra argument; an enum value supplies the wrong number of payload values; a payload-carrying variant was used without constructing its payload; or a match pattern's parenthesized bindings do not match the variant's payload arity.",
+        explanation: "A call-like construct supplied the wrong number of values or bindings. This applies to function and built-in calls, enum tuple-variant construction (including a payload variant used as a bare value), and enum payload patterns with an explicit binding list. Rue has no default arguments, so a missing call argument is never filled in from the declaration.",
+        likely_cause: "A function or built-in call has a missing or extra argument; an enum value supplies the wrong number of payload values; a payload-carrying variant was used without constructing its payload; or a match pattern's parenthesized bindings do not match the variant's payload arity. Pass every argument at the call, or give the common case its own function name.",
         examples: [
             ErrorCodeExample {
                 title: "Missing call argument",
@@ -670,6 +670,11 @@ define_error_codes! {
                 title: "Call argument arity and modes",
                 path: "docs/spec/src/04-expressions/10-call-expressions.md",
                 rule: Some("4.10:3"),
+            },
+            ErrorCodeReference {
+                title: "No default arguments",
+                path: "docs/spec/src/06-items/01-functions.md",
+                rule: Some("6.1:45"),
             },
             ErrorCodeReference {
                 title: "Enum payload-pattern arity",

--- a/crates/rue-parser/src/parser/declarations.rs
+++ b/crates/rue-parser/src/parser/declarations.rs
@@ -551,6 +551,17 @@ impl Parser {
         let name = self.ident_expected("'comptime' or 'inout' or 'borrow' or identifier or …")?;
         self.expect(TokenKind::Colon)?;
         let ty = self.ty()?;
+        if self.at(TokenKind::Eq) {
+            // ADR-0094: a parameter never carries a default value, so `= expr`
+            // after the type is refused here with the alternatives rather than
+            // falling through to a generic "expected ')'" at the `=`.
+            self.error(
+                "Rue has no default arguments; every call spells every argument. Pass the \
+                 value at each call site, or define a second function with a distinct name \
+                 for the common case",
+            );
+            return Err(());
+        }
         Ok(Param {
             mode,
             name,

--- a/crates/rue-spec/cases/expressions/call.toml
+++ b/crates/rue-spec/cases/expressions/call.toml
@@ -43,7 +43,7 @@ exit_code = 42
 name = "too_few_arguments"
 error_contains = "[E0207]"
 expected_error_code = "E0207"
-spec = ["4.10:3"]
+spec = ["4.10:3", "6.1:45"]
 source = """
 fn add(x: i32, y: i32) -> i32 { x + y }
 fn main() -> i32 { add(42) }

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -102,6 +102,38 @@ source = "fn update(value: i32) -> i32 { value }\nfn update(inout value: i32) ->
 compile_fail = true
 error_contains = ["E0436", "update"]
 
+# A parameter declaration has no default value (6.1:45): `= expr` after the
+# parameter type is a syntax error that names the rule, in a function, a
+# method, and an extern declaration alike.
+
+[[case]]
+name = "default_argument_value_rejected"
+spec = ["6.1:45"]
+source = "fn connect(host: i32, timeout: i32 = 30) -> i32 { host + timeout }\nfn main() -> i32 { connect(1) }"
+compile_fail = true
+error_contains = ["Rue has no default arguments"]
+
+[[case]]
+name = "default_argument_value_on_method_rejected"
+spec = ["6.1:45"]
+source = "struct Counter {\n    value: i32,\n\n    fn bump(self, by: i32 = 1) -> i32 { self.value + by }\n}\nfn main() -> i32 { 0 }"
+compile_fail = true
+error_contains = ["Rue has no default arguments"]
+
+[[case]]
+name = "default_argument_value_on_extern_rejected"
+spec = ["6.1:45"]
+source = "extern \"C\" {\n    fn abs(value: i32 = 0) -> i32;\n}\nfn main() -> i32 { 0 }"
+compile_fail = true
+error_contains = ["Rue has no default arguments"]
+
+[[case]]
+name = "distinct_names_replace_default_arguments"
+spec = ["6.1:45"]
+description = "The idiom that replaces a default: one name per arity, each call spelling every argument"
+source = "fn connect_with(host: i32, timeout: i32) -> i32 { host + timeout }\nfn connect(host: i32) -> i32 { connect_with(host, 30) }\nfn main() -> i32 { connect(12) }"
+exit_code = 42
+
 # =============================================================================
 # Function parameters
 # =============================================================================

--- a/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
@@ -11,7 +11,7 @@
 [section]
 id = "diagnostics.rust_refugees"
 name = "Rust-refugee diagnostics"
-description = "Targeted errors for Rust-isms: `as` casts and `impl` blocks."
+description = "Targeted errors for Rust-isms and other-language habits: `as` casts, `impl` blocks, and default arguments."
 
 [[case]]
 name = "as_cast_targeted_error"
@@ -85,3 +85,18 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["Rue has no `impl` blocks"]
+
+[[case]]
+name = "default_argument_hint"
+description = """
+RUE-1904 / ADR-0094: Rue has no default arguments. `fn f(x: i32 = 3)` is habit
+from Python, C++, Kotlin, and Swift; it used to die at the `=` with an opaque
+"expected ')'". The diagnostic must name the rule and the alternatives (spell
+the argument at each call, or give the common case a distinct function name).
+"""
+source = """
+fn connect(host: i32, timeout: i32 = 30) -> i32 { host + timeout }
+fn main() -> i32 { connect(1) }
+"""
+compile_fail = true
+error_contains = ["Rue has no default arguments", "distinct name"]

--- a/docs/designs/0094-no-default-arguments.md
+++ b/docs/designs/0094-no-default-arguments.md
@@ -1,0 +1,45 @@
+---
+id: 0094
+title: "No default arguments: every call spells every argument"
+status: accepted
+tags: [language, syntax, semantics, principle]
+feature-flag: null
+created: 2026-09-11
+accepted: 2026-09-10
+implemented:
+spec-sections: ["6.1:45", "4.10:3"]
+superseded-by:
+relates: ["RUE-1904", "RUE-1886", "RUE-1894", "RUE-981", "ADR-0087"]
+---
+
+# ADR-0094: No default arguments: every call spells every argument
+
+## Status
+
+Accepted on 2026-09-10 by Steve (the RUE-1904 ruling). This record formalizes
+the existing parameter grammar as a permanent language principle, adds a
+targeted diagnostic for the refused spelling, and introduces no preview
+feature.
+
+## Decision
+
+A parameter declaration never carries a default value, and a call supplies an
+argument for every parameter. `fn connect(host: str, timeout: i32 = 30)` is
+rejected at the `=` with a diagnostic that names the rule and the
+alternatives; `connect(host)` against a two-parameter signature stays the
+arity error it is today, and nothing is filled in from the declaration. The
+values a call passes are therefore always visible at the call site, the same
+locality Rue requires of mutation through `inout`; there is no rule to learn
+about when a default is evaluated, and no partial overload resolution over
+which parameters were supplied (ADR-0087). An API with a common configuration
+spells it as a distinct function name per arity, a named constructor, or a
+configuration value the caller builds explicitly. Argument labels (RUE-1886)
+remain a separate decision that this one does not depend on. Struct-literal
+defaults (RUE-981) are decided on their own merits and are not a back door for
+call defaults.
+
+## References
+
+- [Specification rule 6.1:45](../spec/src/06-items/01-functions.md)
+- [Specification rule 4.10:3](../spec/src/04-expressions/10-call-expressions.md)
+- [ADR-0087: No function overloading: one name, one signature per scope](0087-no-function-overloading-one-name-one-signature.md)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -256,4 +256,5 @@ The table is generated from ADR frontmatter. Run
 | [0091](0091-struct-patterns.md) | Struct patterns: exhaustive field destructuring with no rest form | Accepted | language, syntax, semantics, patterns, ownership |
 | [0092](0092-no-configuration-declarations.md) | No configuration declarations: target behavior through comptime | Accepted | language, semantics, comptime, principle |
 | [0093](0093-order-independent-program-meaning.md) | Order-independent program meaning | Accepted | language, semantics, modules, principle |
+| [0094](0094-no-default-arguments.md) | No default arguments: every call spells every argument | Accepted | language, syntax, semantics, principle |
 <!-- ADR-INDEX:END -->

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -30,7 +30,8 @@ An `inout` argument must denote a place; that requirement is a post-parse legali
 {{ rule(id="4.10:3", cat="legality-rule") }}
 
 The number of arguments **MUST** match the number of parameters in the
-function signature. Each explicit argument's source-level passing mode
+function signature; a parameter has no default value that an omitted argument
+could take (6.1:45). Each explicit argument's source-level passing mode
 **MUST** exactly match the corresponding parameter: an `inout` parameter
 requires an `inout` argument, a `borrow` parameter requires a `borrow`
 argument, and every other parameter, including a `comptime` parameter,

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -35,6 +35,17 @@ function and a fixed numeric operator intrinsic are not overloads. The same
 spelling **MAY** be used in distinct module or type scopes, where ordinary
 scope resolution selects the declaration.
 
+{{ rule(id="6.1:45", cat="legality-rule") }}
+
+A parameter declaration **MUST NOT** carry a default value: the parameter
+grammar (6.1:15) has no initializer, and a declaration such as
+`fn connect(host: str, timeout: i32 = 30)` is rejected at the `=` with a
+diagnostic naming the rule. Every call therefore supplies an argument for
+every parameter (4.10:3), so the values a call passes are visible at the call
+site and never filled in from the declaration. An API with a common
+configuration spells it as a distinct function name, a named constructor, or
+a configuration value built by the caller (ADR-0094).
+
 {{ rule(id="6.1:34", cat="legality-rule") }}
 
 The parameters in a single parameter list **MUST** have distinct names. It is a compile-time error for a function or method to declare two parameters with the same name (for example, `fn f(x: i32, x: i32)`); the diagnostic identifies the second occurrence. A method's `self` receiver is not a named parameter for the purpose of this rule.


### PR DESCRIPTION
A parameter never carries a default value and every call spells every argument. The 2026-09-10 ruling on the issue records this as a permanent principle, in the same shape as the no-overloading record (ADR-0087).

- **Spec**: new legality rule 6.1:45 (no default value on a parameter; every call supplies every argument), with a cross-reference from the arity rule 4.10:3.
- **ADR-0094** records the decision and the alternatives: a distinct function name per arity, a named constructor, or a caller-built configuration value. Argument labels (RUE-1886) stay a separate decision; struct-literal defaults (RUE-981) are decided on their own merits and are not a back door.
- **Diagnostic**: `fn f(x: i32 = 3)` used to die at the `=` with an opaque `expected ')'`. The parameter parser now refuses it with a message that names the rule and the alternatives, in functions, methods and extern declarations alike.
- **E0207** (wrong argument count) says a missing argument is never filled in from the declaration and cites 6.1:45.
- Tests: four spec cases under 6.1:45, `too_few_arguments` now also cites 6.1:45, a UI case pinning the wording, and an explain case for E0207.

Validation: spec 6.1 and 4.10, UI `rust_refugees`, CLI `explain`, spec traceability, ADR registry and doc-link validators, parser and error unit tests, `scripts/rue quick`, and the oracle-diff corpus gate all pass locally.

Fixes RUE-1904