### PR TITLE
RUE-1887: checked block reasons behind a preview

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -3762,7 +3762,7 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Checked block: for type inference purposes, the type is the type of the inner expression
             // The actual checking of unchecked operations happens in sema
-            InstData::Checked { expr } => {
+            InstData::Checked { expr, .. } => {
                 // Generate constraints for the inner expression
                 {
                     ctx.checked_depth += 1;

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -674,12 +674,41 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Checked block: evaluate the inner expression within an unchecked
             // context. Raw-pointer intrinsics and calls to `unchecked fn`s are
             // only legal while `checked_depth > 0` (spec 9.1:1, chapter 9).
-            InstData::Checked { expr } => {
+            InstData::Checked { expr, reason } => {
+                self.check_checked_reason(*reason, inst.span)?;
                 ctx.checked_depth += 1;
                 let result = self.analyze_inst(air, *expr, ctx);
                 ctx.checked_depth -= 1;
                 result
             }
+        }
+    }
+
+    /// The `checked_reasons` preview (ADR-0095, spec 9.1:14): a stated reason
+    /// needs the preview, and under the preview every `checked` block states
+    /// a non-empty one. Without the preview a reason-less block is today's
+    /// ordinary block and passes untouched.
+    fn check_checked_reason(&self, reason: Option<Spur>, span: Span) -> CompileResult<()> {
+        let gate = self.require_preview(
+            rue_error::PreviewFeature::CheckedReasons,
+            "checked block reasons",
+            span,
+        );
+        match reason {
+            Some(reason) => {
+                gate?;
+                if self.body_interner().resolve(&reason).is_empty() {
+                    return Err(CompileError::new(ErrorKind::CheckedReasonEmpty, span)
+                        .with_help("state the invariant the block relies on"));
+                }
+                Ok(())
+            }
+            None if gate.is_ok() => Err(CompileError::new(ErrorKind::CheckedReasonMissing, span)
+                .with_help(
+                    "state the invariant as a string literal after `checked`, e.g. \
+                     `checked \"index < len by the guard above\" { ... }`",
+                )),
+            None => Ok(()),
         }
     }
 }

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -796,7 +796,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
         let legal_trailing_bridge = match self.body_rir_ref().get(trailing).data {
             InstData::Yield(operand) => match self.body_rir_ref().get(operand).data {
-                InstData::Checked { expr } => match self.body_rir_ref().get(expr).data {
+                InstData::Checked { expr, .. } => match self.body_rir_ref().get(expr).data {
                     InstData::Intrinsic { name, .. } => {
                         name == self
                             .known_symbols()

--- a/crates/rue-air/src/sema/comptime.rs
+++ b/crates/rue-air/src/sema/comptime.rs
@@ -3813,7 +3813,7 @@ impl<'e, H: ComptimeHost> ComptimeEngine<'e, H> {
             // `checked { expr }` does not change the value produced by a
             // comptime expression. Keep the child traversal in this engine,
             // then let a semantic host observe or refine the completed value.
-            InstData::Checked { expr } => {
+            InstData::Checked { expr, .. } => {
                 if !self.host.allow_checked_comptime() {
                     return ComptimeOutcome::RuntimeDependent;
                 }

--- a/crates/rue-air/src/sema/comptime/value_domain_tests.rs
+++ b/crates/rue-air/src/sema/comptime/value_domain_tests.rs
@@ -2489,7 +2489,10 @@ fn durable_only_instruction_forms_cross_the_semantic_host_boundary() {
         .add_intrinsic(intrinsic_name, &[string, integer], Span::new(0, 7))
         .unwrap();
     let checked = editor.add_inst(rue_rir::Inst {
-        data: InstData::Checked { expr: integer },
+        data: InstData::Checked {
+            expr: integer,
+            reason: None,
+        },
         span: Span::new(8, 18),
     });
     let enum_variant = editor.add_inst(rue_rir::Inst {
@@ -3246,7 +3249,10 @@ fn checked_propagates_a_non_known_child_terminal() {
         span: Span::new(0, 3),
     });
     let checked = editor.add_inst(rue_rir::Inst {
-        data: InstData::Checked { expr: child },
+        data: InstData::Checked {
+            expr: child,
+            reason: None,
+        },
         span: Span::new(0, 3),
     });
     let mut host = FakeHost {

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -3833,7 +3833,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // as an indirect AIR place base. Mandatory accessor splicing embeds
         // that ordinary place in the caller CFG; no accessor ABI is involved.
         let bridge = match &self.body_rir_ref().get(operand).data {
-            InstData::Checked { expr } => matches!(
+            InstData::Checked { expr, .. } => matches!(
                 &self.body_rir_ref().get(*expr).data,
                 InstData::Intrinsic { name, .. } if *name == self.known_symbols().intrinsic(IntrinsicName::Place)
             ),

--- a/crates/rue-cli-tests/cases/borrow_accessors.toml
+++ b/crates/rue-cli-tests/cases/borrow_accessors.toml
@@ -102,7 +102,7 @@ args = ["main.rue", "--preview", "borrow_accessors", "-o", "prog"]
 compile_fail = true
 error_contains = [
     "unknown preview feature 'borrow_accessors'",
-    "Available features: test_infra, c_ffi, non_exhaustive_enums, struct_patterns",
+    "Available features: test_infra, c_ffi, non_exhaustive_enums, struct_patterns, checked_reasons",
 ]
 
 [[case]]

--- a/crates/rue-cli-tests/cases/cli_explain.toml
+++ b/crates/rue-cli-tests/cases/cli_explain.toml
@@ -402,6 +402,15 @@ compile_stdout_not_contains = ["Compiled"]
 compile_stderr_not_contains = ["main.rue", "error[E"]
 
 [[case]]
+name = "checked_reason_required_code_is_explained"
+files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
+args = ["explain", "E1301"]
+compile_only = true
+compile_stdout_contains = ["E1301: Checked reason required", "`checked_reasons` preview feature", "Omit the reason under the preview (requires --preview checked_reasons):", "State the invariant the block relies on (requires --preview checked_reasons):", "docs/spec/src/09-unchecked-code/01-syntax.md (spec rule 9.1:14)"]
+compile_stdout_not_contains = ["Compiled"]
+compile_stderr_not_contains = ["main.rue", "error[E"]
+
+[[case]]
 name = "duplicate_parameter_code_is_explained"
 files = [{ path = "main.rue", source = "fn # this source must never be parsed\n" }]
 args = ["explain", "E0491"]

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -547,3 +547,11 @@ args = ["--emit", "mir", "--emit", "asm", "-O2", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== MIR (", "=== Assembly ("]
 compile_stderr_not_contains = ["internal compiler error"]
+
+[[case]]
+name = "emit_rir_shows_the_checked_block_reason"
+description = "RUE-1887: a checked block's reason (preview checked_reasons, spec 9.1:14) is carried on the RIR instruction and shown by the RIR view, the surface a listing of checked sites reads."
+files = [{ path = "main.rue", source = "fn main() -> i32 {\n    checked \"the reason is inert but visible to tooling\" { 42 }\n}\n" }]
+args = ["--emit", "rir", "--preview", "checked_reasons", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== RIR ===", "checked \"the reason is inert but visible to tooling\" {"]

--- a/crates/rue-cli-tests/cases/float_literals.toml
+++ b/crates/rue-cli-tests/cases/float_literals.toml
@@ -19,7 +19,7 @@ args = ["main.rue", "--preview", "floats", "-o", "prog"]
 compile_fail = true
 error_contains = [
     "unknown preview feature 'floats'",
-    "Available features: test_infra, c_ffi, non_exhaustive_enums, struct_patterns",
+    "Available features: test_infra, c_ffi, non_exhaustive_enums, struct_patterns, checked_reasons",
 ]
 
 [[case]]

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -1554,7 +1554,10 @@ fn expr_record(
             "checked",
             span,
             None,
-            None,
+            block
+                .reason
+                .as_ref()
+                .map(|reason| Arc::from(owner.resolve_raw_symbol(reason.value))),
             vec![expr_record(owner, &block.expr)],
         ),
         Expr::TypeLit(literal) => syntax_record(
@@ -1905,7 +1908,7 @@ fn rir_operands(rir: &rue_rir::Rir, data: &rue_rir::InstData) -> Vec<RirOperandR
                 push("argument", argument.value);
             }
         }
-        Comptime { expr } | Checked { expr } => push("expression", *expr),
+        Comptime { expr } | Checked { expr, .. } => push("expression", *expr),
         AnonStructType { methods, .. } => {
             for method in rir.anon_struct_methods(methods) {
                 push("method", method);

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1695,6 +1695,8 @@ impl RetainedCharge for rue_error::ErrorKind {
             | E::AccessorBodyMissingYield
             | E::YieldOutsideAccessor
             | E::BreakOutsideLoop
+            | E::CheckedReasonMissing
+            | E::CheckedReasonEmpty
             | E::ContinueOutsideLoop
             | E::BreakWithValue
             | E::NonExhaustiveMatch

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -2273,6 +2273,15 @@ define_error_codes! {
     // Unchecked-code errors (E1300-E1399)
     // ========================================================================
     UNCHECKED_OP_REQUIRES_CHECKED = 1300;
+    CHECKED_REASON_REQUIRED = 1301 => {
+        explanation: "Under the `checked_reasons` preview feature, every `checked` block states the invariant it relies on as a string literal between `checked` and the block, and that reason must not be empty. The reason is part of the syntax tree and is carried into the compiler's emitted views, so a reviewer or a tool can read why each unchecked site is sound without reconstructing it.",
+        likely_cause: "A `checked` block was written without a reason, or with an empty string, while compiling with `--preview checked_reasons`. State the invariant the block relies on; there is no per-site opt-out.",
+        examples: [
+            ErrorCodeExample { title: "Omit the reason under the preview", source: "fn main() -> i32 {\n    let value: i32 = 42;\n    let p: ptr const i32 = checked { @raw(value) };\n    checked \"p points at value, which outlives this read\" { @ptr_read(p) }\n}", outcome: ErrorCodeExampleOutcome::EmitsThisCode, preview: ["checked_reasons"] },
+            ErrorCodeExample { title: "State the invariant the block relies on", source: "fn main() -> i32 {\n    let value: i32 = 42;\n    let p: ptr const i32 = checked \"value is a live local for the whole call\" { @raw(value) };\n    checked \"p points at value, which outlives this read\" { @ptr_read(p) }\n}", outcome: ErrorCodeExampleOutcome::Compiles, preview: ["checked_reasons"] },
+        ],
+        references: [ErrorCodeReference { title: "Checked block reasons", path: "docs/spec/src/09-unchecked-code/01-syntax.md", rule: Some("9.1:14") }],
+    };
 
     // ========================================================================
     // Compiler-input errors (E1400-E1499)
@@ -2569,6 +2578,9 @@ pub enum PreviewFeature {
     /// Struct destructuring patterns in `let` statements (ADR-0091,
     /// RUE-1884): `let Point { x, y } = p;` binds every field by name.
     StructPatterns,
+    /// A stated reason on every `checked` block (ADR-0095, RUE-1887):
+    /// `checked "index < len by the guard above" { ... }`.
+    CheckedReasons,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -2592,6 +2604,7 @@ impl PreviewFeature {
             PreviewFeature::CFfi => "c_ffi",
             PreviewFeature::NonExhaustiveEnums => "non_exhaustive_enums",
             PreviewFeature::StructPatterns => "struct_patterns",
+            PreviewFeature::CheckedReasons => "checked_reasons",
         }
     }
 
@@ -2603,6 +2616,7 @@ impl PreviewFeature {
             PreviewFeature::CFfi => "ADR-0064",
             PreviewFeature::NonExhaustiveEnums => "ADR-0005",
             PreviewFeature::StructPatterns => "ADR-0091",
+            PreviewFeature::CheckedReasons => "ADR-0095",
         }
     }
 
@@ -2613,6 +2627,7 @@ impl PreviewFeature {
             PreviewFeature::CFfi,
             PreviewFeature::NonExhaustiveEnums,
             PreviewFeature::StructPatterns,
+            PreviewFeature::CheckedReasons,
         ]
     }
 
@@ -2656,6 +2671,7 @@ impl std::str::FromStr for PreviewFeature {
             "c_ffi" => Ok(PreviewFeature::CFfi),
             "non_exhaustive_enums" => Ok(PreviewFeature::NonExhaustiveEnums),
             "struct_patterns" => Ok(PreviewFeature::StructPatterns),
+            "checked_reasons" => Ok(PreviewFeature::CheckedReasons),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -4057,6 +4073,14 @@ pub enum ErrorKind {
     // Unchecked-code errors
     #[error("{what} requires a `checked` block")]
     UncheckedOpRequiresChecked { what: String },
+    /// A `checked` block under the `checked_reasons` preview (spec 9.1:14)
+    /// states no reason.
+    #[error("`checked` block must state the invariant it relies on")]
+    CheckedReasonMissing,
+    /// A `checked` block under the `checked_reasons` preview (spec 9.1:14)
+    /// states an empty reason.
+    #[error("`checked` block reason must not be empty")]
+    CheckedReasonEmpty,
 
     // Compiler-input errors
     #[error("invalid compiler input: {0}")]
@@ -4341,6 +4365,9 @@ impl ErrorKind {
             // Unchecked-code errors (E1300-E1399)
             ErrorKind::UncheckedOpRequiresChecked { .. } => {
                 ErrorCode::UNCHECKED_OP_REQUIRES_CHECKED
+            }
+            ErrorKind::CheckedReasonMissing | ErrorKind::CheckedReasonEmpty => {
+                ErrorCode::CHECKED_REASON_REQUIRED
             }
 
             // Compiler-input errors (E1400-E1499)
@@ -6101,7 +6128,7 @@ mod tests {
         let names = PreviewFeature::all_names();
         assert_eq!(
             names,
-            "test_infra, c_ffi, non_exhaustive_enums, struct_patterns"
+            "test_infra, c_ffi, non_exhaustive_enums, struct_patterns, checked_reasons"
         );
     }
 

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -686,7 +686,7 @@ impl Shapes<'_> {
                 "checked",
                 "",
                 self.expr(&v.expr),
-                "_".into(),
+                v.reason.as_ref().map_or("_".into(), |_| leaf("string")),
                 "_".into(),
                 "_".into(),
             ),

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -1542,6 +1542,10 @@ pub struct ComptimeBlockExpr {
 /// are only allowed inside checked blocks.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedBlockExpr {
+    /// The block's stated reason (`checked "why this is sound" { ... }`):
+    /// the invariant the programmer relies on. Optional in the tree; the
+    /// `checked_reasons` preview (ADR-0095, spec 9.1:14) requires it.
+    pub reason: Option<StringLit>,
     /// The expression inside the checked block
     pub expr: Box<Expr>,
     pub span: Span,
@@ -2111,6 +2115,9 @@ fn rebind_expr(expr: &mut Expr, file_id: FileId) {
             rebind_span(&mut block.span, file_id);
         }
         Expr::Checked(block) => {
+            if let Some(reason) = &mut block.reason {
+                rebind_span(&mut reason.span, file_id);
+            }
             rebind_expr(&mut block.expr, file_id);
             rebind_span(&mut block.span, file_id);
         }
@@ -2559,7 +2566,10 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
             fmt_expr(f, &comptime.expr, level + 1)
         }
         Expr::Checked(checked) => {
-            writeln!(f, "Checked")?;
+            match &checked.reason {
+                Some(reason) => writeln!(f, "Checked(reason sym:{})", reason.value.into_usize())?,
+                None => writeln!(f, "Checked")?,
+            }
             fmt_expr(f, &checked.expr, level + 1)
         }
         Expr::TypeLit(type_lit) => {

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -179,8 +179,19 @@ impl Parser {
             }
             TokenKind::Checked => {
                 self.bump();
+                // `checked "reason" { ... }`: the optional string is the block's
+                // stated invariant (spec 9.1:14). The parser always accepts it;
+                // semantic analysis gates it on the `checked_reasons` preview.
+                let reason = match self.kind() {
+                    TokenKind::String(value) => {
+                        let span = self.bump().span;
+                        Some(StringLit { value, span })
+                    }
+                    _ => None,
+                };
                 let inner = Expr::Block(self.block()?);
                 Ok(Expr::Checked(CheckedBlockExpr {
+                    reason,
                     expr: Box::new(inner),
                     span: self.span_from(start),
                 }))

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -1722,8 +1722,15 @@ impl<'a> AstGen<'a> {
                     crate::RirStructuralPathSegment::Operand(0),
                     &checked_block.expr,
                 );
+                let reason = checked_block
+                    .reason
+                    .as_ref()
+                    .map(|reason| self.symbol(reason.value));
                 self.rir.add_inst(Inst {
-                    data: InstData::Checked { expr: inner_expr },
+                    data: InstData::Checked {
+                        expr: inner_expr,
+                        reason,
+                    },
                     span: checked_block.span,
                 })
             }

--- a/crates/rue-rir/src/inst/editor.rs
+++ b/crates/rue-rir/src/inst/editor.rs
@@ -1508,9 +1508,12 @@ impl RirEditor {
                             expr: remap_ref(*expr),
                         }))
                     }
-                    InstData::Checked { expr } => self.add_inst(payload_free(InstData::Checked {
-                        expr: remap_ref(*expr),
-                    })),
+                    InstData::Checked { expr, reason } => {
+                        self.add_inst(payload_free(InstData::Checked {
+                            expr: remap_ref(*expr),
+                            reason: reason.map(&mut symbol),
+                        }))
+                    }
                     InstData::TypeConst { type_name } => {
                         self.add_inst(payload_free(InstData::TypeConst {
                             type_name: remap_type(*type_name),

--- a/crates/rue-rir/src/inst/packed.rs
+++ b/crates/rue-rir/src/inst/packed.rs
@@ -1826,7 +1826,11 @@ impl<E, C: FnMut() -> Result<(), E>, P: FnMut(RirSpanSlot, Span) -> Result<(u32,
                 self.reference(*body)?;
             }
             InstData::Comptime { expr } => unary!(58, expr),
-            InstData::Checked { expr } => unary!(59, expr),
+            InstData::Checked { expr, reason } => {
+                self.byte(59)?;
+                self.reference(*expr)?;
+                self.optional_symbol(*reason)?;
+            }
             InstData::TypeConst { type_name } => {
                 self.byte(60)?;
                 self.type_reference(*type_name)?;
@@ -3321,7 +3325,11 @@ impl<
                 add!(InstData::DropFnDecl { type_name, body })
             }
             58 => unary!(Comptime, expr),
-            59 => unary!(Checked, expr),
+            59 => {
+                let expr = self.reference(reader)?;
+                let reason = self.optional_symbol(reader)?;
+                add!(InstData::Checked { expr, reason })
+            }
             60 => {
                 let type_name = self.type_reference(reader)?;
                 add!(InstData::TypeConst { type_name })
@@ -5239,7 +5247,10 @@ mod tests {
             body: block
         });
         add!(InstData::Comptime { expr: unit });
-        add!(InstData::Checked { expr: unit });
+        add!(InstData::Checked {
+            expr: unit,
+            reason: Some(a)
+        });
         add!(InstData::TypeConst { type_name: type_a });
         refs.push(
             editor

--- a/crates/rue-rir/src/inst/printer.rs
+++ b/crates/rue-rir/src/inst/printer.rs
@@ -933,9 +933,16 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 }
 
                 // Checked block
-                InstData::Checked { expr } => {
-                    writeln!(out, "checked {{ {} }}", self.display_ref(*expr)).unwrap();
-                }
+                InstData::Checked { expr, reason } => match reason {
+                    Some(reason) => writeln!(
+                        out,
+                        "checked {:?} {{ {} }}",
+                        self.interner.resolve(reason),
+                        self.display_ref(*expr)
+                    )
+                    .unwrap(),
+                    None => writeln!(out, "checked {{ {} }}", self.display_ref(*expr)).unwrap(),
+                },
 
                 // Type constant
                 InstData::TypeConst { type_name } => {

--- a/crates/rue-rir/src/inst/schema.rs
+++ b/crates/rue-rir/src/inst/schema.rs
@@ -948,6 +948,10 @@ pub enum InstData {
     Checked {
         /// The expression inside the checked block
         expr: InstRef,
+        /// The block's stated reason (`checked "why" { ... }`, spec 9.1:14):
+        /// the invariant the programmer relies on. Inert for evaluation; it
+        /// rides the instruction so the RIR view and tooling can list it.
+        reason: Option<Spur>,
     },
 
     /// Type constant: a type used as a value expression (e.g., `i32` in `identity(i32, 42)`)

--- a/crates/rue-rir/src/inst/validation.rs
+++ b/crates/rue-rir/src/inst/validation.rs
@@ -714,7 +714,7 @@ impl Rir {
                 | InstData::BitNot { operand }
                 | InstData::Try { operand }
                 | InstData::Comptime { expr: operand }
-                | InstData::Checked { expr: operand } => refs!(*operand),
+                | InstData::Checked { expr: operand, .. } => refs!(*operand),
                 InstData::Branch {
                     cond,
                     then_block,
@@ -1086,7 +1086,7 @@ impl Rir {
             | InstData::BitNot { operand }
             | InstData::Try { operand }
             | InstData::Comptime { expr: operand }
-            | InstData::Checked { expr: operand }
+            | InstData::Checked { expr: operand, .. }
             | InstData::Yield(operand) => out.push(*operand),
             InstData::Branch {
                 cond,

--- a/crates/rue-spec/cases/items/unchecked.toml
+++ b/crates/rue-spec/cases/items/unchecked.toml
@@ -6,6 +6,7 @@
 # - `ptr const T` and `ptr mut T` type syntax
 #
 # These features are now part of the language and do not require a preview feature.
+# The reason clause on a `checked` block (9.1:14) is behind `--preview checked_reasons`.
 
 [section]
 id = "items.unchecked"
@@ -251,6 +252,100 @@ fn main() -> i32 {
         @ptr_write(p, 42);
     };
     x
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Checked block reasons (9.1:14-9.1:15, preview feature `checked_reasons`, RUE-1887)
+# =============================================================================
+
+[[case]]
+name = "checked_reason_accepted_under_preview"
+spec = ["9.1:5", "9.1:14", "9.1:15"]
+preview = "checked_reasons"
+preview_should_pass = true
+source = """
+fn first(base: ptr const i32, len: u64) -> i32 {
+    if len == 0 { return 0; }
+    checked "len > 0 was established by the guard above, so index 0 is in bounds" {
+        @ptr_read(base)
+    }
+}
+
+fn main() -> i32 {
+    let value: i32 = 42;
+    let p: ptr const i32 = checked "value is a live local for the whole call" { @raw(value) };
+    first(p, 1)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "checked_reason_does_not_change_the_block_value"
+spec = ["9.1:6", "9.1:14"]
+preview = "checked_reasons"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let x = checked "no unchecked operation; the reason is inert" {
+        let a = 10;
+        let b = 32;
+        a + b
+    };
+    x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "checked_reason_missing_under_preview_rejected"
+spec = ["9.1:14"]
+preview = "checked_reasons"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let value: i32 = 42;
+    let p: ptr const i32 = checked { @raw(value) };
+    checked "p points at value, which outlives this read" { @ptr_read(p) }
+}
+"""
+compile_fail = true
+error_contains = ["[E1301]", "`checked` block must state the invariant it relies on"]
+
+[[case]]
+name = "checked_reason_empty_under_preview_rejected"
+spec = ["9.1:14"]
+preview = "checked_reasons"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    checked "" { 42 }
+}
+"""
+compile_fail = true
+error_contains = ["[E1301]", "reason must not be empty"]
+
+[[case]]
+name = "checked_reason_without_preview_rejected"
+spec = ["9.1:14", "8.4:1"]
+source = """
+fn main() -> i32 {
+    checked "a reason without the preview" { 42 }
+}
+"""
+compile_fail = true
+error_contains = ["[E1100]", "checked block reasons requires preview feature `checked_reasons`"]
+
+[[case]]
+name = "checked_block_without_reason_still_accepted_without_preview"
+spec = ["9.1:5", "9.1:14"]
+description = "Without the preview, today's reason-less checked blocks compile unchanged"
+source = """
+fn main() -> i32 {
+    let value: i32 = 42;
+    let p: ptr const i32 = checked { @raw(value) };
+    checked { @ptr_read(p) }
 }
 """
 exit_code = 42

--- a/crates/rue-ui-tests/cases/diagnostics/checked_reasons.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/checked_reasons.toml
@@ -1,0 +1,59 @@
+# Checked block reasons (RUE-1887, ADR-0095, spec 9.1:14).
+#
+# Under `--preview checked_reasons` a `checked` block states the invariant it
+# relies on as a string literal between the keyword and the block. These pin
+# the three diagnostics: the preview gate when a reason appears without the
+# flag, the missing reason, and the empty reason, and that the missing-reason
+# error points at the block that lacks it, not at the one that has one.
+
+[section]
+id = "diagnostics.checked_reasons"
+name = "Checked block reason diagnostics"
+description = "Pins the diagnostics of the checked_reasons preview (spec 9.1:14, RUE-1887): the preview gate, the missing reason, and the empty reason."
+
+[[case]]
+name = "reason_without_preview_names_the_flag"
+source = """
+fn main() -> i32 {
+    checked "a stated reason" { 42 }
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E1100]",
+    "checked block reasons requires preview feature `checked_reasons`",
+    "use --preview checked_reasons to enable this feature (ADR-0095)",
+]
+
+[[case]]
+name = "missing_reason_points_at_the_block_that_lacks_it"
+preview = "checked_reasons"
+source = """
+fn main() -> i32 {
+    let value: i32 = 42;
+    let p: ptr const i32 = checked "value is a live local for the whole call" { @raw(value) };
+    checked { @ptr_read(p) }
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E1301]",
+    "`checked` block must state the invariant it relies on",
+    "4:5",
+    "state the invariant as a string literal after `checked`, e.g. `checked \"index < len by the guard above\" { ... }`",
+]
+
+[[case]]
+name = "empty_reason_is_rejected"
+preview = "checked_reasons"
+source = """
+fn main() -> i32 {
+    checked "" { 42 }
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E1301]",
+    "`checked` block reason must not be empty",
+]
+

--- a/docs/designs/0095-checked-block-reasons.md
+++ b/docs/designs/0095-checked-block-reasons.md
@@ -1,0 +1,103 @@
+---
+id: 0095
+title: "Checked block reasons: every checked site states the invariant it relies on"
+status: accepted
+tags: [language, syntax, semantics, unchecked, tooling]
+feature-flag: checked_reasons
+created: 2026-09-11
+accepted: 2026-09-10
+implemented:
+spec-sections: ["9.1:5", "9.1:14", "9.1:15"]
+superseded-by:
+relates: ["RUE-1887", "RUE-195", "RUE-1912", "ADR-0005", "ADR-0028"]
+---
+
+# ADR-0095: Checked block reasons: every checked site states the invariant it relies on
+
+## Status
+
+Accepted on 2026-09-10 by Steve (the RUE-1887 ruling). Phase 1, the reason
+clause on `checked` blocks, is implemented behind the `checked_reasons`
+preview feature.
+
+## Summary
+
+A `checked` block carries the reason it is sound, as a string literal between
+the keyword and the block:
+
+```rue
+checked "index < len was established by the guard above" {
+    @ptr_read(@ptr_offset(base, index))
+}
+```
+
+The reason is part of the syntax tree, so it survives formatting, reaches the
+RIR and the `--emit` views, and cannot drift away from the block it justifies.
+Under the preview the reason is required and must not be empty; there is no
+allow-list escape. Once the feature stabilizes, every `checked` block in every
+Rue program states its invariant.
+
+## Context
+
+A `checked` block is where the programmer takes over an obligation the
+compiler cannot discharge (ADR-0028). The block itself is not the risk. The
+risk is that the invariant it relies on is never written down: a reviewer has
+to reconstruct it, and an agent that wrote the block never had to articulate
+it. Rust learned this the hard way and bolted `undocumented_unsafe_blocks` on
+as an opt-in lint; Rue can make it grammar. For agent-written code the cost is
+nothing and the forcing function is the benefit: the one part of the language
+the compiler cannot check is the part where a stated reason earns reviewer
+trust.
+
+A string literal was chosen over a recognized comment form because a literal
+is a node of the tree. It survives a formatter, it is visible in every emitted
+view of the program, and it cannot be separated from the block by an edit
+that moves one line.
+
+## Decision
+
+- `checked_expr = "checked" [ STRING ] "{" block "}"`. The optional string is
+  the block's reason.
+- With `--preview checked_reasons`, a `checked` block without a reason, or
+  with an empty one, is a compile error (E1301) at the block. Without the
+  preview, a reason is refused by the ordinary preview gate (E1100), so
+  today's programs are unchanged.
+- The reason has no effect on the block's value, type, or evaluation
+  (9.1:6). It is carried on the RIR `Checked` instruction and shown by the
+  RIR printer and the syntax and RIR artifact views, which is the surface a
+  listing of every checked site with its invariant will be built on.
+
+## Implementation Phases
+
+- [x] **Phase 1: reason clause on `checked` blocks, behind the preview** -
+  RUE-1887
+- [ ] **Phase 2: the same clause on `unchecked fn`**, stating the
+  precondition the caller upholds. The issue asks for it; the spelling is
+  not yet ruled on. The candidate consistent with phase 1 is
+  `unchecked "precondition" fn name(...)`: the reason follows the keyword it
+  justifies.
+- [ ] **Phase 3: a query that lists every checked site with its reason**,
+  the audit surface for a reviewer of agent-written code.
+- [ ] **Phase 4: stabilization**: the reason becomes mandatory everywhere,
+  the standard library, tests, examples, tutorial, and corpus are ported,
+  and the preview gate is removed. RUE-195 (the keyword names) should be
+  settled first, since the clause attaches to whichever keyword survives.
+
+## Consequences
+
+### Positive
+
+- Every unchecked site states what it relies on, in a place tooling can read.
+- No new semantics: the reason is inert at run time and in comptime.
+
+### Negative
+
+- Ceremony on every `checked` block once stabilized. The standard library has
+  many; the port is mechanical and the reasons already exist as comments in
+  most of them.
+
+## References
+
+- [Specification 9.1](../spec/src/09-unchecked-code/01-syntax.md)
+- [ADR-0028: Unsafe code and raw pointers](0028-unsafe-and-raw-pointers.md)
+- [ADR-0005: Preview Features](0005-preview-features.md)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -257,4 +257,5 @@ The table is generated from ADR frontmatter. Run
 | [0092](0092-no-configuration-declarations.md) | No configuration declarations: target behavior through comptime | Accepted | language, semantics, comptime, principle |
 | [0093](0093-order-independent-program-meaning.md) | Order-independent program meaning | Accepted | language, semantics, modules, principle |
 | [0094](0094-no-default-arguments.md) | No default arguments: every call spells every argument | Accepted | language, syntax, semantics, principle |
+| [0095](0095-checked-block-reasons.md) | Checked block reasons: every checked site states the invariant it relies on | Accepted | language, syntax, semantics, unchecked, tooling |
 <!-- ADR-INDEX:END -->

--- a/docs/spec/src/09-unchecked-code/01-syntax.md
+++ b/docs/spec/src/09-unchecked-code/01-syntax.md
@@ -41,8 +41,10 @@ A `checked` block is an expression that enables unchecked operations within its 
 {{ rule(id="9.1:5", cat="syntax") }}
 
 ```ebnf
-checked_expr = "checked" "{" block "}" ;
+checked_expr = "checked" [ STRING ] "{" block "}" ;
 ```
+
+The optional string literal is the block's *reason* (9.1:14).
 
 {{ rule(id="9.1:6", cat="dynamic-semantics") }}
 
@@ -61,6 +63,34 @@ fn main() -> i32 {
         a + b
     };
     x
+}
+```
+
+{{ preview_feature(feature="checked_reasons", adr="ADR-0095", doc="0095-checked-block-reasons.md") }}
+
+{{ rule(id="9.1:14", cat="legality-rule") }}
+
+A `checked` block **MAY** state the invariant it relies on as a string
+literal between `checked` and the block: its *reason*. The reason is part of
+the syntax tree and is carried through the compiler's emitted views of the
+program; it has no effect on the block's value, type, or evaluation (9.1:6).
+Checked block reasons are a preview feature: a `checked` block that states a
+reason **MUST** be compiled with `--preview checked_reasons` (8.4:1). Under
+that preview every `checked` block **MUST** state a reason, and the reason
+**MUST NOT** be empty; a block that omits its reason, or states an empty
+one, is rejected with E1301 at the block. There is no allow-list or
+per-site opt-out: the point of the rule is that every site where the
+programmer takes over an obligation from the compiler has been thought about
+and says so.
+
+{{ rule(id="9.1:15", cat="example") }}
+
+```rue
+fn first(base: ptr const i32, len: u64) -> i32 {
+    if len == 0 { return 0; }
+    checked "len > 0 was established by the guard above, so index 0 is in bounds" {
+        @ptr_read(base)
+    }
 }
 ```
 

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -227,7 +227,7 @@ primitive_type_literal = "i8" | "i16" | "i32" | "i64"
 (* Compound expressions *)
 block_expr     = "{" block "}" ;
 comptime_expr  = "comptime" "{" block "}" ;
-checked_expr   = "checked" "{" block "}" ;
+checked_expr   = "checked" [ STRING ] "{" block "}" ;   (* the STRING is the block's reason, 9.1:14; preview `checked_reasons` *)
 control_flow_expr = if_expr | match_expr | while_expr | loop_expr | for_expr
                   | break_expr | "continue" | return_expr ;
 if_expr        = "if" expression "{" block "}" [ else_clause ] ;


### PR DESCRIPTION
Phase 1 of the RUE-1887 ruling (a mandatory stated reason on every `checked` block), behind `--preview checked_reasons` per ADR-0005:

```rue
checked "index < len was established by the guard above" {
    @ptr_read(@ptr_offset(base, index))
}
```

- **Parser**: an optional string literal between `checked` and the block, carried on `CheckedBlockExpr`.
- **Sema**: under the preview, a block without a reason or with an empty one is **E1301** at the block, with no per-site opt-out. Without the preview a reason is refused by the ordinary **E1100** gate, so every existing program is unchanged (no std, test, example, or corpus edits).
- **RIR**: the reason rides the `Checked` instruction as an optional symbol (packed encoding, editor remap, validation). It is inert for typing, evaluation, and comptime. `--emit rir`, `--emit ast`, and the syntax artifact view show it, which is the surface a listing of checked sites will read.
- **Spec**: 9.1:5 gains the production; new 9.1:14 (legality rule) and 9.1:15 (example); grammar appendix updated.
- **ADR-0095** records the decision and the phases. Deferred and flagged on the Linear issue: the `unchecked fn` clause (the issue asks for it but its spelling is not ruled on; the consistent candidate is `unchecked "precondition" fn f()`), the listing query, and stabilization with the ~750-site port (which should wait on RUE-195, the keyword-naming decision).
- Tests: six spec cases under 9.1:14/9.1:15, three UI cases pinning the wording and spans, a CLI emit case, the explain corpus for E1301, and the two "Available features" strings.

Validation: spec 9.1 and golden, UI diagnostics (all), CLI explain/emit/preview, spec traceability, ADR registry and doc-link validators, `scripts/rue quick`, frontend-diff unit tests, and the oracle-diff corpus gate all pass locally.

Refs RUE-1887