### PR TITLE
RUE-2131: share the daemon across watch and presentation requests

### DIFF
--- a/crates/rue-cli-tests/cases/daemon.toml
+++ b/crates/rue-cli-tests/cases/daemon.toml
@@ -31,9 +31,9 @@ description = "start launches once and then finds the running service; status re
 files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
 daemon = { steps = [
   { args = ["daemon", "start", "--idle-timeout-ms", "60000"], exit_code = 0, stdout_contains = ["rue daemon: started service pid"] },
-  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["rue daemon: running", "  protocol: 2", "  active request: none", "  retained hosts: 0", "  idle timeout: 60000 ms", "  isolation: none", "  resource policy: connections 1/33; queued 0/8; hosts 0/1", "  source snapshot: 0 files, 0 bytes"] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["rue daemon: running", "  protocol: 3", "  active request: none", "  retained hosts: 0", "  idle timeout: 60000 ms", "  isolation: none", "  resource policy: connections 1/33; queued 0/8; hosts 0/1", "  source snapshot: 0 files, 0 bytes"] },
   { args = ["daemon", "start", "--idle-timeout-ms", "60000"], exit_code = 0, stdout_contains = ["is already running for"], stdout_not_contains = ["started service"] },
-  { args = ["daemon", "status", "--json"], exit_code = 0, stdout_contains = ["\"protocol_version\":2", "\"retained_hosts\":0", "\"service_hex\":", "\"max_connections\":33", "\"max_queued_requests\":8", "\"peak_retained_charge_bytes\":0", "\"peak_response_bytes\":0"] },
+  { args = ["daemon", "status", "--json"], exit_code = 0, stdout_contains = ["\"protocol_version\":3", "\"retained_hosts\":0", "\"service_hex\":", "\"max_connections\":33", "\"max_queued_requests\":8", "\"peak_retained_charge_bytes\":0", "\"peak_response_bytes\":0"] },
   { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["rue daemon: stopped service pid"] },
   { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
   { args = ["daemon", "stop"], exit_code = 0, stdout_contains = ["no service was running for"] },
@@ -119,20 +119,18 @@ daemon = { steps = [
 
 [[case]]
 name = "the_support_table_decides_between_service_and_direct"
-description = "Requests outside the support table run directly under auto and are refused before any work under required; a refused request starts no service."
+description = "Unsupported lifecycle and linker options still run directly or refuse before work, while daemon presentation stages use the shared service pipeline."
 files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }\n" }]
 daemon = { steps = [
-  { args = ["--daemon=required", "--emit", "cfg", "main.rue"], exit_code = 1, stderr_contains = ["Error: --daemon=required: --emit stages other than a sole `air` run directly"] },
-  { args = ["--daemon=required", "--error-format", "json", "--emit", "air", "--emit", "cfg", "main.rue"], exit_code = 1, stderr_contains = ["\"code\":\"E1503\"", "--emit stages other than a sole `air` run directly"] },
-  { args = ["--daemon=required", "--watch", "main.rue"], exit_code = 1, stderr_contains = ["Error: --daemon=required: --watch runs directly"] },
+  { args = ["--daemon=required", "--emit", "cfg", "main.rue"], exit_code = 0, stdout_contains = ["=== CFG ==="] },
+  { args = ["--daemon=required", "--error-format", "json", "--emit", "air", "--emit", "cfg", "main.rue"], exit_code = 0, stdout_contains = ["=== AIR ===", "=== CFG ==="] },
   { args = ["--daemon=required", "--linker", "cc", "main.rue"], exit_code = 1, stderr_contains = ["a system linker runs directly"] },
   { args = ["--daemon=required", "--time-passes", "main.rue"], exit_code = 1, stderr_contains = ["--time-passes runs directly"] },
   { args = ["--daemon=required", "--log-level", "debug", "main.rue"], exit_code = 1, stderr_contains = ["compiler tracing (--log-level) runs directly"] },
-  { args = ["--daemon=required", "test", "--watch", "main.rue"], exit_code = 2, stderr_contains = ["Error: --daemon=required: --watch runs directly"] },
   { args = ["--daemon=auto", "--emit", "deps", "main.rue"], exit_code = 0, stdout_contains = ["main.rue"] },
   { args = ["--daemon=sometimes", "main.rue"], exit_code = 1, stderr_contains = ["unknown --daemon mode `sometimes`"] },
   { args = ["--daemon-scope", ".", "main.rue"], exit_code = 1, stderr_contains = ["--daemon-scope requires --daemon=auto or --daemon=required"] },
-  { args = ["daemon", "status"], exit_code = 1, stderr_contains = ["no service is running for"] },
+  { args = ["daemon", "status"], exit_code = 0, stdout_contains = ["rue daemon: running", "  retained hosts: 1"] },
 ] }
 
 [[case]]

--- a/crates/rue-cli-tests/cases/watch.toml
+++ b/crates/rue-cli-tests/cases/watch.toml
@@ -390,6 +390,52 @@ path = "extra.rue"
 source = "pub fn broken() -> i32 { 2 }\n"
 
 [[case]]
+name = "daemon_watch_edits_and_republishes"
+description = "The daemon-backed executable watcher republishes an edited transitive module."
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+]
+args = ["--daemon=required"]
+[case.watch]
+kind = "edit"
+expected_exit_codes = [1, 2]
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 2 }\n"
+
+[[case]]
+name = "daemon_watch_deleted_import_recovers_when_restored"
+description = "The daemon-backed executable watcher observes a deleted transitive import and resumes after restoration."
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 3 }\n" },
+]
+args = ["--daemon=required"]
+[case.watch]
+kind = "delete"
+expected_exit_codes = [3, 4]
+[[case.watch.edits]]
+path = "helper.rue"
+delete = true
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 4 }\n"
+
+[[case]]
+name = "daemon_watch_missing_import_recovers_when_created"
+description = "The daemon-backed watcher retains an initial missing import observation until the file is created."
+files = [{ path = "main.rue", source = "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.answer() }\n" }]
+args = ["--daemon=required"]
+[case.watch]
+kind = "initial_failure"
+expected_exit_codes = [5]
+stderr_contains = ["E0704"]
+[[case.watch.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 5 }\n"
+
+[[case]]
 name = "an_edit_beside_a_directory_in_a_modules_place_is_acknowledged"
 description = """
 RUE-2105, the other shape of the same read failure: a directory where a module

--- a/crates/rue-cli-tests/cases/watch_test.toml
+++ b/crates/rue-cli-tests/cases/watch_test.toml
@@ -629,3 +629,70 @@ path = "extra.rue"
 source = """
 pub fn broken() -> i32 { 2 }
 """
+
+
+[[case]]
+name = "daemon_required_watch_reuses_the_shared_test_lifecycle"
+description = "The daemon-backed test watcher uses the same deterministic cycle protocol as the direct watcher while the service owns compilation."
+files = [{ path = "main.rue", source = "test \"works\" { @assert(1 == 1); }\nfn main() -> i32 { 0 }\n" }]
+[case.watch_test]
+kind = "edit"
+args = ["--daemon=required"]
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    '"cycle":2,"event":"run_started"',
+    '"compile_error":0,"crash":0,"event":"run_finished"',
+]
+stdout_not_contains = ['"event":"run_canceled"']
+
+[[case.watch_test.edits]]
+path = "main.rue"
+source = "test \"works\" { @assert(2 == 2); }\nfn main() -> i32 { 0 }\n"
+
+[[case]]
+name = "daemon_required_watch_reports_deleted_import_and_repairs"
+description = "The daemon-backed test watcher suppresses a failed deleted-import cycle and resumes after repair."
+files = [
+    { path = "main.rue", source = "const tests = @import(\"tests.rue\");\nfn main() -> i32 { 0 }\n" },
+    { path = "tests.rue", source = "const helper = @import(\"helper.rue\");\ntest \"works\" { @assert(helper.answer() == 1); }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 1 }\n" },
+]
+[case.watch_test]
+kind = "compile_error"
+args = ["--daemon=required"]
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_started"',
+    # The deleted import fails after the accepted test image attempt, so cycle
+    # 2 has no run events and the repaired revision is cycle 3.
+    '"cycle":3,"event":"run_started"',
+    '"event":"run_finished"',
+]
+stderr_contains = ["E0704"]
+[[case.watch_test.edits]]
+path = "helper.rue"
+delete = true
+[[case.watch_test.edits]]
+path = "helper.rue"
+source = "pub fn answer() -> i32 { 1 }\n"
+
+[[case]]
+name = "daemon_required_watch_cancels_running_test_and_reuses_scratch_cycles"
+description = "A daemon-backed test watch cancels its running client-owned process group and starts the next cycle."
+files = [
+    { path = "main.rue", source = "test \"spins\" { let mut i: i32 = 0; while i >= 0 { if i > 0 { i = i - 1; } } }\nfn main() -> i32 { 0 }\n" },
+]
+[case.watch_test]
+kind = "cancel"
+args = ["--daemon=required"]
+timeout_ms = 8000
+expected_exit = 0
+stdout_contains = [
+    '"cycle":1,"event":"run_canceled"',
+    '"cycle":2,"event":"run_started"',
+    '"event":"run_finished"',
+]
+[[case.watch_test.edits]]
+path = "main.rue"
+source = "test \"settles\" { @assert(1 + 1 == 2); }\nfn main() -> i32 { 0 }\n"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -3503,12 +3503,28 @@ fn run_watch_case(
         output_name.to_string(),
         "--watch".to_string(),
     ]);
+    let daemon_watch = case
+        .args
+        .as_ref()
+        .is_some_and(|args| args.iter().any(|arg| arg.starts_with("--daemon=")));
+    let preparation_failure_event = if daemon_watch {
+        "reobserve-error"
+    } else {
+        "compile-error"
+    };
+    if let Some(args) = &case.args {
+        compiler_args.extend(args.iter().cloned());
+    }
+    let daemon_root = daemon_watch.then(|| dir.join("daemon-root"));
     let mut command = case_compiler_command(rue_binary, &compiler_args, dir, &case.env, real_std);
     command
         .env("RUE_WATCH_TEST_PROTOCOL", &protocol)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    if let Some(root) = &daemon_root {
+        command.env("RUE_DAEMON_ROOT", root);
+    }
     if let Some(delay) = scenario.compile_delay_ms {
         command.env("RUE_WATCH_TEST_COMPILE_DELAY_MS", delay.to_string());
     }
@@ -3553,7 +3569,13 @@ fn run_watch_case(
         if scenario.kind == WatchScenarioKind::InitialFailure {
             // The very first cycle is the one that fails, so there is no
             // opening publication to wait for and nothing on disk to run.
-            wait_for_watch_event(&mut child, &protocol, "compile-error", 1, deadline)?;
+            wait_for_watch_event(
+                &mut child,
+                &protocol,
+                preparation_failure_event,
+                1,
+                deadline,
+            )?;
             if program.exists() {
                 return Err("a failed first watch cycle must publish nothing".to_string());
             }
@@ -3588,13 +3610,19 @@ fn run_watch_case(
                 // A deleted transitive input can first be observed as a
                 // closed-invalid revision by the current host snapshot; the
                 // next cycle then reobserves the restored closure.
-                wait_for_watch_event(&mut child, &protocol, "compile-error", 1, deadline)?;
+                wait_for_watch_event(
+                    &mut child,
+                    &protocol,
+                    preparation_failure_event,
+                    1,
+                    deadline,
+                )?;
                 write_watch_edit(dir, &scenario.edits[1])?;
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
                 let events = watch_events(&protocol);
                 let failure = events
                     .iter()
-                    .position(|event| event == "compile-error")
+                    .position(|event| event == preparation_failure_event)
                     .ok_or_else(|| "watch failure anchor disappeared".to_string())?;
                 let reobserve = events
                     .iter()
@@ -3777,6 +3805,9 @@ fn run_watch_case(
     })();
 
     let (status, stdout_bytes, stderr_bytes) = finish_watch_child(child, stdout, stderr, true);
+    if let Some(root) = &daemon_root {
+        stop_leftover_daemon(case, rue_binary, real_std, dir, root);
+    }
     let result = result.and_then(|()| {
         for expected in &scenario.stderr_contains {
             if !contains_bytes(&stderr_bytes, expected) {
@@ -3879,6 +3910,8 @@ fn run_watch_test_case(
         compiler_args.push(timeout.to_string());
     }
     compiler_args.extend(scenario.args.iter().cloned());
+    let daemon_watch = scenario.args.iter().any(|arg| arg.starts_with("--daemon="));
+    let daemon_root = daemon_watch.then(|| dir.join("daemon-root"));
 
     let mut command = case_compiler_command(rue_binary, &compiler_args, dir, &case.env, real_std);
     command
@@ -3886,6 +3919,9 @@ fn run_watch_test_case(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    if let Some(root) = &daemon_root {
+        command.env("RUE_DAEMON_ROOT", root);
+    }
     configure_process_group(&mut command);
     let mut child = command.spawn().map_err(|error| {
         TestFailure::fatal(format!("failed to spawn watch-test process: {error}"))
@@ -3921,8 +3957,31 @@ fn run_watch_test_case(
             }
             WatchTestScenarioKind::CompileError => {
                 wait_for_watch_event(&mut child, &protocol, "run-finished", 1, deadline)?;
+                let initial_events = watch_events(&protocol).len();
                 write_watch_edit(dir, &scenario.edits[0])?;
                 wait_for_watch_event(&mut child, &protocol, "compile-error", 1, deadline)?;
+                let events = watch_events(&protocol);
+                let phases: Vec<&str> = events[initial_events..]
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|event| {
+                        event.starts_with("reobserve-")
+                            || event.starts_with("acquire-")
+                            || event.starts_with("compile-")
+                    })
+                    .collect();
+                let expected = [
+                    "reobserve-started",
+                    "reobserve-ok",
+                    "acquire-ok",
+                    "compile-started",
+                    "compile-error",
+                ];
+                if phases != expected {
+                    return Err(format!(
+                        "accepted image failure phases differ: expected {expected:?}, actual {phases:?}"
+                    ));
+                }
                 // A failed cycle publishes no events at all: the head event is
                 // owed only to a run that began (test-events.md, "Streams").
                 if watch_event_count(&protocol, "run-started") != 1 {
@@ -3989,6 +4048,9 @@ fn run_watch_test_case(
     })();
 
     let (status, stdout_bytes, stderr_bytes) = finish_watch_child(child, stdout, stderr, true);
+    if let Some(root) = &daemon_root {
+        stop_leftover_daemon(case, rue_binary, real_std, dir, root);
+    }
     let result = result.and_then(|()| {
         let exit = interrupted
             .and_then(|status| status.code())

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -3507,11 +3507,6 @@ fn run_watch_case(
         .args
         .as_ref()
         .is_some_and(|args| args.iter().any(|arg| arg.starts_with("--daemon=")));
-    let preparation_failure_event = if daemon_watch {
-        "reobserve-error"
-    } else {
-        "compile-error"
-    };
     if let Some(args) = &case.args {
         compiler_args.extend(args.iter().cloned());
     }
@@ -3575,13 +3570,7 @@ fn run_watch_case(
         if scenario.kind == WatchScenarioKind::InitialFailure {
             // The very first cycle is the one that fails, so there is no
             // opening publication to wait for and nothing on disk to run.
-            wait_for_watch_event(
-                &mut child,
-                &protocol,
-                preparation_failure_event,
-                1,
-                deadline,
-            )?;
+            wait_for_watch_event(&mut child, &protocol, "compile-error", 1, deadline)?;
             if program.exists() {
                 return Err("a failed first watch cycle must publish nothing".to_string());
             }
@@ -3616,19 +3605,13 @@ fn run_watch_case(
                 // A deleted transitive input can first be observed as a
                 // closed-invalid revision by the current host snapshot; the
                 // next cycle then reobserves the restored closure.
-                wait_for_watch_event(
-                    &mut child,
-                    &protocol,
-                    preparation_failure_event,
-                    1,
-                    deadline,
-                )?;
+                wait_for_watch_event(&mut child, &protocol, "compile-error", 1, deadline)?;
                 write_watch_edit(dir, &scenario.edits[1])?;
                 wait_for_watch_event(&mut child, &protocol, "published", 2, deadline)?;
                 let events = watch_events(&protocol);
                 let failure = events
                     .iter()
-                    .position(|event| event == preparation_failure_event)
+                    .position(|event| event == "compile-error")
                     .ok_or_else(|| "watch failure anchor disappeared".to_string())?;
                 let reobserve = events
                     .iter()

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -3515,7 +3515,13 @@ fn run_watch_case(
     if let Some(args) = &case.args {
         compiler_args.extend(args.iter().cloned());
     }
-    let daemon_root = daemon_watch.then(|| dir.join("daemon-root"));
+    let daemon_temp_dir = daemon_watch
+        .then(|| short_private_temp_dir("rw"))
+        .transpose()
+        .map_err(|error| {
+            TestFailure::fatal(format!("failed to create watch daemon temp dir: {error}"))
+        })?;
+    let daemon_root = daemon_temp_dir.as_ref().map(|dir| dir.path().join("r"));
     let mut command = case_compiler_command(rue_binary, &compiler_args, dir, &case.env, real_std);
     command
         .env("RUE_WATCH_TEST_PROTOCOL", &protocol)
@@ -3911,7 +3917,13 @@ fn run_watch_test_case(
     }
     compiler_args.extend(scenario.args.iter().cloned());
     let daemon_watch = scenario.args.iter().any(|arg| arg.starts_with("--daemon="));
-    let daemon_root = daemon_watch.then(|| dir.join("daemon-root"));
+    let daemon_temp_dir = daemon_watch
+        .then(|| short_private_temp_dir("rw"))
+        .transpose()
+        .map_err(|error| {
+            TestFailure::fatal(format!("failed to create watch daemon temp dir: {error}"))
+        })?;
+    let daemon_root = daemon_temp_dir.as_ref().map(|dir| dir.path().join("r"));
 
     let mut command = case_compiler_command(rue_binary, &compiler_args, dir, &case.env, real_std);
     command

--- a/crates/rue/src/daemon/client.rs
+++ b/crates/rue/src/daemon/client.rs
@@ -8,11 +8,10 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use super::protocol::{
-    BuildReply, BuildRequest, BuildResult, Hello, HelloReply, MAX_CONTROL_FRAME_BYTES,
-    MAX_RESULT_FRAME_BYTES, Request, RequestBody, Response, ResponseBody, ServiceInfo,
-    StatusReport, read_chunks, read_frame, write_frame,
+    BuildObservations, BuildReply, BuildRequest, BuildResult, Hello, HelloReply,
+    MAX_CONTROL_FRAME_BYTES, MAX_RESULT_FRAME_BYTES, Request, RequestBody, Response, ResponseBody,
+    ServiceInfo, StatusReport, read_chunks, read_frame, write_frame,
 };
-
 /// Why a connection could not be established or used.
 #[derive(Debug)]
 pub enum ConnectError {
@@ -26,6 +25,8 @@ pub enum ConnectError {
     Rejected(String),
     /// The peer did not follow the protocol.
     Protocol(String),
+    /// A watch input changed while this request was compiling.
+    WatchSuperseded,
     Io(io::Error),
 }
 
@@ -39,6 +40,7 @@ impl std::fmt::Display for ConnectError {
                 write!(formatter, "the service refused this client: {reason}")
             }
             Self::Protocol(reason) => write!(formatter, "protocol error: {reason}"),
+            Self::WatchSuperseded => formatter.write_str("the watched source changed"),
             Self::Io(error) => write!(formatter, "{error}"),
         }
     }
@@ -53,17 +55,36 @@ impl From<io::Error> for ConnectError {
 impl From<super::protocol::FrameError> for ConnectError {
     fn from(error: super::protocol::FrameError) -> Self {
         match error {
+            super::protocol::FrameError::Io(error)
+                if error
+                    .get_ref()
+                    .is_some_and(|source| source.is::<WatchSupersededIo>()) =>
+            {
+                Self::WatchSuperseded
+            }
             super::protocol::FrameError::Io(error) => Self::Io(error),
             other => Self::Protocol(other.to_string()),
         }
     }
 }
 
+#[derive(Debug)]
+struct WatchSupersededIo;
+
+impl std::fmt::Display for WatchSupersededIo {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("the watched source changed")
+    }
+}
+
+impl std::error::Error for WatchSupersededIo {}
+
 /// An established, identity-checked connection to a service.
 pub struct Connection {
     stream: UnixStream,
     service: ServiceInfo,
     next_id: u64,
+    observations: BuildObservations,
 }
 
 impl std::fmt::Debug for Connection {
@@ -121,6 +142,7 @@ pub fn connect(
             stream,
             service,
             next_id: 1,
+            observations: BuildObservations::default(),
         }),
         HelloReply::Rejected { reason } => Err(ConnectError::Rejected(reason)),
     }
@@ -255,27 +277,83 @@ impl Connection {
         } else {
             0
         };
-        let reply: BuildReply = read_frame(
+        let (reply, bytes) = read_build_reply(
             &mut first_byte[..prefix_len].chain(&mut self.stream),
-            MAX_RESULT_FRAME_BYTES,
-        )?
-        .ok_or_else(|| ConnectError::Protocol("the service closed mid-request".into()))?;
-        if reply.ticket != ticket {
-            return Err(ConnectError::Protocol(format!(
-                "the service answered ticket {} while {ticket} was pending",
-                reply.ticket
-            )));
-        }
-        let bytes = match &reply.result {
-            BuildResult::Ready { bytes, .. } => read_chunks(&mut self.stream, *bytes)?,
-            _ => Vec::new(),
-        };
+            ticket,
+        )?;
+        self.observations = reply.observations.clone();
         Ok((
             reply.result,
             bytes,
             reply.measurement,
             transfer_started.map(|started| started.elapsed().as_nanos() as u64),
         ))
+    }
+
+    /// Await an admitted build while the caller's shared watch monitor owns
+    /// cancellation. Dropping this connection after `true` cancels only this
+    /// service request through its peer watcher.
+    pub fn await_build_cancellable<F: Fn() -> bool>(
+        &mut self,
+        ticket: u64,
+        canceled: F,
+    ) -> Result<(BuildResult, Vec<u8>), ConnectError> {
+        self.stream.set_nonblocking(true)?;
+        let mut reader = CancellableReader {
+            stream: &mut self.stream,
+            canceled: &canceled,
+        };
+        let (reply, bytes) = read_build_reply(&mut reader, ticket)?;
+        self.observations = reply.observations.clone();
+        self.stream.set_nonblocking(false)?;
+        Ok((reply.result, bytes))
+    }
+
+    /// Observations from the most recently completed build request.
+    pub fn observations(&self) -> &BuildObservations {
+        &self.observations
+    }
+}
+
+/// One decoder for ordinary, measured, and cancelable build clients. Readers
+/// supply their timing or cancellation policy around the same frame/chunk path.
+fn read_build_reply(
+    reader: &mut impl Read,
+    ticket: u64,
+) -> Result<(BuildReply, Vec<u8>), ConnectError> {
+    let reply: BuildReply = read_frame(reader, MAX_RESULT_FRAME_BYTES)?
+        .ok_or_else(|| ConnectError::Protocol("the service closed mid-request".into()))?;
+    if reply.ticket != ticket {
+        return Err(ConnectError::Protocol(format!(
+            "the service answered ticket {} while {ticket} was pending",
+            reply.ticket
+        )));
+    }
+    let bytes = match &reply.result {
+        BuildResult::Ready { bytes, .. } => read_chunks(reader, *bytes)?,
+        _ => Vec::new(),
+    };
+    Ok((reply, bytes))
+}
+
+struct CancellableReader<'a, F> {
+    stream: &'a mut UnixStream,
+    canceled: &'a F,
+}
+
+impl<F: Fn() -> bool> Read for CancellableReader<'_, F> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        loop {
+            if (self.canceled)() {
+                return Err(io::Error::other(WatchSupersededIo));
+            }
+            match self.stream.read(buffer) {
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                result => return result,
+            }
+        }
     }
 }
 
@@ -318,5 +396,151 @@ fn unexpected(expected: &str, actual: &ResponseBody) -> ConnectError {
     match actual {
         ResponseBody::Error { message } => ConnectError::Protocol(message.clone()),
         other => ConnectError::Protocol(format!("expected {expected}, got {other:?}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+
+    fn send_in_pieces(mut stream: UnixStream, pieces: Vec<Vec<u8>>) {
+        for piece in pieces {
+            stream.write_all(&piece).unwrap();
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    fn framed(body: &[u8]) -> Vec<u8> {
+        let mut frame = (body.len() as u32).to_be_bytes().to_vec();
+        frame.extend_from_slice(body);
+        frame
+    }
+
+    #[test]
+    fn cancellable_frame_reassembles_partial_header_and_body() {
+        let (writer, mut reader) = UnixStream::pair().unwrap();
+        reader.set_nonblocking(true).unwrap();
+        let body = serde_json::to_vec("fragmented response").unwrap();
+        let frame = framed(&body);
+        let writer = thread::spawn(move || {
+            send_in_pieces(
+                writer,
+                vec![
+                    frame[..1].to_vec(),
+                    frame[1..3].to_vec(),
+                    frame[3..7].to_vec(),
+                    frame[7..].to_vec(),
+                ],
+            );
+        });
+        let canceled = || false;
+        let mut adapter = CancellableReader {
+            stream: &mut reader,
+            canceled: &canceled,
+        };
+        let received: String = read_frame(&mut adapter, 1024).unwrap().unwrap();
+        writer.join().unwrap();
+        assert_eq!(received.as_bytes(), &body[1..body.len() - 1]);
+    }
+
+    #[test]
+    fn cancellable_chunks_reassemble_across_fragmented_frames() {
+        let (writer, mut reader) = UnixStream::pair().unwrap();
+        reader.set_nonblocking(true).unwrap();
+        let writer = thread::spawn(move || {
+            let first = framed(b"first ");
+            let second = framed(b"chunk");
+            send_in_pieces(
+                writer,
+                vec![
+                    first[..2].to_vec(),
+                    first[2..].to_vec(),
+                    second[..1].to_vec(),
+                    second[1..].to_vec(),
+                ],
+            );
+        });
+        let canceled = || false;
+        let mut adapter = CancellableReader {
+            stream: &mut reader,
+            canceled: &canceled,
+        };
+        let received = read_chunks(&mut adapter, 11).unwrap();
+        writer.join().unwrap();
+        assert_eq!(received, b"first chunk");
+    }
+
+    #[test]
+    fn cancellable_frame_rejects_oversized_prefix_before_allocation() {
+        let (mut writer, mut reader) = UnixStream::pair().unwrap();
+        reader.set_nonblocking(true).unwrap();
+        writer.write_all(&4097_u32.to_be_bytes()).unwrap();
+        let canceled = || false;
+        let mut adapter = CancellableReader {
+            stream: &mut reader,
+            canceled: &canceled,
+        };
+        let error = read_frame::<serde_json::Value>(&mut adapter, 4096).unwrap_err();
+        assert!(matches!(
+            error,
+            super::super::protocol::FrameError::Oversized {
+                announced: 4097,
+                limit: 4096
+            }
+        ));
+    }
+
+    #[test]
+    fn cancellable_chunks_reject_a_chunk_larger_than_the_announced_remainder() {
+        let (mut writer, mut reader) = UnixStream::pair().unwrap();
+        reader.set_nonblocking(true).unwrap();
+        writer.write_all(&11_u32.to_be_bytes()).unwrap();
+        writer.write_all(b"eleven bytes").unwrap();
+        let canceled = || false;
+        let mut adapter = CancellableReader {
+            stream: &mut reader,
+            canceled: &canceled,
+        };
+        let error = read_chunks(&mut adapter, 5).unwrap_err();
+        assert!(matches!(
+            error,
+            super::super::protocol::FrameError::Oversized {
+                announced: 11,
+                limit: 5
+            }
+        ));
+    }
+
+    #[test]
+    fn cancellable_frame_aborts_while_waiting_for_the_rest_of_a_frame() {
+        let (writer, mut reader) = UnixStream::pair().unwrap();
+        reader.set_nonblocking(true).unwrap();
+        let canceled = Arc::new(AtomicBool::new(false));
+        let signal = Arc::clone(&canceled);
+        let writer = thread::spawn(move || {
+            writer.try_clone().unwrap().write_all(&[0, 0]).unwrap();
+            thread::sleep(Duration::from_millis(40));
+            signal.store(true, Ordering::Release);
+            drop(writer);
+        });
+        let canceled_fn = || canceled.load(Ordering::Acquire);
+        let mut adapter = CancellableReader {
+            stream: &mut reader,
+            canceled: &canceled_fn,
+        };
+        let error = read_frame::<serde_json::Value>(&mut adapter, 4096).unwrap_err();
+        writer.join().unwrap();
+        assert!(matches!(
+            error,
+            super::super::protocol::FrameError::Io(error)
+                if error.get_ref().is_some_and(|source| source.is::<WatchSupersededIo>())
+        ));
     }
 }

--- a/crates/rue/src/daemon/mod.rs
+++ b/crates/rue/src/daemon/mod.rs
@@ -32,11 +32,12 @@ use sha2::{Digest, Sha256};
 use crate::running_image::{RunningImageIdentity, running_image_identity};
 pub use client::{ConnectError, Connection, Submission, SubmitError};
 pub use protocol::{
-    BuildKind, BuildRequest, BuildResult, CompileFailureRecord, CrashRecord,
-    DAEMON_PROTOCOL_VERSION, DestinationRecord, DiagnosticFormat, IdentityRecord, InputRecord,
-    InventoryEntryRecord, MAX_RESPONSE_BYTES, OutputStream, RequestMeasurement, RequestSummary,
-    ResourcePolicy, ResourcePressure, ServiceInfo, StatusReport, StreamWrite, TestImageRecord,
-    UnimportedFileRecord, UnimportedRecord,
+    AttemptedReadOutcomeRecord, AttemptedReadRecord, BuildKind, BuildObservations, BuildRequest,
+    BuildResult, CompileFailureRecord, CrashRecord, DAEMON_PROTOCOL_VERSION, DestinationRecord,
+    DiagnosticFormat, IdentityRecord, InputRecord, InventoryEntryRecord, MAX_RESPONSE_BYTES,
+    OutputStream, RequestMeasurement, RequestSummary, ResourcePolicy, ResourcePressure,
+    ServiceInfo, StatusReport, StreamWrite, TestImageRecord, UnimportedFileRecord,
+    UnimportedRecord,
 };
 pub use service::{BuildExecutor, BuildOutput, MAX_CONNECTIONS, MAX_QUEUED_REQUESTS, ServeExit};
 
@@ -540,6 +541,9 @@ fn probe(endpoint: &Endpoint, identity: &ServiceIdentity) -> Result<Probe, Daemo
             reason,
         )),
         Err(client::ConnectError::Protocol(reason)) => Err(DaemonError::Protocol(reason)),
+        Err(client::ConnectError::WatchSuperseded) => {
+            Err(DaemonError::Protocol("watch request superseded".into()))
+        }
         Err(client::ConnectError::Io(error)) => Err(DaemonError::io(
             format!("connecting to {}", endpoint.socket.display()),
             error,

--- a/crates/rue/src/daemon/protocol.rs
+++ b/crates/rue/src/daemon/protocol.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 /// The version of the message shapes in this module. It participates in the
 /// service identity, so a client and a service that disagree on it can never
 /// meet on one socket, and the handshake checks it again anyway.
-pub const DAEMON_PROTOCOL_VERSION: u32 = 2;
+pub const DAEMON_PROTOCOL_VERSION: u32 = 3;
 
 /// The largest control frame either side accepts. Control messages are a few
 /// hundred bytes; a frame claiming more than this is a malformed or hostile
@@ -287,6 +287,12 @@ pub struct BuildRequest {
     /// flattened into the internally tagged [`RequestBody`], whose tag is
     /// `kind`.
     pub artifact: BuildKind,
+    /// Requested presentation stages, encoded with the same names accepted
+    /// by the command line. Empty for executable, test, and listing builds.
+    /// Keeping this as data lets the service use the canonical emit pipeline
+    /// instead of maintaining an Air-only special case.
+    #[serde(default)]
+    pub emit_stages: Vec<String>,
     /// The client's invocation directory.
     pub working_directory: String,
     /// The root source as written.
@@ -358,6 +364,44 @@ pub struct BuildReply {
     /// status requests cannot attribute another request's last value.
     pub measurement: Option<RequestMeasurement>,
     pub result: BuildResult,
+    /// Filesystem observations belong to the completed request, including a
+    /// failed or canceled request, so a watch client can recover deleted and
+    /// missing imports without consulting service state.
+    #[serde(default)]
+    pub observations: BuildObservations,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BuildObservations {
+    pub inputs: Vec<InputRecord>,
+    pub attempted_reads: Vec<AttemptedReadRecord>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttemptedReadRecord {
+    pub requested_path: String,
+    pub outcome: AttemptedReadOutcomeRecord,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AttemptedReadOutcomeRecord {
+    Accepted {
+        canonical_path: String,
+        content_fingerprint: u64,
+    },
+    Failed {
+        reason: String,
+        observed: u64,
+        /// Whether the loader was permitted to inspect the candidate's
+        /// physical contents/metadata. Policy-denied reads remain unprobed.
+        #[serde(default)]
+        probe: bool,
+        /// A canonical policy denial may observe only its symlink route and
+        /// canonical target, never the denied target's contents.
+        #[serde(default)]
+        route_only: bool,
+    },
 }
 
 /// How an accepted build ended. `stderr` is everything the direct compile
@@ -369,6 +413,10 @@ pub struct BuildReply {
 pub enum BuildResult {
     /// The program was rejected or the destination refused; nothing to publish.
     Rejected { stderr: String },
+    /// The retained source revision was accepted and its image compilation
+    /// failed. Watch clients account for this as an attempted cycle so its
+    /// event stream stays aligned with the direct compiler path.
+    CompileRejected { stderr: String },
     /// The executable or test image is linked. `bytes` raw chunk bytes
     /// follow this frame; the client publishes them at `destination` after
     /// revalidating `inputs`, exactly as a watch cycle does. A test image
@@ -682,6 +730,7 @@ mod tests {
             body: RequestBody::Build(Box::new(BuildRequest {
                 measure_performance: false,
                 artifact: BuildKind::TestImage,
+                emit_stages: Vec::new(),
                 working_directory: "/w".into(),
                 root_source: "main.rue".into(),
                 output_path: "/w/.run/image".into(),

--- a/crates/rue/src/daemon/service.rs
+++ b/crates/rue/src/daemon/service.rs
@@ -22,10 +22,10 @@ use std::time::{Duration, Instant};
 use rue_compiler::unstable::CompilationCancellation;
 
 use super::protocol::{
-    BuildReply, BuildRequest, BuildResult, CrashRecord, DAEMON_PROTOCOL_VERSION, Hello, HelloReply,
-    MAX_CONTROL_FRAME_BYTES, MAX_RESPONSE_BYTES, Request, RequestBody, RequestMeasurement,
-    RequestSummary, ResourcePolicy, ResourcePressure, Response, ResponseBody, ServiceInfo,
-    StatusReport,
+    BuildObservations, BuildReply, BuildRequest, BuildResult, CrashRecord, DAEMON_PROTOCOL_VERSION,
+    Hello, HelloReply, MAX_CONTROL_FRAME_BYTES, MAX_RESPONSE_BYTES, Request, RequestBody,
+    RequestMeasurement, RequestSummary, ResourcePolicy, ResourcePressure, Response, ResponseBody,
+    ServiceInfo, StatusReport,
 };
 
 /// Why the service loop returned.
@@ -161,6 +161,7 @@ pub trait BuildExecutor: Send {
 pub struct BuildOutput {
     pub result: BuildResult,
     pub bytes: Vec<u8>,
+    pub observations: BuildObservations,
 }
 
 impl BuildOutput {
@@ -171,6 +172,7 @@ impl BuildOutput {
                 internal: false,
             },
             bytes: Vec::new(),
+            observations: BuildObservations::default(),
         }
     }
 }
@@ -482,6 +484,7 @@ fn compiler_owner(
                 BuildOutput {
                     result: BuildResult::Canceled,
                     bytes: Vec::new(),
+                    observations: BuildObservations::default(),
                 },
                 None,
                 shared,
@@ -619,7 +622,12 @@ fn leased_output(
         output = BuildOutput::failed("the compiler service produced an invalid response length");
     }
     let ready = matches!(output.result, BuildResult::Ready { .. }) && ready;
-    let encoded = encode_build_reply(ticket, measurement.clone(), output.result);
+    let encoded = encode_build_reply(
+        ticket,
+        measurement.clone(),
+        output.result,
+        output.observations,
+    );
     let amount = encoded
         .as_ref()
         .ok()
@@ -632,6 +640,7 @@ fn leased_output(
             ticket,
             measurement,
             result: output.result,
+            observations: BuildObservations::default(),
         })
         .unwrap_or_default();
         return LeasedOutput {
@@ -654,6 +663,7 @@ fn leased_output(
             ticket,
             measurement,
             result: output.result,
+            observations: BuildObservations::default(),
         })
         .unwrap_or_default();
         return LeasedOutput {
@@ -671,6 +681,7 @@ fn leased_output(
                 message: "the compiler service could not serialize its response".into(),
                 internal: true,
             },
+            observations: BuildObservations::default(),
         })
         .unwrap_or_default()
     });
@@ -692,6 +703,7 @@ fn encode_build_reply(
     ticket: u64,
     measurement: Option<RequestMeasurement>,
     result: BuildResult,
+    observations: BuildObservations,
 ) -> Result<Vec<u8>, io::Error> {
     let mut buffer = CappedBuffer {
         bytes: Vec::new(),
@@ -703,6 +715,7 @@ fn encode_build_reply(
             ticket,
             measurement,
             result,
+            observations,
         },
     )
     .map_err(io::Error::other)?;
@@ -1011,6 +1024,7 @@ fn serve_build(mut stream: UnixStream, request_id: u64, request: BuildRequest, s
                         message: "the compiler service ended before answering".into(),
                         internal: true,
                     },
+                    observations: BuildObservations::default(),
                 })
                 .unwrap_or_default(),
                 bytes: Vec::new(),
@@ -1033,6 +1047,7 @@ fn serve_build(mut stream: UnixStream, request_id: u64, request: BuildRequest, s
                     message: "the compiler service ended before answering".into(),
                     internal: true,
                 },
+                observations: BuildObservations::default(),
             })
             .unwrap_or_default(),
             bytes: Vec::new(),

--- a/crates/rue/src/daemon/tests.rs
+++ b/crates/rue/src/daemon/tests.rs
@@ -83,6 +83,7 @@ impl BuildExecutor for StubExecutor {
                 return BuildOutput {
                     result: BuildResult::Canceled,
                     bytes: Vec::new(),
+                    observations: Default::default(),
                 };
             }
             thread::sleep(Duration::from_millis(5));
@@ -109,6 +110,7 @@ impl BuildExecutor for StubExecutor {
                 test_image: None,
             },
             bytes,
+            observations: Default::default(),
         }
     }
 
@@ -137,6 +139,7 @@ fn build_request(root_source: &str) -> BuildRequest {
     BuildRequest {
         measure_performance: false,
         artifact: BuildKind::Executable,
+        emit_stages: Vec::new(),
         working_directory: "/w".into(),
         root_source: root_source.into(),
         output_path: "out".into(),

--- a/crates/rue/src/daemon_cli.rs
+++ b/crates/rue/src/daemon_cli.rs
@@ -350,7 +350,7 @@ mod tests {
             "scope: /work/project",
             "isolation: ci",
             "endpoint: /run/rue/0123",
-            "protocol: 2",
+            "protocol: 3",
             "image: X86_64 LinuxProcSelfExeSha256 abcd",
             "idle timeout: 1800000 ms",
             "active request: none",

--- a/crates/rue/src/daemon_client.rs
+++ b/crates/rue/src/daemon_client.rs
@@ -77,9 +77,8 @@ impl std::str::FromStr for DaemonMode {
 /// the support table of ADR-0085 §2: each of these keeps its existing direct
 /// stream and lifecycle contract until its own slice moves it.
 pub(crate) fn unsupported_reason(options: &Options) -> Option<&'static str> {
-    // Watch remains a direct-only lifecycle until the service adapter is
-    // selected by the caller. Emit stages, however, are ordinary service
-    // presentation requests and travel through the canonical pipeline.
+    // Watch selects a service adapter for the shared cycle lifecycle. Emit
+    // stages are ordinary requests through the canonical presentation path.
     if !matches!(options.linker, LinkerMode::Internal) {
         return Some("a system linker runs directly");
     }

--- a/crates/rue/src/daemon_client.rs
+++ b/crates/rue/src/daemon_client.rs
@@ -8,11 +8,14 @@ use std::path::{Path, PathBuf};
 
 use rue_compiler::{CompileOptions, LinkerMode};
 use rue_driver::daemon::{
-    self, BuildKind, BuildRequest, BuildResult, DaemonScope, DiagnosticFormat, EndpointRoot,
-    InputRecord, ProcessLauncher, RequestMeasurement, ServiceInfo, StartOptions, Submission,
-    SubmitError,
+    self, BuildKind, BuildObservations, BuildRequest, BuildResult, ConnectError, DaemonScope,
+    DiagnosticFormat, EndpointRoot, InputRecord, ProcessLauncher, RequestMeasurement, ServiceInfo,
+    StartOptions, Submission, SubmitError,
 };
-use rue_driver::{HostPathContext, WatchInput, WatchInputParts};
+use rue_driver::{
+    AttemptedRead, AttemptedReadOutcomeParts, AttemptedReadParts, HostPathContext, WatchInput,
+    WatchInputParts,
+};
 use rue_error::ErrorCode;
 use rue_perf_schema::{
     DAEMON_PERFORMANCE_RECORD_KIND, DAEMON_PERFORMANCE_SCHEMA_VERSION, DaemonArtifact,
@@ -22,8 +25,13 @@ use rue_perf_schema::{
 use sha2::{Digest, Sha256};
 
 use crate::compile::{Announcement, announce};
-use crate::emit::{self, EmitStage};
+use crate::emit;
+use crate::emit::EmitStage;
 use crate::output::{PublicationDestination, PublishRequest, publish_watch_executable};
+use crate::watch::{
+    BackendCycle, BackendFailure, BackendPrepare, WatchBackend, WatchCycleRequest,
+    WatchLoopRequest, WatchMode, WatchTermination,
+};
 use crate::{
     DiagnosticOutput, DriverMode, ErrorFormat, Options, VERSION, compile_pool_jobs,
     driver_failure_exit_code, ice_diagnostic, render_driver_error, render_internal_error,
@@ -69,12 +77,9 @@ impl std::str::FromStr for DaemonMode {
 /// the support table of ADR-0085 §2: each of these keeps its existing direct
 /// stream and lifecycle contract until its own slice moves it.
 pub(crate) fn unsupported_reason(options: &Options) -> Option<&'static str> {
-    if options.watch {
-        return Some("--watch runs directly");
-    }
-    if !options.emit_stages.is_empty() && options.emit_stages != [EmitStage::Air] {
-        return Some("--emit stages other than a sole `air` run directly");
-    }
+    // Watch remains a direct-only lifecycle until the service adapter is
+    // selected by the caller. Emit stages, however, are ordinary service
+    // presentation requests and travel through the canonical pipeline.
     if !matches!(options.linker, LinkerMode::Internal) {
         return Some("a system linker runs directly");
     }
@@ -375,6 +380,10 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
         ));
     }
 
+    if options.watch {
+        return run_watch(options, path_context);
+    }
+
     let kind = match (&options.mode, options.test.list) {
         (DriverMode::Compile, _) if !options.emit_stages.is_empty() => BuildKind::Analysis,
         (DriverMode::Compile, _) => BuildKind::Executable,
@@ -387,7 +396,7 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
     let test_plan = match kind {
         BuildKind::TestImage => {
             let seed = options.test.seed.unwrap_or_else(test_mode::fresh_seed);
-            match test_mode::service_run_root(seed) {
+            match test_mode::service_run_root(seed, None) {
                 Ok((run_root, image_path)) => Some(TestPlan {
                     seed,
                     run_root,
@@ -499,7 +508,7 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
     };
 
     match result {
-        BuildResult::Rejected { stderr } => {
+        BuildResult::Rejected { stderr } | BuildResult::CompileRejected { stderr } => {
             eprint!("{stderr}");
             let accepted_input_identity = measurement
                 .as_ref()
@@ -695,6 +704,8 @@ pub(crate) fn run(options: &Options, path_context: &HostPathContext) -> Outcome 
                         opt_level: options.opt_level,
                         candidates_declared: options.test_candidates_path.is_some(),
                         seed: plan.seed,
+                        cycle: None,
+                        cancellation: None,
                     });
                     write_performance_sidecar(
                         options,
@@ -744,6 +755,11 @@ fn capture(
     BuildRequest {
         measure_performance: options.daemon_performance_json.is_some(),
         artifact: kind,
+        emit_stages: options
+            .emit_stages
+            .iter()
+            .map(|stage| stage.name().into())
+            .collect(),
         working_directory: path_context.working_directory().display().to_string(),
         root_source: options.source_path.clone(),
         output_path,
@@ -765,6 +781,485 @@ fn capture(
             ErrorFormat::Json => DiagnosticFormat::Json,
         },
         color: std::io::stderr().is_terminal(),
+    }
+}
+
+/// Run the service backend through the same watch lifecycle as direct builds.
+fn run_watch(options: &Options, path_context: &HostPathContext) -> Outcome {
+    if !options.emit_stages.is_empty() {
+        return Outcome::Direct;
+    }
+    let scope_dir = match &options.daemon_scope {
+        Some(scope) => path_context.anchor(Path::new(scope)),
+        None => {
+            let root = path_context.anchor(Path::new(&options.source_path));
+            root.parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| path_context.working_directory().to_path_buf())
+        }
+    };
+    let kind = match options.mode {
+        DriverMode::Compile => BuildKind::Executable,
+        DriverMode::Test => BuildKind::TestImage,
+    };
+    let seed = options.test.seed.unwrap_or_else(test_mode::fresh_seed);
+    let backend = ServiceWatchBackend {
+        options,
+        path_context,
+        scope_dir,
+        kind,
+        seed,
+        pending: None,
+        // The service's loader owns root observation and source-manifest
+        // policy. A client-side probe here could read a denied root before
+        // the service has admitted the request.
+        inputs: Vec::new(),
+        attempted_reads: Vec::new(),
+    };
+    let mode = match options.mode {
+        DriverMode::Compile => WatchMode::Executable {
+            output_path: options.output_path.clone(),
+        },
+        DriverMode::Test => WatchMode::Test(Box::new(crate::watch::TestWatch {
+            repro_flags: test_repro_flags(options, path_context),
+            repro_root: test_mode::absolute_spelling_at(
+                Path::new(&options.source_path),
+                path_context.working_directory(),
+            ),
+            repro_env: test_repro_env(std::env::var_os("RUE_STD_PATH").as_deref().map(Path::new)),
+            jobs: test_mode_jobs(options.jobs),
+            target: options.target,
+            opt_level: options.opt_level,
+            test_candidates_path: options
+                .test_candidates_path
+                .as_deref()
+                .map(|path| path_context.anchor(Path::new(path)).display().to_string()),
+            test_candidates_display_path: options.test_candidates_path.clone(),
+            seed,
+            options: options.test.clone(),
+        })),
+    };
+    match crate::watch::run_backend(
+        WatchLoopRequest {
+            source_path: options.source_path.clone(),
+            error_format: options.error_format,
+            mode,
+        },
+        backend,
+    ) {
+        WatchTermination::Direct => Outcome::Direct,
+        WatchTermination::Exit(code) => Outcome::Exit(code),
+    }
+}
+
+struct ServiceWatchBuild {
+    result: BuildResult,
+    bytes: Vec<u8>,
+    run_root: PathBuf,
+    image_path: PathBuf,
+    cleanup: bool,
+}
+
+impl Drop for ServiceWatchBuild {
+    fn drop(&mut self) {
+        if self.cleanup {
+            discard_service_run_root(&self.image_path, &self.run_root);
+        }
+    }
+}
+
+impl ServiceWatchBuild {
+    fn disarm(mut self) -> (BuildResult, Vec<u8>, PathBuf, PathBuf) {
+        self.cleanup = false;
+        (
+            std::mem::replace(&mut self.result, BuildResult::Canceled),
+            std::mem::take(&mut self.bytes),
+            std::mem::take(&mut self.run_root),
+            std::mem::take(&mut self.image_path),
+        )
+    }
+}
+
+fn retire_pending_before_successor<T>(
+    pending: &mut Option<ServiceWatchBuild>,
+    allocate: impl FnOnce() -> T,
+) -> T {
+    drop(pending.take());
+    allocate()
+}
+
+fn discard_service_run_root(image_path: &Path, run_root: &Path) {
+    if !image_path.as_os_str().is_empty() {
+        let _ = std::fs::remove_file(image_path);
+    }
+    if !run_root.as_os_str().is_empty() {
+        let _ = std::fs::remove_dir(run_root);
+    }
+}
+
+struct ServiceRunRootGuard {
+    run_root: PathBuf,
+    image_path: PathBuf,
+    armed: bool,
+}
+
+impl Drop for ServiceRunRootGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            discard_service_run_root(&self.image_path, &self.run_root);
+        }
+    }
+}
+
+struct ServiceWatchBackend<'a> {
+    options: &'a Options,
+    path_context: &'a HostPathContext,
+    scope_dir: PathBuf,
+    kind: BuildKind,
+    seed: u64,
+    pending: Option<ServiceWatchBuild>,
+    inputs: Vec<WatchInput>,
+    attempted_reads: Vec<AttemptedRead>,
+}
+
+impl ServiceWatchBackend<'_> {
+    fn termination(&self, message: String, fallback_allowed: bool) -> BackendPrepare {
+        if fallback_allowed && self.options.daemon == DaemonMode::Auto {
+            BackendPrepare::Terminate(WatchTermination::Direct)
+        } else {
+            eprintln!(
+                "{}",
+                render_daemon_error(self.options.error_format, message)
+            );
+            BackendPrepare::Terminate(WatchTermination::Exit(driver_failure_exit_code(
+                &self.options.mode,
+            )))
+        }
+    }
+
+    fn observation_inputs(&self, observations: &BuildObservations) -> Vec<WatchInput> {
+        let mut inputs: Vec<WatchInput> = observations
+            .inputs
+            .iter()
+            .cloned()
+            .map(watch_input)
+            .collect();
+        inputs.sort_by(|a, b| a.requested_path().cmp(b.requested_path()));
+        inputs.dedup();
+        inputs
+    }
+
+    fn attempted_reads(&self, observations: &BuildObservations) -> Vec<AttemptedRead> {
+        observations
+            .attempted_reads
+            .iter()
+            .cloned()
+            .map(|read| {
+                AttemptedRead::from_parts(AttemptedReadParts {
+                    requested_path: read.requested_path,
+                    outcome: match read.outcome {
+                        rue_driver::daemon::AttemptedReadOutcomeRecord::Accepted {
+                            canonical_path,
+                            content_fingerprint,
+                        } => AttemptedReadOutcomeParts::Accepted {
+                            canonical_path,
+                            content_fingerprint,
+                        },
+                        rue_driver::daemon::AttemptedReadOutcomeRecord::Failed {
+                            reason,
+                            observed,
+                            probe,
+                            route_only,
+                        } => AttemptedReadOutcomeParts::Failed {
+                            reason,
+                            observed,
+                            probe,
+                            route_only,
+                        },
+                    },
+                })
+            })
+            .collect()
+    }
+}
+
+impl WatchBackend for ServiceWatchBackend<'_> {
+    fn prepare_each_cycle(&self) -> bool {
+        true
+    }
+
+    fn announces_reobserve_during_prepare(&self) -> bool {
+        true
+    }
+
+    fn returned_observations_are_authoritative(&self) -> bool {
+        true
+    }
+
+    fn prepare(
+        &mut self,
+        _inputs: &[WatchInput],
+        _reobserve: bool,
+        cycle: u64,
+        cancellation: &rue_compiler::unstable::CompilationCancellation,
+    ) -> BackendPrepare {
+        // A ready image can be rejected as stale after publication
+        // revalidation. Drop its owned preparation before allocating the next
+        // cycle's root, so a stale cycle cannot retain or later delete a path
+        // that the successor just claimed.
+        let root_guard = retire_pending_before_successor(&mut self.pending, || {
+            if self.kind == BuildKind::TestImage {
+                match test_mode::service_run_root(self.seed, Some(cycle)) {
+                    Ok((run_root, image_path)) => Ok(ServiceRunRootGuard {
+                        run_root,
+                        image_path,
+                        armed: true,
+                    }),
+                    Err(message) => Err(message),
+                }
+            } else {
+                Ok(ServiceRunRootGuard {
+                    run_root: PathBuf::new(),
+                    image_path: PathBuf::new(),
+                    armed: true,
+                })
+            }
+        });
+        let mut root_guard = match root_guard {
+            Ok(root_guard) => root_guard,
+            Err(message) => return self.termination(message, false),
+        };
+        let request = capture(
+            self.options,
+            self.path_context,
+            self.kind,
+            if self.kind == BuildKind::TestImage {
+                root_guard.image_path.display().to_string()
+            } else {
+                self.options.output_path.clone()
+            },
+        );
+        let (scope, root, launcher) = match (
+            DaemonScope::new(&self.scope_dir, self.options.daemon_isolation.as_deref()),
+            EndpointRoot::resolve(),
+            ProcessLauncher::current_executable(),
+        ) {
+            (Ok(scope), Ok(root), Ok(launcher)) => (scope, root, launcher),
+            (Err(error), _, _) => {
+                return self.termination(format!("no service scope: {error}"), true);
+            }
+            (_, Err(error), _) => {
+                return self.termination(format!("no service endpoint: {error}"), true);
+            }
+            (_, _, Err(error)) => {
+                return self.termination(format!("no service launcher: {error}"), true);
+            }
+        };
+        let mut started =
+            match daemon::start_connection(scope, &root, &StartOptions::default(), &launcher) {
+                Ok(started) => started,
+                Err(error) => {
+                    return self.termination(format!("the service is unavailable: {error}"), true);
+                }
+            };
+        let ticket = match started.connection.submit_build(request) {
+            Ok(Submission::Accepted { ticket, .. }) => ticket,
+            Ok(Submission::Rejected { reason }) => {
+                return self
+                    .termination(format!("the service refused the request: {reason}"), true);
+            }
+            Err(SubmitError::BeforeSubmission(error)) => {
+                return self
+                    .termination(format!("the request could not be submitted: {error}"), true);
+            }
+            Err(SubmitError::Ambiguous(error)) => {
+                return self.termination(error.to_string(), false);
+            }
+        };
+        let (result, bytes) = match started
+            .connection
+            .await_build_cancellable(ticket, || cancellation.is_canceled())
+        {
+            Ok(answer) => answer,
+            Err(ConnectError::WatchSuperseded) => return BackendPrepare::Superseded,
+            Err(error) => return self.termination(error.to_string(), false),
+        };
+        let observations = started.connection.observations().clone();
+        self.inputs = self.observation_inputs(&observations);
+        self.attempted_reads = self.attempted_reads(&observations);
+        match &result {
+            BuildResult::Canceled if cancellation.is_canceled() => {
+                return BackendPrepare::Superseded;
+            }
+            BuildResult::Rejected { stderr } => {
+                return BackendPrepare::Failed(BackendFailure {
+                    diagnostic: stderr.clone(),
+                    inputs: self.inputs.clone(),
+                    attempted_reads: self.attempted_reads(&observations),
+                });
+            }
+            BuildResult::Failed { message, internal } => {
+                let rendered = if *internal {
+                    render_internal_error(self.options.error_format, message.clone())
+                } else {
+                    render_daemon_error(self.options.error_format, message.clone())
+                };
+                eprintln!("{rendered}");
+                return BackendPrepare::Terminate(WatchTermination::Exit(
+                    driver_failure_exit_code(&self.options.mode),
+                ));
+            }
+            BuildResult::Canceled => return BackendPrepare::Superseded,
+            BuildResult::Listing { .. } | BuildResult::Presentation { .. } => {
+                return self.termination("invalid watch artifact response".into(), false);
+            }
+            BuildResult::Ready { .. } | BuildResult::CompileRejected { .. } => {}
+        }
+        self.pending = Some(ServiceWatchBuild {
+            result,
+            bytes,
+            run_root: root_guard.run_root.clone(),
+            image_path: root_guard.image_path.clone(),
+            cleanup: true,
+        });
+        root_guard.armed = false;
+        BackendPrepare::Ready
+    }
+
+    fn inputs(&self) -> Vec<WatchInput> {
+        self.inputs.clone()
+    }
+
+    fn attempted_reads(&self) -> Vec<AttemptedRead> {
+        self.attempted_reads.clone()
+    }
+
+    fn cycle(&mut self, request: WatchCycleRequest<'_>) -> BackendCycle {
+        let WatchCycleRequest {
+            mode,
+            cancellation,
+            inputs,
+            cycle,
+            ..
+        } = request;
+        let Some(pending) = self.pending.take() else {
+            return BackendCycle::Terminate(WatchTermination::Exit(driver_failure_exit_code(
+                &self.options.mode,
+            )));
+        };
+        if cancellation.compilation.is_canceled() || rue_driver::watch_inputs_changed(&inputs) {
+            return BackendCycle::Superseded(crate::compile::Supersession::BeforePublication);
+        }
+        // An accepted revision whose image failed still reaches the shared
+        // cycle boundary. It owns the same cycle number, diagnostics, and
+        // completion milestones as a direct compilation failure.
+        if let BuildResult::CompileRejected { stderr } = &pending.result {
+            return BackendCycle::Failed {
+                diagnostic: Some(stderr.clone()),
+            };
+        }
+        // The test runner owns cleanup of a published image. Every earlier
+        // return drops the preparation; a published failing test can retain
+        // its own scratch evidence.
+        let (result, bytes, run_root, image_path) = pending.disarm();
+        let BuildResult::Ready {
+            stderr,
+            target,
+            destination,
+            test_image,
+            ..
+        } = result
+        else {
+            return BackendCycle::Terminate(WatchTermination::Exit(driver_failure_exit_code(
+                &self.options.mode,
+            )));
+        };
+        let target = match target.parse::<rue_target::Target>() {
+            Ok(target) => target,
+            Err(error) => {
+                discard_service_run_root(&image_path, &run_root);
+                return BackendCycle::Terminate(
+                    self.termination(error.to_string(), false).termination(),
+                );
+            }
+        };
+        let destination = PublicationDestination::from_parts(
+            PathBuf::from(destination.path),
+            PathBuf::from(destination.display_path),
+            destination
+                .source_paths
+                .into_iter()
+                .map(PathBuf::from)
+                .collect(),
+        );
+        if let Err(error) = publish_watch_executable(
+            PublishRequest {
+                destination,
+                bytes: &bytes,
+                target,
+            },
+            &inputs,
+        ) {
+            if matches!(error, crate::output::PublishError::InputsChanged) {
+                discard_service_run_root(&image_path, &run_root);
+                return BackendCycle::Superseded(crate::compile::Supersession::AtPublication);
+            }
+            discard_service_run_root(&image_path, &run_root);
+            return BackendCycle::Failed {
+                diagnostic: Some(
+                    DiagnosticOutput::new(self.options.error_format, Vec::new())
+                        .render_error(&error.into_compile_error()),
+                ),
+            };
+        }
+        eprint!("{stderr}");
+        if let Some(record) = test_image {
+            let std_root = std::env::var_os("RUE_STD_PATH").map(PathBuf::from);
+            let run_cancellation = cancellation.run();
+            let exit = test_mode::run_service_image(test_mode::ServiceRun {
+                record: *record,
+                image_path: &image_path,
+                run_root: &run_root,
+                options: &self.options.test,
+                root: &self.options.source_path,
+                repro_root: &test_mode::absolute_spelling_at(
+                    Path::new(&self.options.source_path),
+                    self.path_context.working_directory(),
+                ),
+                repro_flags: &test_repro_flags(self.options, self.path_context),
+                repro_env: &test_repro_env(std_root.as_deref()),
+                jobs: test_mode_jobs(self.options.jobs),
+                target: self.options.target,
+                opt_level: self.options.opt_level,
+                candidates_declared: self.options.test_candidates_path.is_some(),
+                seed: self.seed,
+                cycle: Some(cycle),
+                cancellation: run_cancellation,
+            });
+            if cancellation.compilation.is_canceled()
+                || cancellation.run().is_some_and(|r| r.is_canceled())
+            {
+                return BackendCycle::Superseded(crate::compile::Supersession::BeforePublication);
+            }
+            if exit.code() == 2 {
+                return BackendCycle::Failed { diagnostic: None };
+            }
+        }
+        let _ = mode;
+        BackendCycle::Completed
+    }
+}
+
+trait PrepareTermination {
+    fn termination(self) -> WatchTermination;
+}
+
+impl PrepareTermination for BackendPrepare {
+    fn termination(self) -> WatchTermination {
+        match self {
+            BackendPrepare::Terminate(result) => result,
+            _ => WatchTermination::Exit(1),
+        }
     }
 }
 
@@ -804,6 +1299,10 @@ fn render_service_panic(format: ErrorFormat, message: &str, location: Option<Str
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use rue_driver::daemon::DestinationRecord;
+
     use super::*;
 
     #[test]
@@ -826,5 +1325,53 @@ mod tests {
         let json = render_service_panic(ErrorFormat::Json, "boom", None);
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed[0]["code"], "E9000");
+    }
+
+    #[test]
+    fn stale_ready_preparation_cleanup_does_not_remove_the_successor_scratch() {
+        let directory = tempfile::tempdir().unwrap();
+        // A successor uses the same cycle-owned path after the stale pending
+        // preparation is dropped. The old build must be cleared before that
+        // path is allocated again, or its Drop would erase the successor.
+        let cycle_root = directory.path().join("run-cycle-2");
+        let image = cycle_root.join("rue-test-image");
+        let failed_scratch = cycle_root.join("rue-test-0-1");
+        fs::create_dir_all(&cycle_root).unwrap();
+        fs::create_dir_all(&failed_scratch).unwrap();
+        fs::write(&image, b"stale").unwrap();
+        fs::write(failed_scratch.join("stderr"), b"retained failure").unwrap();
+
+        let stale = ServiceWatchBuild {
+            result: BuildResult::Ready {
+                stderr: String::new(),
+                target: "x86_64-linux".into(),
+                destination: DestinationRecord {
+                    path: "out".into(),
+                    display_path: "out".into(),
+                    source_paths: Vec::new(),
+                },
+                inputs: Vec::new(),
+                bytes: 0,
+                test_image: None,
+            },
+            bytes: Vec::new(),
+            run_root: cycle_root.clone(),
+            image_path: image.clone(),
+            cleanup: true,
+        };
+        let mut pending = Some(stale);
+        // This is the operation performed before a successor prepare allocates
+        // its cycle-owned root. The old image is disposable; the successor's
+        // failed-test evidence is a separate ownership scope.
+        retire_pending_before_successor(&mut pending, || {
+            fs::create_dir_all(&cycle_root).unwrap();
+            fs::write(&image, b"successor image").unwrap();
+        });
+        assert!(cycle_root.exists());
+        assert_eq!(fs::read(&image).unwrap(), b"successor image");
+        assert_eq!(
+            fs::read(failed_scratch.join("stderr")).unwrap(),
+            b"retained failure"
+        );
     }
 }

--- a/crates/rue/src/daemon_qualification_tests.rs
+++ b/crates/rue/src/daemon_qualification_tests.rs
@@ -27,6 +27,7 @@ impl Project {
         BuildRequest {
             measure_performance: false,
             artifact: BuildKind::Executable,
+            emit_stages: Vec::new(),
             working_directory: self.0.path().display().to_string(),
             root_source: "main.rue".into(),
             output_path: "app".into(),
@@ -71,7 +72,10 @@ fn fresh_parity(executor: &mut Executor, request: &BuildRequest, ready: bool) ->
     );
     if !ready {
         assert!(
-            matches!(answer.result, BuildResult::Rejected { .. }),
+            matches!(
+                answer.result,
+                BuildResult::Rejected { .. } | BuildResult::CompileRejected { .. }
+            ),
             "{:?}",
             answer.result
         );

--- a/crates/rue/src/daemon_service.rs
+++ b/crates/rue/src/daemon_service.rs
@@ -15,15 +15,17 @@ use rue_compiler::unstable::{
 };
 use rue_compiler::{CompileOptions, CompilerSessionConfig, LinkerMode, RootSelection};
 use rue_driver::daemon::{
-    BuildExecutor, BuildKind, BuildOutput, BuildRequest, BuildResult, DestinationRecord,
-    DiagnosticFormat, InputRecord, TestImageRecord,
+    AttemptedReadOutcomeRecord, AttemptedReadRecord, BuildExecutor, BuildKind, BuildObservations,
+    BuildOutput, BuildRequest, BuildResult, DestinationRecord, DiagnosticFormat, InputRecord,
+    TestImageRecord,
 };
 use rue_driver::{
-    FilesystemCompilerHost, HostOpenRequest, HostPathContext, SourceLoadError,
-    load_declared_candidates_with_context,
+    AttemptedRead, AttemptedReadOutcomeParts, FilesystemCompilerHost, HostOpenRequest,
+    HostPathContext, SourceLoadError, SourceLoadFailure, load_declared_candidates_with_context,
 };
 
 use crate::compile::{CycleTransport, TransportOutcome, produce_test_transport, produce_transport};
+use crate::emit::EmitStage;
 use crate::test_mode::{inventory_entry_record, prepare_image, produce_listing_transport};
 use crate::{DiagnosticOutput, ErrorFormat, render_source_load_error_with_color};
 
@@ -91,6 +93,7 @@ impl Executor {
 /// The parts of a request that must parse before any host is touched.
 struct Parsed {
     options: CompileOptions,
+    emit_stages: Vec<EmitStage>,
     format: ErrorFormat,
     color: ColorChoice,
     compiler_config: CompilerSessionConfig,
@@ -119,6 +122,14 @@ fn parse(request: &BuildRequest) -> Result<Parsed, String> {
                 .map_err(|error| format!("preview feature `{name}`: {error}"))
         })
         .collect::<Result<_, _>>()?;
+    let mut emit_stages = request
+        .emit_stages
+        .iter()
+        .map(|name| name.parse::<EmitStage>().map_err(|error| error.to_string()))
+        .collect::<Result<Vec<_>, _>>()?;
+    if request.artifact == BuildKind::Analysis && emit_stages.is_empty() {
+        emit_stages.push(EmitStage::Air);
+    }
     let workers = if request.workers == 0 {
         DAEMON_AUTOMATIC_WORKERS
     } else {
@@ -147,6 +158,7 @@ fn parse(request: &BuildRequest) -> Result<Parsed, String> {
                 BuildKind::TestImage | BuildKind::TestListing => RootSelection::Tests,
             },
         },
+        emit_stages,
         format: match request.error_format {
             DiagnosticFormat::Text => ErrorFormat::Text,
             DiagnosticFormat::Json => ErrorFormat::Json,
@@ -170,10 +182,10 @@ impl Executor {
         key: HostKey,
         request: &BuildRequest,
         parsed: &Parsed,
-    ) -> Result<&mut FilesystemCompilerHost, SourceLoadError> {
-        // A request starts as a fresh observation.  Only a successfully
-        // committed reobserve is reuse evidence; a failed attempt must not
-        // inherit the predecessor's session identity in its reply.
+        cancellation: &CompilationCancellation,
+    ) -> Result<&mut FilesystemCompilerHost, SourceLoadFailure> {
+        // Only a successfully committed reobserve is reuse evidence; a failed
+        // attempt must not inherit its predecessor's session identity.
         self.reused_session = false;
         let reuse = self
             .retained
@@ -183,14 +195,19 @@ impl Executor {
             let retained = self.retained.as_mut().expect("checked above");
             // A pre-commit failure keeps the prior coherent closure, so the
             // host stays retained; the request is answered with the failure.
-            retained.host.reobserve()?;
+            retained
+                .host
+                .reobserve_superseding(&|| cancellation.is_canceled())
+                .map_err(|error| SourceLoadFailure {
+                    error,
+                    attempted_reads: retained.host.attempted_reads().to_vec(),
+                })?;
             self.reused_session = true;
             return Ok(&mut retained.host);
         }
-        // Open the successor off to the side.  A failed open leaves the
-        // predecessor available for the next request; the generation advances
-        // only once the new host has been admitted.
-        let host = FilesystemCompilerHost::open(HostOpenRequest {
+        // Open the successor off to the side. A failed open leaves the
+        // predecessor available; generation advances only on admission.
+        let host = FilesystemCompilerHost::open_with_observations(HostOpenRequest {
             root_source: &request.root_source,
             source_manifest_path: request.source_manifest_path.as_deref(),
             std_root: request.std_root.as_deref().map(Path::new),
@@ -224,7 +241,7 @@ impl BuildExecutor for Executor {
             std_root: request.std_root.clone(),
             workers: parsed.compiler_config.workers(),
         };
-        let rejected = |error: SourceLoadError| BuildOutput {
+        let rejected = |error: SourceLoadError, observations: BuildObservations| BuildOutput {
             result: BuildResult::Rejected {
                 stderr: format!(
                     "{}\n",
@@ -232,21 +249,64 @@ impl BuildExecutor for Executor {
                 ),
             },
             bytes: Vec::new(),
+            observations,
         };
         let observation_started = std::time::Instant::now();
-        let host = match self.host(key, request, &parsed) {
+        let host = match self.host(key, request, &parsed, cancellation) {
             Ok(host) => host,
-            Err(error) => return rejected(error),
-        };
-        match host.acquire_reached_toolchain_modules_cancellable(&parsed.options, cancellation) {
-            Ok(()) => {}
-            Err(SourceLoadError::Superseded) => {
+            Err(failure) if matches!(failure.error, SourceLoadError::Superseded) => {
                 return BuildOutput {
                     result: BuildResult::Canceled,
                     bytes: Vec::new(),
+                    observations: BuildObservations::default(),
                 };
             }
-            Err(error) => return rejected(error),
+            Err(failure) => {
+                return rejected(
+                    failure.error,
+                    observations_from_attempts(&failure.attempted_reads),
+                );
+            }
+        };
+        if cancellation.is_canceled() {
+            return BuildOutput {
+                result: BuildResult::Canceled,
+                bytes: Vec::new(),
+                observations: observations(host),
+            };
+        }
+        let needs_semantic = match request.artifact {
+            BuildKind::Analysis => {
+                crate::emit::emit_requires_semantic(&parsed.emit_stages)
+                    || parsed.emit_stages.contains(&EmitStage::ModuleManifest)
+            }
+            BuildKind::Executable | BuildKind::TestImage | BuildKind::TestListing => true,
+        };
+        let acquisition = if needs_semantic {
+            Some(host.acquire_reached_toolchain_modules_cancellable(&parsed.options, cancellation))
+        } else {
+            None
+        };
+        match acquisition {
+            None | Some(Ok(())) => {}
+            Some(Err(SourceLoadError::Superseded)) => {
+                return BuildOutput {
+                    result: BuildResult::Canceled,
+                    bytes: Vec::new(),
+                    observations: observations(host),
+                };
+            }
+            Some(Err(error)) => {
+                let stderr = format!(
+                    "{}\n",
+                    render_source_load_error_with_color(error, parsed.format, parsed.color)
+                );
+                return BuildOutput {
+                    result: BuildResult::Rejected { stderr },
+                    bytes: Vec::new(),
+                    observations: observations(host),
+                };
+            }
         }
         let observation_ns = Some(observation_started.elapsed().as_nanos() as u64);
         let input_sha256 = request
@@ -261,11 +321,12 @@ impl BuildExecutor for Executor {
                 return BuildOutput {
                     result: BuildResult::Rejected { stderr },
                     bytes: Vec::new(),
+                    observations: observations(host),
                 };
             }
         };
         let mut link_ns = None;
-        let output = match request.artifact {
+        let mut output = match request.artifact {
             BuildKind::Executable => {
                 let transport = produce_transport(
                     host,
@@ -301,7 +362,7 @@ impl BuildExecutor for Executor {
             BuildKind::Analysis => {
                 match crate::emit::produce_transport(
                     host,
-                    &[crate::emit::EmitStage::Air],
+                    &parsed.emit_stages,
                     parsed.options.clone(),
                     parsed.format,
                     parsed.color,
@@ -310,6 +371,7 @@ impl BuildExecutor for Executor {
                     None => BuildOutput {
                         result: BuildResult::Canceled,
                         bytes: Vec::new(),
+                        observations: BuildObservations::default(),
                     },
                     Some(presentation) => BuildOutput {
                         result: BuildResult::Presentation {
@@ -317,6 +379,7 @@ impl BuildExecutor for Executor {
                             writes: presentation.writes,
                         },
                         bytes: Vec::new(),
+                        observations: BuildObservations::default(),
                     },
                 }
             }
@@ -331,6 +394,7 @@ impl BuildExecutor for Executor {
                     None => BuildOutput {
                         result: BuildResult::Canceled,
                         bytes: Vec::new(),
+                        observations: BuildObservations::default(),
                     },
                     Some(listing) => BuildOutput {
                         result: BuildResult::Listing {
@@ -340,10 +404,12 @@ impl BuildExecutor for Executor {
                             }),
                         },
                         bytes: Vec::new(),
+                        observations: BuildObservations::default(),
                     },
                 }
             }
         };
+        output.observations = observations(host);
         self.last_observation_ns = observation_ns;
         self.last_input_sha256 = input_sha256;
         self.last_link_ns = link_ns;
@@ -474,12 +540,14 @@ fn ready_output<Published>(
     } = transport;
     match outcome {
         TransportOutcome::Rejected => BuildOutput {
-            result: BuildResult::Rejected { stderr },
+            result: BuildResult::CompileRejected { stderr },
             bytes: Vec::new(),
+            observations: BuildObservations::default(),
         },
         TransportOutcome::Canceled => BuildOutput {
             result: BuildResult::Canceled,
             bytes: Vec::new(),
+            observations: BuildObservations::default(),
         },
         TransportOutcome::Ready {
             target,
@@ -506,6 +574,7 @@ fn ready_output<Published>(
                     test_image: companion(published),
                 },
                 bytes,
+                observations: BuildObservations::default(),
             }
         }
     }
@@ -521,6 +590,97 @@ fn input_record(input: rue_driver::WatchInput) -> InputRecord {
             .symlink_boundary
             .map(|path| path.display().to_string()),
         symlink_route: parts.symlink_route,
+    }
+}
+
+fn observations(host: &FilesystemCompilerHost) -> BuildObservations {
+    BuildObservations {
+        inputs: host.watch_inputs().into_iter().map(input_record).collect(),
+        attempted_reads: host
+            .attempted_reads()
+            .iter()
+            .cloned()
+            .map(|read| {
+                let parts = read.into_parts();
+                let outcome = match parts.outcome {
+                    AttemptedReadOutcomeParts::Accepted {
+                        canonical_path,
+                        content_fingerprint,
+                    } => AttemptedReadOutcomeRecord::Accepted {
+                        canonical_path,
+                        content_fingerprint,
+                    },
+                    AttemptedReadOutcomeParts::Failed {
+                        reason,
+                        observed,
+                        probe,
+                        route_only,
+                    } => AttemptedReadOutcomeRecord::Failed {
+                        reason,
+                        observed,
+                        probe,
+                        route_only,
+                    },
+                };
+                AttemptedReadRecord {
+                    requested_path: parts.requested_path,
+                    outcome,
+                }
+            })
+            .collect(),
+    }
+}
+
+/// Convert the loader-owned attempt ledger to the daemon wire projection.
+/// Failed entries remain failed entries; their domain-tagged observations are
+/// consumed by the shared watcher rather than being reinterpreted as accepted
+/// file fingerprints.
+fn observations_from_attempts(attempts: &[AttemptedRead]) -> BuildObservations {
+    let mut inputs = Vec::new();
+    let mut attempted_reads = Vec::new();
+    for attempt in attempts.iter().cloned() {
+        let parts = attempt.into_parts();
+        let outcome = match parts.outcome {
+            AttemptedReadOutcomeParts::Accepted {
+                canonical_path,
+                content_fingerprint,
+            } => {
+                inputs.push(InputRecord {
+                    requested_path: parts.requested_path.clone(),
+                    canonical_path: canonical_path.clone(),
+                    fingerprint: Some(content_fingerprint),
+                    symlink_boundary: None,
+                    symlink_route: Vec::new(),
+                });
+                AttemptedReadOutcomeRecord::Accepted {
+                    canonical_path,
+                    content_fingerprint,
+                }
+            }
+            AttemptedReadOutcomeParts::Failed {
+                reason,
+                observed,
+                probe,
+                route_only,
+            } => AttemptedReadOutcomeRecord::Failed {
+                reason,
+                observed,
+                probe,
+                route_only,
+            },
+        };
+        attempted_reads.push(AttemptedReadRecord {
+            requested_path: parts.requested_path,
+            outcome,
+        });
+    }
+    inputs.sort_by(|left, right| left.requested_path.cmp(&right.requested_path));
+    inputs.dedup();
+    attempted_reads.sort_by(|left, right| left.requested_path.cmp(&right.requested_path));
+    attempted_reads.dedup();
+    BuildObservations {
+        inputs,
+        attempted_reads,
     }
 }
 
@@ -548,6 +708,7 @@ mod tests {
         fn request(&self, output: &str) -> BuildRequest {
             BuildRequest {
                 artifact: BuildKind::Executable,
+                emit_stages: Vec::new(),
                 working_directory: self.directory.path().display().to_string(),
                 root_source: "main.rue".into(),
                 output_path: output.into(),
@@ -673,12 +834,12 @@ mod tests {
         // host answers it.
         project.write(BROKEN);
         let broken = executor.build(&project.request("app"), &cancellation);
-        let BuildResult::Rejected { stderr } = &broken.result else {
+        let BuildResult::CompileRejected { stderr } = &broken.result else {
             panic!("a broken program is rejected: {:?}", broken.result);
         };
         assert!(stderr.contains("E0206"), "{stderr}");
         let fresh = Executor::new().build(&project.request("app"), &cancellation);
-        let BuildResult::Rejected {
+        let BuildResult::CompileRejected {
             stderr: fresh_stderr,
         } = &fresh.result
         else {
@@ -736,7 +897,7 @@ mod tests {
         assert!(matches!(first.result, BuildResult::Ready { .. }));
         project.write(BROKEN);
         let broken = executor.build(&project.request("app"), &cancellation);
-        assert!(matches!(broken.result, BuildResult::Rejected { .. }));
+        assert!(matches!(broken.result, BuildResult::CompileRejected { .. }));
         project.write(GOOD);
         let repaired = executor.build(&project.request("app"), &cancellation);
         assert!(matches!(repaired.result, BuildResult::Ready { .. }));
@@ -902,6 +1063,7 @@ mod test_request_tests {
         fn request(&self, artifact: BuildKind, output: &str) -> BuildRequest {
             BuildRequest {
                 artifact,
+                emit_stages: Vec::new(),
                 working_directory: self.directory.path().display().to_string(),
                 root_source: "main.rue".into(),
                 output_path: output.into(),
@@ -1036,6 +1198,7 @@ mod test_request_tests {
         match result {
             BuildResult::Ready { stderr, .. }
             | BuildResult::Rejected { stderr }
+            | BuildResult::CompileRejected { stderr }
             | BuildResult::Listing { stderr, .. } => stderr,
             other => panic!("{other:?}"),
         }

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -204,6 +204,25 @@ impl EmitStage {
         "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, abi, \
          deps, module-manifest"
     }
+
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::Tokens => "tokens",
+            Self::Ast => "ast",
+            Self::Rir => "rir",
+            Self::Air => "air",
+            Self::Cfg => "cfg",
+            Self::Lowering => "lowering",
+            Self::Mir => "mir",
+            Self::Liveness => "liveness",
+            Self::RegAlloc => "regalloc",
+            Self::Asm => "asm",
+            Self::StackFrame => "stackframe",
+            Self::Abi => "abi",
+            Self::Deps => "deps",
+            Self::ModuleManifest => "module-manifest",
+        }
+    }
 }
 
 /// Reject output-mode combinations that cannot coexist, independent of any

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -18,9 +18,10 @@ use rue_compiler::{
 };
 
 use crate::source_loader::{
-    AttemptedRead, ImportDiscoveryResult, SourceLoadError, SourceLoadRequest, WatchInput,
-    acquire_reached_toolchain_modules, acquire_reached_toolchain_modules_cancellable, load,
-    load_explicit_manifest, load_explicit_manifest_candidate, reload_from_filesystem,
+    AttemptedRead, ImportDiscoveryResult, SourceLoadError, SourceLoadFailure, SourceLoadRequest,
+    WatchInput, acquire_reached_toolchain_modules, acquire_reached_toolchain_modules_cancellable,
+    load, load_explicit_manifest, load_explicit_manifest_candidate, load_with_observations,
+    reload_from_filesystem,
 };
 
 /// Immutable filesystem configuration captured when a retained host opens.
@@ -98,6 +99,22 @@ impl FilesystemCompilerHost {
     /// Open a root source and drive parser-owned import discovery to closure.
     pub fn open(request: HostOpenRequest<'_>) -> Result<Self, SourceLoadError> {
         load(SourceLoadRequest {
+            root_source: request.root_source,
+            source_manifest_path: request.source_manifest_path,
+            std_root: request.std_root,
+            compiler_config: request.compiler_config,
+            path_context: request.path_context,
+        })
+        .map(|state| Self {
+            state,
+            path_context: request.path_context.clone(),
+        })
+    }
+
+    /// Open while preserving the loader-owned failed-read ledger for a
+    /// request boundary that must publish observations on rejection.
+    pub fn open_with_observations(request: HostOpenRequest<'_>) -> Result<Self, SourceLoadFailure> {
+        load_with_observations(SourceLoadRequest {
             root_source: request.root_source,
             source_manifest_path: request.source_manifest_path,
             std_root: request.std_root,

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -19,8 +19,9 @@ pub use running_image::{
     RunningImageIdentityError, RunningImageIdentityScheme, running_image_identity,
 };
 pub use source_loader::{
-    AttemptedRead, HermeticDenialError, SourceLoadError, ToolchainIntegrityError, WatchFingerprint,
-    WatchInput, WatchInputParts, watch_input_fingerprints, watch_inputs_changed,
+    AttemptedRead, AttemptedReadOutcomeParts, AttemptedReadParts, HermeticDenialError,
+    SourceLoadError, SourceLoadFailure, ToolchainIntegrityError, WatchFingerprint, WatchInput,
+    WatchInputParts, watch_input_fingerprints, watch_inputs_changed,
     watch_inputs_changed_with_reader, with_import_migration_helps,
     with_import_migration_helps_batches,
 };

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -74,6 +74,9 @@ impl WatchFingerprint {
     }
 
     pub fn read(path: &Path) -> Option<Self> {
+        if !fs::metadata(path).is_ok_and(|metadata| metadata.is_file()) {
+            return None;
+        }
         fs::read(path).ok().map(|bytes| Self::from_bytes(&bytes))
     }
 }
@@ -288,6 +291,119 @@ pub struct AttemptedRead {
     outcome: AttemptedReadOutcome,
 }
 
+/// Owned wire-friendly projection of an attempted source read.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum AttemptedReadOutcomeParts {
+    Accepted {
+        canonical_path: String,
+        content_fingerprint: u64,
+    },
+    Failed {
+        reason: String,
+        observed: u64,
+        probe: bool,
+        route_only: bool,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct AttemptedReadParts {
+    pub requested_path: String,
+    pub outcome: AttemptedReadOutcomeParts,
+}
+
+impl AttemptedRead {
+    pub fn into_parts(self) -> AttemptedReadParts {
+        AttemptedReadParts {
+            requested_path: self.requested_path.to_string(),
+            outcome: match self.outcome {
+                AttemptedReadOutcome::Accepted {
+                    canonical_path,
+                    content_fingerprint,
+                } => AttemptedReadOutcomeParts::Accepted {
+                    canonical_path: canonical_path.to_string(),
+                    content_fingerprint,
+                },
+                AttemptedReadOutcome::Failed {
+                    reason,
+                    observed,
+                    probe,
+                    route_only,
+                } => AttemptedReadOutcomeParts::Failed {
+                    reason: reason.to_string(),
+                    observed,
+                    probe,
+                    route_only,
+                },
+            },
+        }
+    }
+
+    pub fn from_parts(parts: AttemptedReadParts) -> Self {
+        Self {
+            requested_path: Arc::from(parts.requested_path),
+            outcome: match parts.outcome {
+                AttemptedReadOutcomeParts::Accepted {
+                    canonical_path,
+                    content_fingerprint,
+                } => AttemptedReadOutcome::Accepted {
+                    canonical_path: Arc::from(canonical_path),
+                    content_fingerprint,
+                },
+                AttemptedReadOutcomeParts::Failed {
+                    reason,
+                    observed,
+                    probe,
+                    route_only,
+                } => AttemptedReadOutcome::Failed {
+                    reason: Arc::from(reason),
+                    observed,
+                    probe,
+                    route_only,
+                },
+            },
+        }
+    }
+
+    /// Whether the loader-owned observation has changed. Tagged fingerprints
+    /// are interpreted only here, beside their producer. Lexical denials
+    /// never probe; canonical denials can observe routes without reading contents.
+    pub fn changed(&self) -> bool {
+        match &self.outcome {
+            AttemptedReadOutcome::Accepted {
+                canonical_path,
+                content_fingerprint,
+            } => {
+                let requested = Path::new(self.requested_path.as_ref());
+                let canonical = Path::new(canonical_path.as_ref());
+                // An accepted source read is only safe to poll as a regular
+                // file. In particular, do not hand a path replaced by a
+                // FIFO/socket to fs::read: a watch retry must never block on
+                // a route that the loader no longer accepts.
+                if fs::canonicalize(requested).ok().as_deref() != Some(canonical)
+                    || !fs::metadata(canonical).is_ok_and(|metadata| metadata.is_file())
+                {
+                    return true;
+                }
+                WatchFingerprint::read(canonical)
+                    .is_none_or(|fingerprint| fingerprint.0 != *content_fingerprint)
+            }
+            AttemptedReadOutcome::Failed {
+                observed,
+                probe,
+                route_only,
+                ..
+            } => {
+                let path = Path::new(self.requested_path.as_ref());
+                if *route_only {
+                    return failed_route_fingerprint(path) != *observed;
+                }
+                *probe && failed_candidate_fingerprint(path) != *observed
+            }
+        }
+    }
+}
+
 /// What an attempt found at an [`AttemptedRead`]'s path.
 ///
 /// The two variants can never compare equal, so a path that failed to read is
@@ -308,13 +424,19 @@ enum AttemptedReadOutcome {
     /// is the failure's shape, so a candidate that starts failing differently
     /// is a different record; `observed` is whatever the attempt could still
     /// see there, which is what makes one save distinguishable from the next.
-    Failed { reason: Arc<str>, observed: u64 },
+    Failed {
+        reason: Arc<str>,
+        observed: u64,
+        probe: bool,
+        route_only: bool,
+    },
 }
 
 /// Domain separators, so a raw-byte hash and a metadata hash for the same path
 /// cannot coincide.
 const FAILED_READ_CONTENT_TAG: u64 = 0x5255_4532_3130_3501;
 const FAILED_READ_PLACE_TAG: u64 = 0x5255_4532_3130_3502;
+const FAILED_READ_ROUTE_TAG: u64 = 0x5255_4532_3130_3503;
 
 /// What an attempt can still observe about a candidate it failed to read.
 ///
@@ -366,6 +488,28 @@ fn failed_candidate_fingerprint(path: &Path) -> u64 {
     WatchFingerprint::from_bytes(&place).0 ^ FAILED_READ_PLACE_TAG
 }
 
+/// Fingerprint only the route facts needed to retry a canonically denied read.
+/// It deliberately does not open the denied target's contents. Canonicalizing
+/// the route and recording symlink targets makes a retarget from a denied
+/// location to an allowed one observable without turning policy into a probe.
+fn failed_route_fingerprint(path: &Path) -> u64 {
+    let mut route = Vec::new();
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        if let Ok(target) = fs::read_link(&current) {
+            route.extend_from_slice(current.as_os_str().as_encoded_bytes());
+            route.push(0);
+            route.extend_from_slice(target.as_os_str().as_encoded_bytes());
+            route.push(0);
+        }
+    }
+    if let Ok(canonical) = fs::canonicalize(path) {
+        route.extend_from_slice(canonical.as_os_str().as_encoded_bytes());
+    }
+    WatchFingerprint::from_bytes(&route).0 ^ FAILED_READ_ROUTE_TAG
+}
+
 /// The reads one observation attempt made and could not accept.
 ///
 /// Accepted reads survive a failed attempt in the assembler's manifest;
@@ -379,41 +523,43 @@ type FailedReads = Vec<AttemptedRead>;
 /// `observed_absent_path`, which the watch closure covers.
 fn record_failed_read(failed: &mut FailedReads, observation: &ImportObservation) {
     let requested = observation.request().requested_path();
-    let (reason, probe): (String, bool) = match observation.status() {
+    let (reason, probe, route_only): (String, bool, bool) = match observation.status() {
         ImportObservationStatus::Absent | ImportObservationStatus::PresentReadable { .. } => return,
         ImportObservationStatus::PresentUnreadable(reason) => {
-            (format!("unreadable: {reason}"), true)
+            (format!("unreadable: {reason}"), true, false)
         }
         ImportObservationStatus::InvalidPhysicalType { canonical_path } => (
             format!("not a regular source file at '{canonical_path}'"),
             true,
+            false,
         ),
         ImportObservationStatus::UnstableRead(reason) => {
-            (format!("changed during its read: {reason}"), true)
+            (format!("changed during its read: {reason}"), true, false)
         }
         // A lexically denied path must not be probed at all — declining the
-        // filesystem is the whole content of that denial — and a canonically
-        // denied one is a path the policy says this build may not read. Both
-        // are configuration facts about the manifest rather than about what is
-        // on disk, and the manifest is itself a watched input.
+        // filesystem is the whole content of that denial. A canonical denial
+        // may observe only the route needed to notice a later retarget; the
+        // manifest remains the authority on whether the target may be read.
         ImportObservationStatus::DeniedLexical => (
             "denied by the source manifest read policy".to_owned(),
+            false,
             false,
         ),
         ImportObservationStatus::DeniedCanonical { canonical_path } => (
             format!("denied by the source manifest after resolving to '{canonical_path}'"),
             false,
+            true,
         ),
         // An abandoned attempt is answered by its restart, never by this record.
         ImportObservationStatus::Cancelled => return,
     };
-    push_failed_read(failed, requested, reason, probe);
+    push_failed_read(failed, requested, reason, probe, route_only);
 }
 
 /// Record a demanded trusted toolchain module the host could not acquire.
 ///
-/// The same rule as [`record_failed_read`]: a hermetic denial is a statement
-/// about the read policy and must not touch the filesystem, while every
+/// The same rule as [`record_failed_read`]: lexical denials never probe, and
+/// canonical denials retain only route observations. Every
 /// integrity failure is a statement about what is (or is not) under the
 /// standard-library root, and observing it is what lets the next save be told
 /// from the next retry.
@@ -422,10 +568,11 @@ fn record_failed_toolchain_demand(
     path: &Path,
     error: &ToolchainAcquisitionError,
 ) {
-    let (reason, probe) = match error {
-        ToolchainAcquisitionError::Hermetic(_) => (
+    let (reason, probe, route_only) = match error {
+        ToolchainAcquisitionError::Hermetic(error) => (
             "denied by the source manifest read policy".to_owned(),
             false,
+            error.route_only,
         ),
         // The failure's class, not its rendered text: the rendered diagnostic
         // is already the other half of the debounce key, and repeating it here
@@ -445,21 +592,38 @@ fn record_failed_toolchain_demand(
                 }
             },
             true,
+            false,
         ),
     };
-    push_failed_read(failed, path.to_string_lossy().as_ref(), reason, probe);
+    push_failed_read(
+        failed,
+        path.to_string_lossy().as_ref(),
+        reason,
+        probe,
+        route_only,
+    );
 }
 
-fn push_failed_read(failed: &mut FailedReads, requested: &str, reason: String, probe: bool) {
+fn push_failed_read(
+    failed: &mut FailedReads,
+    requested: &str,
+    reason: String,
+    probe: bool,
+    route_only: bool,
+) {
     failed.push(AttemptedRead {
         requested_path: Arc::from(requested),
         outcome: AttemptedReadOutcome::Failed {
             reason: Arc::from(reason),
             observed: if probe {
                 failed_candidate_fingerprint(Path::new(requested))
+            } else if route_only {
+                failed_route_fingerprint(Path::new(requested))
             } else {
                 0
             },
+            probe,
+            route_only,
         },
     });
 }
@@ -603,6 +767,20 @@ impl SourceManifest {
             declared.join("\0"),
             allowed.join("\0")
         )
+    }
+
+    /// Preserve the manifest read in a failed loader attempt without opening
+    /// it a second time. A valid manifest normally becomes a committed
+    /// `WatchInput`; on a later root-policy/discovery failure this projection
+    /// keeps the same accepted input available to the watch backend.
+    fn attempted_read(&self) -> AttemptedRead {
+        AttemptedRead {
+            requested_path: Arc::from(self.path.to_string_lossy().into_owned()),
+            outcome: AttemptedReadOutcome::Accepted {
+                canonical_path: Arc::from(self.path.to_string_lossy().into_owned()),
+                content_fingerprint: self.content_hash.0,
+            },
+        }
     }
 }
 
@@ -873,6 +1051,7 @@ fn reobserve_accepted_reads(
     source_manifest: Option<&SourceManifest>,
     context: &ImportDiscoveryContext,
     control: DiscoveryControl<'_>,
+    failed_reads: &mut FailedReads,
 ) -> Result<AHashMap<String, AcceptedImportSource>, SourceLoadError> {
     control.checkpoint()?;
     let now = SystemTime::now();
@@ -892,6 +1071,13 @@ fn reobserve_accepted_reads(
         let boundary = context.boundary_for_requested(requested_path);
         if source_manifest.is_some_and(|policy| !policy.declares_path_without_probe(requested_path))
         {
+            push_failed_read(
+                failed_reads,
+                entry.requested_path(),
+                "denied by the source manifest read policy".to_owned(),
+                false,
+                false,
+            );
             continue;
         }
         // The requested spelling is the watchable authority. Re-resolve it on
@@ -899,18 +1085,50 @@ fn reobserve_accepted_reads(
         // cannot keep feeding the old canonical file into the next graph.
         let canonical_path = match fs::canonicalize(requested_path) {
             Ok(path) => path,
-            Err(_) => continue,
+            Err(error) => {
+                push_failed_read(
+                    failed_reads,
+                    entry.requested_path(),
+                    format!("unreadable: {error}"),
+                    true,
+                    false,
+                );
+                continue;
+            }
         };
         if source_manifest.is_some_and(|policy| !policy.allows_canonical(&canonical_path)) {
+            push_failed_read(
+                failed_reads,
+                entry.requested_path(),
+                "denied by the source manifest after canonicalization".to_owned(),
+                false,
+                true,
+            );
             continue;
         }
         if !canonical_path.is_file() {
+            push_failed_read(
+                failed_reads,
+                entry.requested_path(),
+                "not a regular source file".to_owned(),
+                true,
+                false,
+            );
             continue;
         }
         let canonical_unchanged = canonical_path == Path::new(entry.canonical_path());
         let metadata = match fs::metadata(&canonical_path) {
             Ok(metadata) => metadata,
-            Err(_) => continue,
+            Err(error) => {
+                push_failed_read(
+                    failed_reads,
+                    entry.requested_path(),
+                    format!("unreadable: {error}"),
+                    true,
+                    false,
+                );
+                continue;
+            }
         };
         let accepted = if canonical_unchanged
             && !metadata_requires_content_hash(
@@ -931,7 +1149,17 @@ fn reobserve_accepted_reads(
         } else {
             let read = match stable_read_to_string(&canonical_path) {
                 Ok(read) => read,
-                Err(_) => continue,
+                Err(error) => {
+                    let reason = match error {
+                        StableReadError::Io(error) => format!("unreadable: {error}"),
+                        StableReadError::Changed => {
+                            "changed during its read: candidate metadata changed during read"
+                                .to_owned()
+                        }
+                    };
+                    push_failed_read(failed_reads, entry.requested_path(), reason, true, false);
+                    continue;
+                }
             };
             accepted_source_from_read(
                 entry,
@@ -1175,6 +1403,24 @@ pub enum SourceLoadError {
     HermeticDenial(HermeticDenialError),
 }
 
+/// A failed initial load together with the loader's own read ledger. The
+/// ledger is captured while discovery is running; consumers must not infer it
+/// later from rendered diagnostics or probe paths outside the loader policy.
+#[derive(Debug)]
+pub struct SourceLoadFailure {
+    pub error: SourceLoadError,
+    pub attempted_reads: Vec<AttemptedRead>,
+}
+
+impl From<SourceLoadError> for SourceLoadFailure {
+    fn from(error: SourceLoadError) -> Self {
+        Self {
+            error,
+            attempted_reads: Vec::new(),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Default)]
 struct DiscoveryControl<'a> {
     supersession: Option<&'a dyn Fn() -> bool>,
@@ -1355,6 +1601,15 @@ pub fn with_import_migration_helps_batches(batches: &[&CompileErrors]) -> Vec<Co
 pub(crate) fn load(
     request: SourceLoadRequest<'_>,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
+    load_with_observations(request).map_err(|failure| failure.error)
+}
+
+/// Load a fresh root while retaining the canonical loader read ledger when
+/// discovery rejects it. This is the only initial-failure observation source;
+/// callers must not reconstruct it from diagnostics after the fact.
+pub(crate) fn load_with_observations(
+    request: SourceLoadRequest<'_>,
+) -> Result<ImportDiscoveryResult, SourceLoadFailure> {
     // Source loading is the first half of the `compile` root: manifest policy,
     // then the demand-driven import-discovery frontier. It was previously
     // timed only through the `parse_file` spans it happens to contain, which
@@ -1363,36 +1618,72 @@ pub(crate) fn load(
         tracing::info_span!("source_loading", phase = "source_discovery_and_parsing").entered();
     let manifest = {
         let _span = tracing::info_span!("source_manifest").entered();
-        let manifest = request
-            .source_manifest_path
-            .map(|path| SourceManifest::load_with_context(path, request.path_context))
-            .transpose()
-            .map_err(SourceLoadError::Message)?;
+        let manifest = match request.source_manifest_path {
+            Some(path) => match SourceManifest::load_with_context(path, request.path_context) {
+                Ok(manifest) => Some(manifest),
+                Err(error) => {
+                    let requested = request.path_context.anchor(Path::new(path));
+                    let mut attempted_reads = FailedReads::new();
+                    // The manifest path is an explicit request input, so its
+                    // own failure may be probed to wake a repair. The loader
+                    // owns this observation; consumers must not rediscover it
+                    // by parsing the rendered diagnostic.
+                    push_failed_read(
+                        &mut attempted_reads,
+                        requested.to_string_lossy().as_ref(),
+                        error.clone(),
+                        true,
+                        false,
+                    );
+                    return Err(SourceLoadFailure {
+                        error: SourceLoadError::Message(error),
+                        attempted_reads,
+                    });
+                }
+            },
+            None => None,
+        };
         let root_path = normalize_lexical_path_at(
             Path::new(request.root_source),
             request.path_context.working_directory(),
         );
-        validate_manifest_allows_source_with_display(
+        if let Err(error) = validate_manifest_allows_source_with_display(
             manifest.as_ref(),
             &root_path.to_string_lossy(),
             request.root_source,
             "root",
-        )
-        .map_err(SourceLoadError::Message)?;
+        ) {
+            return Err(SourceLoadFailure {
+                error: SourceLoadError::Message(error),
+                attempted_reads: manifest
+                    .as_ref()
+                    .map(|manifest| vec![manifest.attempted_read()])
+                    .unwrap_or_default(),
+            });
+        }
         manifest
     };
+    let manifest_attempt = manifest.as_ref().map(SourceManifest::attempted_read);
     let std_root = request
         .std_root
         .filter(|path| !path.as_os_str().is_empty())
         .map(|path| request.path_context.anchor(path));
-    discover_and_load_imports_with_configuration(
+    discover_and_load_imports_with_configuration_with_observations(
         request.root_source,
         manifest,
         std_root.as_deref(),
         request.compiler_config,
         request.path_context,
     )
-    .map_err(prepare_source_load_error)
+    .map_err(|mut failure| {
+        if let Some(manifest_attempt) = manifest_attempt {
+            failure.attempted_reads.push(manifest_attempt);
+            failure.attempted_reads.sort();
+            failure.attempted_reads.dedup();
+        }
+        failure.error = prepare_source_load_error(failure.error);
+        failure
+    })
 }
 
 /// Load a build-system supplied closed module set. Every declared path is read
@@ -2939,6 +3230,7 @@ pub(crate) fn discover_and_load_imports(
     )
 }
 
+#[cfg(test)]
 fn discover_and_load_imports_with_configuration(
     root_source: &str,
     source_manifest: Option<SourceManifest>,
@@ -2946,6 +3238,23 @@ fn discover_and_load_imports_with_configuration(
     compiler_config: CompilerSessionConfig,
     path_context: &HostPathContext,
 ) -> Result<ImportDiscoveryResult, SourceLoadError> {
+    discover_and_load_imports_with_configuration_with_observations(
+        root_source,
+        source_manifest,
+        std_root,
+        compiler_config,
+        path_context,
+    )
+    .map_err(|failure| failure.error)
+}
+
+fn discover_and_load_imports_with_configuration_with_observations(
+    root_source: &str,
+    source_manifest: Option<SourceManifest>,
+    std_root: Option<&Path>,
+    compiler_config: CompilerSessionConfig,
+    path_context: &HostPathContext,
+) -> Result<ImportDiscoveryResult, SourceLoadFailure> {
     // Validate the root source's span representability before discovery aliases
     // physical identities. With a single positional source there are no
     // duplicate CLI inputs left to detect here; discovery still recognizes
@@ -2958,7 +3267,8 @@ fn discover_and_load_imports_with_configuration(
         return Err(SourceLoadError::Compiler {
             snapshot: None,
             errors: CompileErrors::from(error),
-        });
+        }
+        .into());
     }
 
     let root_path =
@@ -3021,7 +3331,8 @@ fn discover_and_load_imports_with_configuration(
     {
         return Err(SourceLoadError::Message(
             "Error: root source escapes the source manifest after canonicalization".into(),
-        ));
+        )
+        .into());
     }
     let root_read = stable_read_to_string(&root_canonical).map_err(|error| {
         SourceLoadError::Message(match error {
@@ -3056,7 +3367,7 @@ fn discover_and_load_imports_with_configuration(
     // and closure witness out so that loop can satisfy demands and re-close in the
     // same request generation.
     let mut failed_reads = FailedReads::new();
-    let close = drive_import_discovery_to_close(
+    let close = match drive_import_discovery_to_close(
         &mut assembler,
         &mut staging,
         &context,
@@ -3067,7 +3378,18 @@ fn discover_and_load_imports_with_configuration(
         None,
         &mut failed_reads,
         DiscoveryControl::default(),
-    )?;
+    ) {
+        Ok(close) => close,
+        Err(error) => {
+            return Err(SourceLoadFailure {
+                error,
+                attempted_reads: attempted_reads_of(
+                    &assembler.accepted_read_manifest(),
+                    &failed_reads,
+                ),
+            });
+        }
+    };
 
     let read_manifest = assembler.accepted_read_manifest();
     Ok(ImportDiscoveryResult {
@@ -3116,20 +3438,37 @@ fn reload_from_filesystem_inner(
     // read nothing rather than inheriting the previous attempt's files.
     result.attempted_reads.clear();
     control.checkpoint()?;
-    let source_manifest = result
-        .source_manifest
-        .as_ref()
-        .map(SourceManifest::reload)
-        .transpose()
-        .map_err(SourceLoadError::Message)?;
+    let source_manifest = match result.source_manifest.as_ref() {
+        Some(previous) => match previous.reload() {
+            Ok(manifest) => Some(manifest),
+            Err(error) => {
+                let mut failed_reads = FailedReads::new();
+                push_failed_read(
+                    &mut failed_reads,
+                    previous.path.to_string_lossy().as_ref(),
+                    error.clone(),
+                    true,
+                    false,
+                );
+                result.attempted_reads = failed_reads;
+                return Err(SourceLoadError::Message(error));
+            }
+        },
+        None => None,
+    };
     control.checkpoint()?;
-    validate_manifest_allows_source_with_display(
+    if let Err(error) = validate_manifest_allows_source_with_display(
         source_manifest.as_ref(),
         result.resolution.root_path.to_string_lossy().as_ref(),
         &result.resolution.root_display_path,
         "root",
-    )
-    .map_err(SourceLoadError::Message)?;
+    ) {
+        result.attempted_reads = source_manifest
+            .as_ref()
+            .map(|manifest| vec![manifest.attempted_read()])
+            .unwrap_or_default();
+        return Err(SourceLoadError::Message(error));
+    }
     let policy_revision = source_manifest
         .as_ref()
         .map(SourceManifest::policy_revision)
@@ -3146,25 +3485,37 @@ fn reload_from_filesystem_inner(
         policy_revision.clone(),
     )
     .map_err(source_load_compiler_error)?;
-    let reobserved = reobserve_accepted_reads(
+    let mut failed_reads = FailedReads::new();
+    let reobserved = match reobserve_accepted_reads(
         &result.source_snapshot,
         &result.read_manifest,
         source_manifest.as_ref(),
         &context,
         control,
-    )?;
+        &mut failed_reads,
+    ) {
+        Ok(reobserved) => reobserved,
+        Err(error) => {
+            result.attempted_reads = attempted_reads_of(&result.read_manifest, &failed_reads);
+            return Err(error);
+        }
+    };
     let root_module = result.source_snapshot.source_revision().root();
     let root_entry = result
         .read_manifest
         .iter()
         .find(|entry| entry.module() == root_module)
         .expect("a closed read manifest contains its root");
-    let root = reobserved.get(root_entry.requested_path()).ok_or_else(|| {
-        SourceLoadError::Message(format!(
-            "Error reading {}: source is no longer readable",
-            root_entry.requested_path()
-        ))
-    })?;
+    let root = match reobserved.get(root_entry.requested_path()) {
+        Some(root) => root,
+        None => {
+            result.attempted_reads = attempted_reads_of(&result.read_manifest, &failed_reads);
+            return Err(SourceLoadError::Message(format!(
+                "Error reading {}: source is no longer readable",
+                root_entry.requested_path()
+            )));
+        }
+    };
     // The retained root may have been retargeted since the previous close, so
     // its physical spelling is known only after reobservation. Recapture the
     // context with that spelling: discovery owns the overlap policy, and the
@@ -3195,7 +3546,6 @@ fn reload_from_filesystem_inner(
     // for requests the new rooted frontier actually issues; making every old
     // read explicit would keep modules that are no longer reachable after an
     // import-set edit and grow the retained snapshot monotonically.
-    let mut failed_reads = FailedReads::new();
     let close = match drive_import_discovery_to_close(
         &mut assembler,
         &mut result.session,
@@ -3569,6 +3919,7 @@ fn classify_trusted_transitive_failure(
                     logical_path: logical,
                     path,
                     reason: "the source manifest does not declare this path".to_owned(),
+                    route_only: false,
                 })
             }
             ImportObservationStatus::DeniedCanonical { canonical_path } => {
@@ -3576,6 +3927,7 @@ fn classify_trusted_transitive_failure(
                     logical_path: logical,
                     path: PathBuf::from(canonical_path.as_ref()),
                     reason: "its canonical path is not listed in the source manifest".to_owned(),
+                    route_only: true,
                 })
             }
             ImportObservationStatus::Cancelled => continue,
@@ -3725,12 +4077,14 @@ impl std::fmt::Display for ToolchainIntegrityError {
 /// remedy is the source manifest, not the toolchain. It therefore carries its
 /// own outer classification and presentation and never the "toolchain integrity"
 /// / broken-installation framing. A manifest denial is enforced before any
-/// filesystem probe, so a denied path is never even stat-ed.
+/// filesystem probe, so a lexically denied path is never even stat-ed.
+/// Canonical denials retain route observation authority without content reads.
 #[derive(Debug)]
 pub struct HermeticDenialError {
     pub(crate) logical_path: String,
     pub(crate) path: PathBuf,
     pub(crate) reason: String,
+    pub(crate) route_only: bool,
 }
 
 impl std::fmt::Display for HermeticDenialError {
@@ -3831,6 +4185,7 @@ fn satisfy_toolchain_module_demand(
                 "the source manifest '{}' does not declare this path",
                 manifest.display_path()
             ),
+            route_only: false,
         }
         .into());
     }
@@ -3873,6 +4228,7 @@ fn satisfy_toolchain_module_demand(
             "the standard-library root '{}' cannot be canonicalized: {error}",
             std_root.display()
         ),
+        route_only: true,
     })?;
     if !canonical.starts_with(&canonical_std_root) {
         return Err(HermeticDenialError {
@@ -3882,6 +4238,7 @@ fn satisfy_toolchain_module_demand(
                 "it canonicalizes outside the standard-library root '{}'",
                 canonical_std_root.display()
             ),
+            route_only: true,
         }
         .into());
     }
@@ -3898,6 +4255,7 @@ fn satisfy_toolchain_module_demand(
                 "its canonical path is not listed in the source manifest '{}'",
                 manifest.display_path()
             ),
+            route_only: true,
         }
         .into());
     }
@@ -4192,6 +4550,39 @@ mod tests {
 
         assert!(manifest.allows_canonical(&fs::canonicalize(main).unwrap()));
         assert!(manifest.allows_canonical(&fs::canonicalize(hashed).unwrap()));
+    }
+
+    #[test]
+    fn failed_initial_manifest_load_retains_its_loader_observation() {
+        let dir = TestDir::new("source-manifest-failed-observation");
+        dir.write("main.rue", "fn main() -> i32 { 0 }\n");
+        let manifest_path = dir.path.join("sources.manifest");
+        let context = HostPathContext::from_working_directory(dir.path.clone()).unwrap();
+        let root = dir.path.join("main.rue");
+        let root = root.to_string_lossy().into_owned();
+        let manifest = manifest_path.to_string_lossy().into_owned();
+
+        let failure = load_with_observations(SourceLoadRequest {
+            root_source: &root,
+            source_manifest_path: Some(&manifest),
+            std_root: None,
+            compiler_config: CompilerSessionConfig::default(),
+            path_context: &context,
+        })
+        .expect_err("the missing manifest must reject the initial load");
+        let SourceLoadError::Message(error) = failure.error else {
+            panic!("missing manifest should be a source-load message");
+        };
+        assert!(error.contains("source manifest"));
+        assert_eq!(failure.attempted_reads.len(), 1);
+        assert_eq!(
+            failure.attempted_reads[0].requested_path,
+            Arc::<str>::from(manifest_path.to_string_lossy().into_owned())
+        );
+        assert!(!failure.attempted_reads[0].changed());
+
+        fs::write(&manifest_path, "main.rue\n").unwrap();
+        assert!(failure.attempted_reads[0].changed());
     }
 
     #[test]
@@ -5115,6 +5506,56 @@ mod tests {
             recorded.outcome,
             AttemptedReadOutcome::Failed { .. }
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn watch_fingerprint_never_reads_a_directory_or_named_pipe() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = TestDir::new("watch-fingerprint-non-file");
+        let directory = dir.path.join("module.rue");
+        fs::create_dir(&directory).unwrap();
+        assert!(WatchFingerprint::read(&directory).is_none());
+
+        let pipe = dir.path.join("pipe.rue");
+        let name = std::ffi::CString::new(pipe.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(name.as_ptr(), 0o644) }, 0);
+        assert!(WatchFingerprint::read(&pipe).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_denial_watches_only_the_route_until_it_becomes_allowed() {
+        let project = TestDir::new("watch-canonical-denial-project");
+        let stdlib = TestDir::new("watch-canonical-denial-stdlib");
+        let main = project.write("main.rue", FALLIBLE_ROOT);
+        let denied = project.write("outside.rue", MALFORMED_OPTION);
+        let allowed = stdlib.write("allowed.rue", VALID_OPTION);
+        let alias = stdlib.path.join("option.rue");
+        std::os::unix::fs::symlink(&denied, &alias).unwrap();
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+        let mut loaded =
+            discover_and_load_imports(main.to_str().unwrap(), None, Some(&std_root)).unwrap();
+        let failure = acquire_reached_toolchain_modules(&mut loaded, &CompileOptions::default())
+            .expect_err("the reached module escapes the trusted root");
+        assert!(matches!(failure, SourceLoadError::HermeticDenial(_)));
+        let attempted = loaded
+            .attempted_reads()
+            .iter()
+            .find(|read| Path::new(read.requested_path.as_ref()) == std_root.join("option.rue"))
+            .expect("the actual acquisition must publish its denied route")
+            .clone();
+        assert!(!attempted.changed());
+        fs::write(&denied, "changed denied contents").unwrap();
+        assert!(!attempted.changed(), "denied contents are not watched");
+        fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&allowed, &alias).unwrap();
+        assert!(attempted.changed(), "retargeting must wake the watcher");
+        reload_from_filesystem(&mut loaded, None).unwrap();
+        acquire_reached_toolchain_modules(&mut loaded, &CompileOptions::default())
+            .expect("the retargeted trusted module can be acquired");
+        assert!(contains_trusted_option(&loaded.source_snapshot));
     }
 
     #[test]

--- a/crates/rue/src/test_mode/mod.rs
+++ b/crates/rue/src/test_mode/mod.rs
@@ -386,6 +386,11 @@ pub(crate) struct ServiceRun<'a> {
     pub(crate) opt_level: OptLevel,
     pub(crate) candidates_declared: bool,
     pub(crate) seed: u64,
+    /// The shared watch lifecycle's 1-based cycle number, or `None` for a
+    /// one-shot service invocation.
+    pub(crate) cycle: Option<u64>,
+    /// Optional watch-owned cancellation for a client-run service image.
+    pub(crate) cancellation: Option<&'a exec::RunCancellation>,
 }
 
 /// The private directory and image path a service-linked run stages its
@@ -393,8 +398,9 @@ pub(crate) struct ServiceRun<'a> {
 /// destination preflight sees it.
 pub(crate) fn service_run_root(
     seed: u64,
+    cycle: Option<u64>,
 ) -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
-    let run_root = exec::run_root(seed, None);
+    let run_root = exec::run_root(seed, cycle);
     std::fs::create_dir_all(&run_root)
         .map_err(|error| format!("could not create the test run directory: {error}"))?;
     let image_path = run_root.join("rue-test-image");
@@ -407,7 +413,12 @@ pub(crate) fn service_run_root(
 pub(crate) fn run_service_image(request: ServiceRun<'_>) -> TestExitCode {
     reset_performance_observations();
     exec::reserve_channel_descriptor();
-    exec::install_signal_forwarding();
+    // A watch lifecycle installs its exit handler once and owns the cycle's
+    // cancellation. Installing one-shot forwarding here would replace that
+    // handler and lose the watch cycle's terminal status.
+    if request.cancellation.is_none() {
+        exec::install_signal_forwarding();
+    }
     let ServiceRun {
         record,
         image_path,
@@ -422,6 +433,8 @@ pub(crate) fn run_service_image(request: ServiceRun<'_>) -> TestExitCode {
         opt_level,
         candidates_declared,
         seed,
+        cancellation,
+        cycle,
     } = request;
     let outcome = run_prepared(PreparedRun {
         prepared: PreparedImage::from_record(record),
@@ -441,8 +454,8 @@ pub(crate) fn run_service_image(request: ServiceRun<'_>) -> TestExitCode {
             CandidateSource::None
         },
         seed,
-        cycle: None,
-        cancellation: None,
+        cycle,
+        cancellation,
     });
     match outcome {
         CycleOutcome::Finished(exit) => exit,

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -92,43 +92,6 @@ fn test_boundary_delay() {
     thread::sleep(Duration::from_millis(milliseconds.min(5_000)));
 }
 
-/// Which half of a re-observation cycle is running. One `ChangeMonitor` spans
-/// both, so the phase — not the monitor — decides which protocol event a
-/// supersession or failure reports (RUE-1863).
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum ObservationPhase {
-    Reobserve,
-    Acquire,
-}
-
-impl ObservationPhase {
-    fn superseded_event(self) -> &'static str {
-        match self {
-            ObservationPhase::Reobserve => "reobserve-superseded",
-            ObservationPhase::Acquire => "acquire-superseded",
-        }
-    }
-
-    /// The milestone for a failure this cycle actually reported to the user.
-    fn error_event(self) -> &'static str {
-        match self {
-            ObservationPhase::Reobserve => "reobserve-error",
-            ObservationPhase::Acquire => "acquire-error",
-        }
-    }
-
-    /// The milestone for a retry that hit the failure already on screen and
-    /// said nothing. The retry itself is not silent to the protocol — a
-    /// harness can still count attempts — but the user's terminal is
-    /// (RUE-2091).
-    fn repeated_error_event(self) -> &'static str {
-        match self {
-            ObservationPhase::Reobserve => "reobserve-error-repeat",
-            ObservationPhase::Acquire => "acquire-error-repeat",
-        }
-    }
-}
-
 /// The re-observation failure whose diagnostic is already on the user's
 /// terminal.
 ///
@@ -176,6 +139,84 @@ pub(crate) struct WatchRequest {
     pub(crate) mode: WatchMode,
 }
 
+/// The result of the backend's pre-cycle work.  Direct watches use this phase
+/// to reobserve and reacquire their retained host; the service backend uses it
+/// to submit and await one request.  The lifecycle below owns the monitor for
+/// both paths.
+pub(crate) enum BackendPrepare {
+    Ready,
+    Superseded,
+    Failed(BackendFailure),
+    Terminate(WatchTermination),
+}
+
+pub(crate) struct BackendFailure {
+    pub(crate) diagnostic: String,
+    pub(crate) inputs: Vec<WatchInput>,
+    pub(crate) attempted_reads: Vec<AttemptedRead>,
+}
+
+pub(crate) enum WatchTermination {
+    Direct,
+    Exit(i32),
+}
+
+pub(crate) enum BackendCycle {
+    Completed,
+    Failed { diagnostic: Option<String> },
+    Superseded(Supersession),
+    Canceled,
+    Terminate(WatchTermination),
+}
+
+pub(crate) struct WatchCycleRequest<'a> {
+    pub(crate) mode: &'a mut WatchMode,
+    pub(crate) source_path: &'a str,
+    pub(crate) error_format: ErrorFormat,
+    pub(crate) cycle: u64,
+    pub(crate) cancellation: &'a CycleCancellation,
+    pub(crate) inputs: Vec<WatchInput>,
+}
+
+/// Operations that differ between a filesystem host and the compiler service.
+/// The watch lifecycle and its one change monitor remain shared.
+pub(crate) trait WatchBackend {
+    fn prepare_each_cycle(&self) -> bool;
+    /// Whether `prepare` returned a fresh observation set from an external
+    /// backend that must be checked before replaying a terminal result.
+    fn returned_observations_are_authoritative(&self) -> bool {
+        false
+    }
+    /// Whether the backend reports the re-observation milestone itself while
+    /// it can still expose the exact phase boundary. The service completes
+    /// re-observation and acquisition in one request, so the shared loop
+    /// emits its milestone after a successful response.
+    fn announces_reobserve_during_prepare(&self) -> bool {
+        false
+    }
+    fn prepare(
+        &mut self,
+        inputs: &[WatchInput],
+        reobserve: bool,
+        cycle: u64,
+        cancellation: &CompilationCancellation,
+    ) -> BackendPrepare;
+    fn inputs(&self) -> Vec<WatchInput>;
+    /// The loader-owned read ledger for the most recent failed preparation.
+    /// Failed entries retain their own tagged observation semantics and are
+    /// watched separately from the accepted closure.
+    fn attempted_reads(&self) -> Vec<AttemptedRead> {
+        Vec::new()
+    }
+    /// Direct hosts retain their established periodic retry behavior after a
+    /// failed re-observation; service clients can wait on the owned ledger
+    /// instead because each retry is a new request boundary.
+    fn retry_failed_preparation(&self) -> bool {
+        false
+    }
+    fn cycle(&mut self, request: WatchCycleRequest<'_>) -> BackendCycle;
+}
+
 /// What one accepted source revision produces.
 ///
 /// The loop itself — the change monitor, re-observation, acquisition,
@@ -217,9 +258,9 @@ pub(crate) struct TestWatch {
 /// both, so the change monitor holds both and the two can never disagree about
 /// whether this cycle is still wanted (RUE-2023).
 #[derive(Clone)]
-struct CycleCancellation {
-    compilation: CompilationCancellation,
-    run: Option<test_mode::RunCancellation>,
+pub(crate) struct CycleCancellation {
+    pub(crate) compilation: CompilationCancellation,
+    pub(crate) run: Option<test_mode::RunCancellation>,
 }
 
 impl CycleCancellation {
@@ -228,6 +269,10 @@ impl CycleCancellation {
         if let Some(run) = &self.run {
             run.cancel();
         }
+    }
+
+    pub(crate) fn run(&self) -> Option<&test_mode::RunCancellation> {
+        self.run.as_ref()
     }
 }
 
@@ -327,10 +372,6 @@ impl ChangeMonitor {
         )
     }
 
-    fn changed(&self) -> bool {
-        self.changed.load(Ordering::Acquire)
-    }
-
     fn finish(self) -> bool {
         self.stop.store(true, Ordering::Release);
         // Idle polling backs off, but completing a compile must never wait for
@@ -345,33 +386,197 @@ impl ChangeMonitor {
 
 pub(crate) fn run(request: WatchRequest) -> ! {
     let WatchRequest {
-        mut host,
+        host,
         compile_options,
+        source_path,
+        error_format,
+        mode,
+    } = request;
+    let backend = DirectBackend {
+        host,
+        compile_options,
+        error_format,
+        first_cycle: true,
+    };
+    match run_backend(
+        WatchLoopRequest {
+            source_path,
+            error_format,
+            mode,
+        },
+        backend,
+    ) {
+        WatchTermination::Direct => unreachable!("direct watch cannot fall back"),
+        WatchTermination::Exit(code) => std::process::exit(code),
+    }
+}
+
+pub(crate) struct WatchLoopRequest {
+    pub(crate) source_path: String,
+    pub(crate) error_format: ErrorFormat,
+    pub(crate) mode: WatchMode,
+}
+
+struct DirectBackend {
+    host: FilesystemCompilerHost,
+    compile_options: CompileOptions,
+    error_format: ErrorFormat,
+    first_cycle: bool,
+}
+
+impl WatchBackend for DirectBackend {
+    fn prepare_each_cycle(&self) -> bool {
+        !self.first_cycle
+    }
+
+    fn prepare(
+        &mut self,
+        _inputs: &[WatchInput],
+        reobserve: bool,
+        _cycle: u64,
+        cancellation: &CompilationCancellation,
+    ) -> BackendPrepare {
+        if !reobserve {
+            self.first_cycle = false;
+            return BackendPrepare::Ready;
+        }
+        let mut result = self
+            .host
+            .reobserve_superseding(&|| cancellation.is_canceled());
+        let mut acquired = false;
+        if result.is_ok() {
+            test_event("reobserve-ok");
+            test_acquire_delay();
+            acquired = true;
+            result = self
+                .host
+                .acquire_reached_toolchain_modules_cancellable(&self.compile_options, cancellation);
+        }
+        match result {
+            Ok(()) => {
+                if acquired && cancellation.is_canceled() {
+                    // The acquisition can finish after the monitor has
+                    // observed a newer revision. Preserve the phase-specific
+                    // protocol milestone before the shared loop discards the
+                    // stale attempt.
+                    test_event("acquire-superseded");
+                }
+                self.first_cycle = false;
+                BackendPrepare::Ready
+            }
+            Err(SourceLoadError::Superseded) if acquired => {
+                test_event("acquire-superseded");
+                BackendPrepare::Superseded
+            }
+            Err(SourceLoadError::Superseded) => BackendPrepare::Superseded,
+            Err(error) => BackendPrepare::Failed(BackendFailure {
+                diagnostic: render_source_load_error(error, self.error_format),
+                inputs: self.host.watch_inputs(),
+                attempted_reads: self.host.attempted_reads().to_vec(),
+            }),
+        }
+    }
+
+    fn inputs(&self) -> Vec<WatchInput> {
+        self.host.watch_inputs()
+    }
+
+    fn attempted_reads(&self) -> Vec<AttemptedRead> {
+        self.host.attempted_reads().to_vec()
+    }
+
+    fn retry_failed_preparation(&self) -> bool {
+        true
+    }
+
+    fn cycle(&mut self, request: WatchCycleRequest<'_>) -> BackendCycle {
+        let WatchCycleRequest {
+            mode,
+            source_path,
+            error_format,
+            cycle,
+            cancellation,
+            inputs,
+        } = request;
+        let source_snapshot = self.host.source_snapshot().clone();
+        let source_infos = source_snapshot
+            .files()
+            .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+            .collect();
+        let diagnostics = DiagnosticOutput::new(error_format, source_infos);
+        let cycle_inputs = inputs;
+        let supersession_inputs = cycle_inputs.clone();
+        let superseded =
+            || cancellation.compilation.is_canceled() || inputs_changed(&supersession_inputs);
+        match mode {
+            WatchMode::Executable { output_path } => executable_status(drive_cycle(CycleRequest {
+                host: &mut self.host,
+                options: &self.compile_options,
+                diagnostics: &diagnostics,
+                source_path,
+                output_path,
+                observation: CycleObservation::Watch {
+                    inputs: cycle_inputs.clone(),
+                    cancellation: cancellation.compilation.clone(),
+                    superseded: &superseded,
+                },
+                announcement: Announcement::Cycle(Instant::now()),
+            }))
+            .into_backend_cycle(),
+            WatchMode::Test(config) => {
+                let Some(run_cancellation) = cancellation.run() else {
+                    return BackendCycle::Canceled;
+                };
+                test_status(test_watch_cycle(TestWatchCycle {
+                    host: &mut self.host,
+                    compile_options: &self.compile_options,
+                    config,
+                    diagnostics: &diagnostics,
+                    source_path,
+                    cycle,
+                    cancellation: run_cancellation,
+                    observation: CycleObservation::Watch {
+                        inputs: cycle_inputs,
+                        cancellation: cancellation.compilation.clone(),
+                        superseded: &superseded,
+                    },
+                }))
+                .into_backend_cycle()
+            }
+        }
+    }
+}
+
+impl CycleStatus {
+    fn into_backend_cycle(self) -> BackendCycle {
+        match self {
+            Self::Completed => BackendCycle::Completed,
+            Self::Failed => BackendCycle::Failed { diagnostic: None },
+            Self::Superseded(boundary) => BackendCycle::Superseded(boundary),
+            Self::Canceled => BackendCycle::Canceled,
+        }
+    }
+}
+
+pub(crate) fn run_backend<B: WatchBackend>(
+    request: WatchLoopRequest,
+    mut backend: B,
+) -> WatchTermination {
+    let WatchLoopRequest {
         source_path,
         error_format,
         mut mode,
     } = request;
+    let mut inputs = backend.inputs();
     let mut needs_reobserve = false;
     let mut cycle: u64 = 0;
     let mut reported_failure: Option<ReportedFailure> = None;
 
     if let WatchMode::Test(_) = &mode {
-        // Once for the process, before anything can spawn: descriptor 3 is
-        // pinned shut so no pipe the standard library opens for its own
-        // bookkeeping can be allocated there and then destroyed by a child's
-        // `dup2` onto the failure channel (`exec::reserve_channel_descriptor`).
-        // Per cycle would be pointless — the reservation is idempotent and
-        // never released — and per spawn would be a race.
         test_mode::reserve_channel_descriptor();
-        // A watch process has no natural end, so being asked to stop IS its
-        // result: it reports the last completed cycle's status rather than
-        // dying of the signal a one-shot run dies of (ADR-0083 §2).
         test_mode::install_watch_signal_exit();
     }
-
     match &mode {
-        // stdout is the event stream in test mode, so the loop's own voice
-        // goes where every other runner notice goes.
         WatchMode::Test(_) => eprintln!("Watching {source_path} for changes"),
         WatchMode::Executable { .. } => println!("Watching {source_path} for changes"),
     }
@@ -379,182 +584,109 @@ pub(crate) fn run(request: WatchRequest) -> ! {
 
     loop {
         let cycle_started = Instant::now();
-        if needs_reobserve {
-            // Observe edits WHILE the cycle re-observes AND acquires: both
-            // halves block on filesystem reads across several waves, and an
-            // edit landing in either must supersede the stale attempt promptly
-            // instead of waiting for compilation proper to notice it
-            // (RUE-1830, RUE-1863). One monitor spans both so the window has
-            // no unobserved seam between them.
-            let stale_inputs = host.watch_inputs();
+        if needs_reobserve || backend.prepare_each_cycle() {
+            let stale_inputs = inputs.clone();
             let cancellation = CompilationCancellation::new();
-            let (monitor, observation_baseline) =
-                ChangeMonitor::start_reobservation(stale_inputs.clone(), cancellation.clone());
-            let superseded = || cancellation.is_canceled();
+            let (monitor, baseline) = if stale_inputs.is_empty() {
+                (None, Vec::new())
+            } else {
+                let (monitor, baseline) =
+                    ChangeMonitor::start_reobservation(stale_inputs.clone(), cancellation.clone());
+                (Some(monitor), baseline)
+            };
             test_event("reobserve-started");
-            let mut phase = ObservationPhase::Reobserve;
-            let mut observed = host.reobserve_superseding(&superseded);
-            if observed.is_ok() {
-                test_event("reobserve-ok");
-                phase = ObservationPhase::Acquire;
-                test_acquire_delay();
-                observed = host
-                    .acquire_reached_toolchain_modules_cancellable(&compile_options, &cancellation);
-            }
-            let monitor_changed = monitor.finish();
-            let changed =
-                monitor_changed || current_observations(&stale_inputs) != observation_baseline;
-            if changed || matches!(&observed, Err(SourceLoadError::Superseded)) {
-                test_event(phase.superseded_event());
-                print_cycle_status(
-                    &mode,
-                    error_format,
-                    format!(
-                        "Watch re-observation superseded after {} ms; a newer source revision is available",
-                        cycle_started.elapsed().as_millis()
-                    ),
-                );
-                // Each phase commits either nothing or one coherent close. Let
-                // the burst settle, then re-observe the exact physical routes
-                // from the newest bytes; `needs_reobserve` remains set.
-                debounce(&stale_inputs);
-                continue;
-            }
-            match observed {
-                Ok(()) => {
-                    test_event("acquire-ok");
-                    // A revision that loads again ends the failure state. The
-                    // next failure is news even if it renders exactly like the
-                    // last one did — reverting to previously broken bytes must
-                    // report, and the fingerprints alone cannot tell that
-                    // revert from a retry, because they are content hashes.
-                    reported_failure = None;
-                }
-                Err(SourceLoadError::Superseded) => {
-                    unreachable!("supersession was handled before source errors")
-                }
-                Err(error) => {
-                    let diagnostic = render_source_load_error(error, error_format);
-                    // Content hashes of the bytes the attempt accepted, on
-                    // the same terms as the closure observation above: a save
-                    // that rewrites a file without changing it compares equal
-                    // and stays suppressed. Deliberately not the modification
-                    // time the accepted-read manifest also carries, which such
-                    // a save moves without producing a revision anyone asked
-                    // to hear about.
-                    //
-                    // Compared borrowed, and copied only by the branch that
-                    // keeps it: this runs four times a second for as long as a
-                    // failure stands, and the suppressed retry is the path
-                    // RUE-2091 exists to keep both quiet and cheap.
-                    let repeat = reported_failure.as_ref().is_some_and(|reported| {
-                        reported.diagnostic == diagnostic
-                            && reported.observation == observation_baseline
-                            && reported.attempted_reads == host.attempted_reads()
-                    });
-                    if repeat {
-                        test_event(phase.repeated_error_event());
-                    } else {
-                        test_event(phase.error_event());
-                        // Diagnostics are stderr's in both formats.
-                        eprintln!("{diagnostic}");
-                        print_cycle_status(
-                            &mode,
-                            error_format,
-                            format!(
-                                "Watch cycle failed after {} ms; {}",
-                                cycle_started.elapsed().as_millis(),
-                                failure_consequence(&mode)
-                            ),
-                        );
-                        reported_failure = Some(ReportedFailure {
-                            diagnostic,
-                            observation: observation_baseline,
-                            attempted_reads: host.attempted_reads().to_vec(),
-                        });
-                    }
-                    thread::sleep(FAILED_REOBSERVE_RETRY);
+            let prepare_cycle = if matches!(mode, WatchMode::Test(_)) {
+                cycle + 1
+            } else {
+                cycle
+            };
+            let prepared =
+                backend.prepare(&stale_inputs, needs_reobserve, prepare_cycle, &cancellation);
+            let monitor_changed = monitor.map(ChangeMonitor::finish).unwrap_or(false);
+            let returned_changed = backend.returned_observations_are_authoritative()
+                && inputs_changed(&backend.inputs());
+            let changed = monitor_changed
+                || (!stale_inputs.is_empty() && current_observations(&stale_inputs) != baseline)
+                || cancellation.is_canceled()
+                || returned_changed;
+            match prepared {
+                BackendPrepare::Terminate(termination) => return termination,
+                BackendPrepare::Superseded if changed => {
+                    test_event("reobserve-superseded");
+                    debounce(&stale_inputs);
+                    inputs = backend.inputs();
                     continue;
+                }
+                BackendPrepare::Superseded => {
+                    test_event("reobserve-superseded");
+                    continue;
+                }
+                BackendPrepare::Failed(_failure) if changed => {
+                    test_event("reobserve-superseded");
+                    debounce(&stale_inputs);
+                    inputs = backend.inputs();
+                    continue;
+                }
+                BackendPrepare::Failed(failure) => {
+                    report_or_suppress_failure(&mode, error_format, &mut reported_failure, failure);
+                    inputs = backend.inputs();
+                    let attempted_reads = backend.attempted_reads();
+                    if backend.retry_failed_preparation() {
+                        thread::sleep(FAILED_REOBSERVE_RETRY);
+                    } else {
+                        wait_for_change(&inputs, &attempted_reads);
+                    }
+                    debounce(&inputs);
+                    needs_reobserve = true;
+                    continue;
+                }
+                BackendPrepare::Ready if changed => {
+                    test_event("reobserve-superseded");
+                    debounce(&stale_inputs);
+                    inputs = backend.inputs();
+                    continue;
+                }
+                BackendPrepare::Ready => {
+                    if needs_reobserve && backend.announces_reobserve_during_prepare() {
+                        test_event("reobserve-ok");
+                    }
+                    test_event("acquire-ok");
+                    reported_failure = None;
                 }
             }
         }
 
-        let inputs = host.watch_inputs();
-        let source_snapshot = host.source_snapshot().clone();
-        let source_infos = source_snapshot
-            .files()
-            .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
-            .collect();
-        let diagnostics = DiagnosticOutput::new(error_format, source_infos);
-
-        let cancellation = CompilationCancellation::new();
-        // A test cycle stays abandonable past its compile: one edit cancels
-        // whichever half of the cycle it lands in, so the monitor carries the
-        // authority to kill this cycle's running tests alongside the one that
-        // cancels its compilation (RUE-2023). An executable cycle has no
-        // execution phase and so carries none.
-        let run_cancellation =
-            matches!(mode, WatchMode::Test(_)).then(test_mode::RunCancellation::new);
-        let monitor = ChangeMonitor::start(
-            inputs.clone(),
-            CycleCancellation {
-                compilation: cancellation.clone(),
-                run: run_cancellation.clone(),
-            },
-        );
+        inputs = backend.inputs();
+        let cancellation = CycleCancellation {
+            compilation: CompilationCancellation::new(),
+            run: matches!(mode, WatchMode::Test(_)).then(test_mode::RunCancellation::new),
+        };
+        let monitor = ChangeMonitor::start(inputs.clone(), cancellation.clone());
         test_event("compile-started");
         test_compile_delay();
-        // A cycle is superseded once the monitor has seen an edit, or once a
-        // fresh read of the closure disagrees with what this cycle observed.
-        let superseded = || monitor.changed() || inputs_changed(&inputs);
-        let observation = CycleObservation::Watch {
+        if matches!(mode, WatchMode::Test(_)) {
+            cycle += 1;
+        }
+        let result = backend.cycle(WatchCycleRequest {
+            mode: &mut mode,
+            source_path: &source_path,
+            error_format,
+            cycle,
+            cancellation: &cancellation,
             inputs: inputs.clone(),
-            cancellation,
-            superseded: &superseded,
-        };
-        let status = match &mut mode {
-            WatchMode::Executable { output_path } => executable_status(drive_cycle(CycleRequest {
-                host: &mut host,
-                options: &compile_options,
-                diagnostics: &diagnostics,
-                source_path: &source_path,
-                output_path,
-                observation,
-                announcement: Announcement::Cycle(cycle_started),
-            })),
-            WatchMode::Test(config) => {
-                cycle += 1;
-                test_status(test_watch_cycle(TestWatchCycle {
-                    host: &mut host,
-                    compile_options: &compile_options,
-                    config,
-                    diagnostics: &diagnostics,
-                    source_path: &source_path,
-                    cycle,
-                    cancellation: run_cancellation
-                        .as_ref()
-                        .expect("a test cycle always holds a run cancellation"),
-                    observation,
-                }))
-            }
-        };
+        });
+        let publication_changed = matches!(
+            &result,
+            BackendCycle::Superseded(Supersession::AtPublication)
+        );
+        let monitor_changed = monitor.finish();
+        test_boundary_delay();
+        let observed_changed = inputs_changed(&inputs);
+        let changed = watch_cycle_changed(publication_changed, monitor_changed, observed_changed);
 
-        let mut publication_changed = false;
-        match status {
-            CycleStatus::Completed => {
-                // The milestone names the artifact reaching disk, which both
-                // modes do: an executable at the output path, a test image in
-                // the cycle's own run directory. A test cycle's run milestones
-                // are `test_mode`'s and were emitted inside it.
-                test_event("published");
-                announce_watching(&mode);
-            }
-            CycleStatus::Superseded(boundary) => {
-                // The compile monitor and the publication guard both refuse to
-                // publish a stale revision; the milestone says which of them
-                // caught it, and only the publication guard's answer feeds the
-                // cycle-boundary decision below.
-                publication_changed = matches!(boundary, Supersession::AtPublication);
+        match result {
+            BackendCycle::Terminate(termination) => return termination,
+            BackendCycle::Superseded(boundary) => {
                 test_event(match boundary {
                     Supersession::AtPublication => "canceled-at-publication",
                     Supersession::BeforePublication => "canceled-before-publication",
@@ -568,7 +700,7 @@ pub(crate) fn run(request: WatchRequest) -> ! {
                     ),
                 );
             }
-            CycleStatus::Canceled => {
+            BackendCycle::Canceled => {
                 test_event("canceled");
                 print_cycle_status(
                     &mode,
@@ -579,43 +711,74 @@ pub(crate) fn run(request: WatchRequest) -> ! {
                     ),
                 );
             }
-            CycleStatus::Failed => {
-                test_event("compile-error");
-                print_cycle_status(
-                    &mode,
-                    error_format,
-                    format!(
-                        "Watch cycle failed after {} ms; {}",
-                        cycle_started.elapsed().as_millis(),
-                        failure_consequence(&mode)
-                    ),
-                );
-                // A failed cycle ends the same way a completed one does: the
-                // loop goes back to waiting, and a person is told so.
+            BackendCycle::Completed if !changed => {
+                test_event("published");
                 announce_watching(&mode);
+            }
+            BackendCycle::Completed => {
+                test_event("canceled-at-publication");
+            }
+            BackendCycle::Failed { diagnostic } => {
+                if let Some(diagnostic) = diagnostic
+                    && !changed
+                {
+                    eprint!("{diagnostic}");
+                }
+                if !changed {
+                    test_event("compile-error");
+                    print_cycle_status(
+                        &mode,
+                        error_format,
+                        format!(
+                            "Watch cycle failed after {} ms; {}",
+                            cycle_started.elapsed().as_millis(),
+                            failure_consequence(&mode)
+                        ),
+                    );
+                    announce_watching(&mode);
+                }
             }
         }
 
-        let monitor_changed = monitor.finish();
-        // The monitor has stopped and nothing observes the inputs again until
-        // the trailing check below. That gap is where RUE-1783 lived, and it is
-        // normally too short to hit deliberately -- so the harness can widen it
-        // to make the race reproducible instead of hoping a loaded runner
-        // supplies it.
-        test_boundary_delay();
-        let changed = watch_cycle_changed(
-            publication_changed,
-            monitor_changed,
-            inputs_changed(&inputs),
-        );
+        inputs = backend.inputs();
         match cycle_boundary_action(changed, monitor_changed) {
-            CycleBoundary::Wait => wait_for_change(&inputs),
+            CycleBoundary::Wait => wait_for_change(&inputs, &[]),
             CycleBoundary::Announce => test_event("change-detected"),
             CycleBoundary::AlreadyAnnounced => {}
         }
         debounce(&inputs);
         needs_reobserve = true;
     }
+}
+
+fn report_or_suppress_failure(
+    mode: &WatchMode,
+    format: ErrorFormat,
+    reported: &mut Option<ReportedFailure>,
+    failure: BackendFailure,
+) {
+    let observation = current_observations(&failure.inputs);
+    let repeat = reported.as_ref().is_some_and(|previous| {
+        previous.diagnostic == failure.diagnostic
+            && previous.observation == observation
+            && previous.attempted_reads == failure.attempted_reads
+    });
+    if repeat {
+        test_event("reobserve-error-repeat");
+        return;
+    }
+    test_event("reobserve-error");
+    eprintln!("{}", failure.diagnostic);
+    print_cycle_status(
+        mode,
+        format,
+        format!("Watch cycle failed; {}", failure_consequence(mode)),
+    );
+    *reported = Some(ReportedFailure {
+        diagnostic: failure.diagnostic,
+        observation,
+        attempted_reads: failure.attempted_reads,
+    });
 }
 
 /// What a failed cycle leaves the user with, which is the one thing the two
@@ -791,10 +954,10 @@ fn print_cycle_status(
     }
 }
 
-fn wait_for_change(inputs: &[WatchInput]) {
+fn wait_for_change(inputs: &[WatchInput], attempted_reads: &[AttemptedRead]) {
     let mut poll = PollBackoff::new();
     loop {
-        if inputs_changed(inputs) {
+        if inputs_changed(inputs) || attempted_reads.iter().any(AttemptedRead::changed) {
             test_event("change-detected");
             break;
         }

--- a/docs/designs/0085-persistent-compiler-daemon.md
+++ b/docs/designs/0085-persistent-compiler-daemon.md
@@ -26,8 +26,9 @@ rather than a language `PreviewFeature`.
 
 ADR acceptance is tracked by RUE-2123; implementation is tracked by RUE-2126.
 The opt-in service and its bounded resource qualification are implemented by
-RUE-2128 and RUE-2129. Automatic startup remains gated by the separate
-measurement and rollout decision in RUE-2130.
+RUE-2128 and RUE-2129. RUE-2130 records the measured decision to keep automatic
+use off by default. RUE-2131 extends the service to watch and all presentation
+stages through the existing compiler and client lifecycle owners.
 
 ## Summary
 
@@ -196,16 +197,23 @@ Driver options are `--daemon=off|auto|required`:
 | `auto` | Use or start a compatible daemon for supported requests. An unsupported request or a service known not to have accepted the request uses direct execution. |
 | `required` | Require daemon execution; incompatibility, unavailability, or an unsupported mode is an error. Useful for tests and reproducible performance experiments. |
 
-The initial default remains `off`. The intended final default is `auto` for
-ordinary internal-linker compilation, `rue test` and `rue test --list`, and
-analysis-only `--emit air` requests. `--help`, `--version`, and `explain`
-remain local. Initially `--watch`, other or combined `--emit` requests, explicit system linking,
+The default remains `off`: the RUE-2130
+[qualification](../notes/daemon-performance-regime.md) did not demonstrate an
+end-to-end benefit. Explicit `auto|required` supports ordinary internal-linker
+compilation, `rue test` and `rue test --list`, executable and test watch, and all
+presentation stages, including combined `--emit` requests. Presentation uses
+the existing stage parser, order, and artifact producers. Watch uses the same
+cycle lifecycle as direct execution; the client monitors loader-owned read
+observations and owns publication, diagnostics, test execution, and
+supersession. Canceling its request does not stop the shared service.
+
+`--help`, `--version`, and `explain` remain local. Explicit system linking,
 `--time-passes`, the existing `--benchmark-json` contract, and compiler tracing
 enabled by `--log-level` or `RUST_LOG` use direct mode under `auto`; `required`
-rejects them before starting work. Tracing format retains its existing meaning
-in direct mode. This support table must be documented and tested, so partial
-rollout never silently changes their
-existing stream or lifecycle contracts.
+rejects them before starting work. Existing invalid option combinations remain
+invalid, including watch with presentation or input `--module-manifest`. The
+separate daemon performance-capture contract retains its narrower qualified
+surface. The [driver support table](../development.md) documents these rules.
 
 The analysis-only entry point uses the existing artifact query and its current
 rooting semantics. This ADR does not add a new `rue check` command. The daemon
@@ -540,12 +548,15 @@ input validation. Each slice lands through its own reviewed PR and merge queue.
    retention, idle retirement, process-boundary parity, and edit-sequence
    coverage. The qualification record documents native macOS evidence;
    both supported architectures remain subject to their native CI hosts.
-4. **Performance regime and automatic-mode decision — RUE-2130.** Add separate daemon
-   measurements, pin hermetic/fresh callers to `off`, calibrate policy, then
-   decide whether the supported check/test/build workflow defaults to `auto`.
-5. **Additional consumers — RUE-2131.** Move watch and remaining presentation modes
-   onto the service when each has cancellation and stream-parity coverage.
-   Replace their lifetime adapters while retaining the same executor.
+4. **Performance regime and automatic-mode decision — RUE-2130.** Implemented a
+   separate validated daemon measurement regime and preserved hermetic/fresh
+   callers. Release qualification keeps automatic use off: observed retained
+   query reuse did not produce an end-to-end benefit.
+5. **Additional consumers — RUE-2131.** Implemented service adapters for watch
+   and all presentation stages through the same executor, with cancellation,
+   repair, publication, and stream-parity coverage. The watching client keeps
+   its cycle and test-process lifecycle; loader-owned read observations cross
+   the protocol as owned data.
 
 Acceptance coverage must include unchanged/body/import/manifest/std/archive
 changes; missing candidates appearing; symlink retargeting; target/options and

--- a/docs/development.md
+++ b/docs/development.md
@@ -85,11 +85,24 @@ any failure is the invocation's failure and nothing is retried.
 | --- | --- | --- |
 | Ordinary internal-linker build | service | service |
 | `rue test`, `rue test --list` (the image or inventory; the runner stays in the client) | service | service |
-| `--emit air` alone (analysis only; nothing is linked) | service | service |
-| `--watch`, any other `--emit`, `--linker <cmd>` | direct | refused |
+| Any supported `--emit` stage or combination (presentation only; nothing is linked) | service | service |
+| Executable `--watch` and `rue test --watch` | service | service |
+| `--linker <cmd>` | direct | refused |
 | `--time-passes`, `--benchmark-json` | direct | refused |
 | Tracing via `--log-level` or `RUST_LOG` | direct | refused |
 | `--help`, `--version`, `explain`, `rue daemon` | local | local |
+
+Watch uses the same cycle lifecycle in direct and service modes. The client
+monitors the loader's accepted and attempted reads, cancels superseded requests,
+and owns output publication and test process groups. Canceling or ending a
+watch does not stop the shared service. Existing watch exclusions still apply,
+including `--emit` and input `--module-manifest`; selecting a daemon does not
+make an otherwise invalid option combination valid.
+
+Automatic service use remains off by default after the
+[client-to-publication qualification](notes/daemon-performance-regime.md).
+The explicit performance-capture mode has its own narrower support table;
+watch and additional presentation stages are not qualified by that experiment.
 
 The model is exactly one root source file per compile; additional files are
 reached through `@import` and discovered transitively from the root. The legacy

--- a/docs/process/test-events.md
+++ b/docs/process/test-events.md
@@ -940,9 +940,13 @@ for no test.
 
 ## `--watch`
 
-`rue test <root> --watch` keeps **one** compiler for the life of the process and
-runs one test cycle per accepted source revision, so a cycle pays for what the
-edit changed rather than for a whole recompile. It combines with every test-mode
+`rue test <root> --watch` retains compiler state between accepted source
+revisions and runs one test cycle per revision. The default `--daemon=off`
+keeps that compiler in the watch process; `--daemon=auto|required` uses the
+shared service and its bounded retention policy. Both use the same cycle
+lifecycle. Test execution, process-group cancellation, scratch directories, and
+event output belong to the watching client. Stopping a watch does not stop the
+service. It combines with every test-mode
 flag except `--list` — a listing is an inventory of one revision, and a watcher
 has no one revision — and keeps compile mode's own exclusions (`--emit`,
 `--benchmark-json`, `--time-passes`, `-o`).


### PR DESCRIPTION
Executable and test watch now use the shared compiler service under `--daemon=auto|required`. All presentation stages and combined `--emit` requests also use the canonical compiler artifacts through the service. The default remains `off`.

Watch uses one cycle lifecycle for direct and service execution. Loader-owned accepted and attempted reads cross the protocol as owned observations, so missing/deleted imports and source-policy failures can recover without a second discovery path. Clients retain diagnostics, output publication, test process groups, and scratch cleanup; supersession cancels only their request. Ordinary, measured, and cancelable replies share one frame decoder.

The support table and test-watch documentation describe the extended surface and its existing option exclusions. Performance capture retains its separately qualified scope.

Validation:
- Focused executable watch, test watch, daemon, and emit suites passed, including edit/repair, event ordering, and cancellation.
- Regression checks exercise canonical source-policy denials and successor scratch cleanup; the old cleanup order fails its regression.
- Integration and architectural reviews found no remaining issues.
- Full standard selection: 238 targets passed; the remaining CLI corpus passed after repairing its socket-directory setup and stale event assertions. All six oracle corpora passed.
- Final CLI corpus and CLI harness clippy: both passed; formatting and diff checks passed.

Fixes RUE-2131.
